### PR TITLE
[feat/sign_up] 초회자 회원가입 UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
     implementation(project(":feature:profile"))
     implementation(project(":feature:sign"))
     implementation(project(":feature:signIn"))
+    implementation(project(":feature:signUp"))
     implementation(project(":feature:termsOfUse"))
     implementation(project(":feature:welcome"))
     //endregion

--- a/core/common/src/main/kotlin/com/captures2024/soongan/core/common/Validation.kt
+++ b/core/common/src/main/kotlin/com/captures2024/soongan/core/common/Validation.kt
@@ -18,4 +18,22 @@ object Validation {
         }
     }
 
+    enum class BirthYearValidState {
+        Success, Length, Regex
+    }
+
+    fun isValidBirthYear(birthYear: String): BirthYearValidState {
+        if (birthYear.length in 0 until 4) {
+            return BirthYearValidState.Length
+        }
+
+        val num = birthYear.toIntOrNull() ?: return BirthYearValidState.Regex
+
+        if (num !in 1950 .. 2009) {
+            return BirthYearValidState.Regex
+        }
+
+        return BirthYearValidState.Success
+    }
+
 }

--- a/core/common/src/main/kotlin/com/captures2024/soongan/core/common/Validation.kt
+++ b/core/common/src/main/kotlin/com/captures2024/soongan/core/common/Validation.kt
@@ -1,0 +1,21 @@
+package com.captures2024.soongan.core.common
+
+object Validation {
+    enum class NicknameValidState {
+        Success, Length, Regex
+    }
+
+    fun isValidNickname(nickname: String): NicknameValidState {
+        if (nickname.length !in 3 .. 10) {
+            return NicknameValidState.Length
+        }
+
+        val regex = "^[a-zA-Z0-9가-힣]+$".toRegex()
+
+        return when (regex.matches(nickname)) {
+            true -> NicknameValidState.Success
+            false -> NicknameValidState.Regex
+        }
+    }
+
+}

--- a/core/common/src/main/kotlin/com/captures2024/soongan/core/common/extension/WindowInsets.kt
+++ b/core/common/src/main/kotlin/com/captures2024/soongan/core/common/extension/WindowInsets.kt
@@ -1,0 +1,20 @@
+package com.captures2024.soongan.core.common.extension
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.ime
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalDensity
+
+val WindowInsets.Companion.isImeVisible: Boolean
+    @Composable
+    get() {
+        val density = LocalDensity.current
+        val ime = this.ime
+        return remember {
+            derivedStateOf {
+                ime.getBottom(density) > 0
+            }
+        }.value
+    }

--- a/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/component/CustomBasicTextField.kt
+++ b/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/component/CustomBasicTextField.kt
@@ -1,0 +1,173 @@
+package com.captures2024.soongan.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconCircleCheck
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconCircleCheckFail
+import com.captures2024.soongan.core.designsystem.theme.Negative
+import com.captures2024.soongan.core.designsystem.theme.Positive
+import com.captures2024.soongan.core.designsystem.theme.PrimaryB
+import com.captures2024.soongan.core.designsystem.util.DevicePreviews
+
+enum class CustomBasicTextFieldState {
+    Init, Valid, NonValid
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CustomBasicTextField(
+    modifier: Modifier = Modifier,
+    value: String,
+    title: String,
+    hint: String = "",
+    isValid: CustomBasicTextFieldState = CustomBasicTextFieldState.Init,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    enabled: Boolean = true,
+    singleLine: Boolean = true,
+    shape: Shape = RoundedCornerShape(8.dp),
+    onValueChange: (String) -> Unit,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row {
+            Spacer(modifier = Modifier.width(12.dp))
+            NonScaleText(
+                text = title,
+                color = PrimaryB ,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            textStyle = TextStyle(
+
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    color = PrimaryB,
+                    shape = shape
+                )
+                .border(
+                    width = 2.dp,
+                    color = when (isValid) {
+                        CustomBasicTextFieldState.NonValid -> Negative
+                        else -> Color(0xFFDBDBDB)
+                    },
+                    shape = shape
+                ),
+            interactionSource = interactionSource,
+            enabled = enabled,
+            singleLine = singleLine
+        ) {
+            TextFieldDefaults.DecorationBox(
+                value = value,
+                innerTextField = it,
+                singleLine = true,
+                enabled = enabled,
+                visualTransformation = VisualTransformation.None,
+                trailingIcon = @Composable {
+                    Icon(
+                        imageVector = when (isValid) {
+                            CustomBasicTextFieldState.NonValid -> MyIconPack.IconCircleCheckFail
+                            else -> MyIconPack.IconCircleCheck
+                        },
+                        contentDescription = "",
+                        tint = when (isValid) {
+                            CustomBasicTextFieldState.Init -> Color(0xFFDBDBDB)
+                            CustomBasicTextFieldState.Valid -> Positive
+                            CustomBasicTextFieldState.NonValid -> Negative
+                        }
+                    )
+                },
+                placeholder = @Composable {
+                    NonScaleText(
+                        text = hint,
+                        color = Color(0xFFCACACA),
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Medium,
+                    )
+                },
+                interactionSource = interactionSource,
+                contentPadding = TextFieldDefaults.contentPaddingWithoutLabel(
+                    start = 16.dp,
+                    end = 16.dp,
+                    top = 12.dp,
+                    bottom = 12.dp
+                ),
+                shape = shape,
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Color.White,
+                    unfocusedContainerColor = Color.White,
+                    focusedTextColor = Color.Black,
+                    unfocusedTextColor = Color.Black,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    disabledIndicatorColor = Color.Transparent,
+                )
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun CustomBasicTextFieldInitPreview() {
+    CustomBasicTextField(
+        value = "",
+        title = "닉네임"
+    ) {
+
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun CustomBasicTextFieldValidPreview() {
+    CustomBasicTextField(
+        value = "",
+        title = "닉네임",
+        isValid = CustomBasicTextFieldState.Valid
+    ) {
+
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun CustomBasicTextFieldNonValidPreview() {
+    CustomBasicTextField(
+        value = "",
+        title = "닉네임",
+        isValid = CustomBasicTextFieldState.NonValid
+    ) {
+
+    }
+}

--- a/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/component/CustomBasicTextField.kt
+++ b/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/component/CustomBasicTextField.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.TextFieldDefaults
@@ -44,6 +45,7 @@ fun CustomBasicTextField(
     title: String,
     hint: String = "",
     isValid: CustomBasicTextFieldState = CustomBasicTextFieldState.Init,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     enabled: Boolean = true,
     singleLine: Boolean = true,
@@ -83,6 +85,7 @@ fun CustomBasicTextField(
                     },
                     shape = shape
                 ),
+            keyboardOptions = keyboardOptions,
             interactionSource = interactionSource,
             enabled = enabled,
             singleLine = singleLine

--- a/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/icon/__MyIconPack.kt
+++ b/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/icon/__MyIconPack.kt
@@ -1,6 +1,9 @@
 package com.captures2024.soongan.core.designsystem.icon
 
 import androidx.compose.ui.graphics.vector.ImageVector
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconBack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconCircleCheck
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconCircleCheckFail
 import com.captures2024.soongan.core.designsystem.icon.myiconpack.LogoApple
 import com.captures2024.soongan.core.designsystem.icon.myiconpack.LogoGoogle
 import com.captures2024.soongan.core.designsystem.icon.myiconpack.LogoKakao
@@ -15,6 +18,7 @@ public val MyIconPack.AllIcons: ____KtList<ImageVector>
     if (__AllIcons != null) {
       return __AllIcons!!
     }
-    __AllIcons= listOf(LogoGoogle, LogoApple, LogoKakao)
+    __AllIcons= listOf(LogoGoogle, IconCircleCheck, IconBack, LogoApple, IconCircleCheckFail,
+        LogoKakao)
     return __AllIcons!!
   }

--- a/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/icon/myiconpack/IconBack.kt
+++ b/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/icon/myiconpack/IconBack.kt
@@ -1,0 +1,38 @@
+package com.captures2024.soongan.core.designsystem.icon.myiconpack
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+
+public val MyIconPack.IconBack: ImageVector
+    get() {
+        if (_iconBack != null) {
+            return _iconBack!!
+        }
+        _iconBack = Builder(name = "IconBack", defaultWidth = 24.0.dp, defaultHeight = 24.0.dp,
+                viewportWidth = 24.0f, viewportHeight = 24.0f).apply {
+            path(fill = SolidColor(Color(0xFFF5F5F5)), stroke = null, strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                    pathFillType = NonZero) {
+                moveTo(17.7879f, 3.7879f)
+                lineTo(16.0f, 2.0f)
+                lineTo(6.0f, 12.0f)
+                lineTo(16.0f, 22.0f)
+                lineTo(17.7879f, 20.2121f)
+                lineTo(9.5758f, 12.0f)
+                lineTo(17.7879f, 3.7879f)
+                close()
+            }
+        }
+        .build()
+        return _iconBack!!
+    }
+
+private var _iconBack: ImageVector? = null

--- a/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/icon/myiconpack/IconCircleCheck.kt
+++ b/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/icon/myiconpack/IconCircleCheck.kt
@@ -1,0 +1,44 @@
+package com.captures2024.soongan.core.designsystem.icon.myiconpack
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+
+public val MyIconPack.IconCircleCheck: ImageVector
+    get() {
+        if (_iconCircleCheck != null) {
+            return _iconCircleCheck!!
+        }
+        _iconCircleCheck = Builder(name = "IconCircleCheck", defaultWidth = 24.0.dp, defaultHeight =
+                24.0.dp, viewportWidth = 24.0f, viewportHeight = 24.0f).apply {
+            path(fill = SolidColor(Color(0xFFDBDBDB)), stroke = null, strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                    pathFillType = NonZero) {
+                moveTo(12.0f, 2.0f)
+                curveTo(6.48f, 2.0f, 2.0f, 6.48f, 2.0f, 12.0f)
+                curveTo(2.0f, 17.52f, 6.48f, 22.0f, 12.0f, 22.0f)
+                curveTo(17.52f, 22.0f, 22.0f, 17.52f, 22.0f, 12.0f)
+                curveTo(22.0f, 6.48f, 17.52f, 2.0f, 12.0f, 2.0f)
+                close()
+                moveTo(10.0f, 17.0f)
+                lineTo(5.0f, 12.0f)
+                lineTo(6.41f, 10.59f)
+                lineTo(10.0f, 14.17f)
+                lineTo(17.59f, 6.58f)
+                lineTo(19.0f, 8.0f)
+                lineTo(10.0f, 17.0f)
+                close()
+            }
+        }
+        .build()
+        return _iconCircleCheck!!
+    }
+
+private var _iconCircleCheck: ImageVector? = null

--- a/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/icon/myiconpack/IconCircleCheckFail.kt
+++ b/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/icon/myiconpack/IconCircleCheckFail.kt
@@ -1,0 +1,50 @@
+package com.captures2024.soongan.core.designsystem.icon.myiconpack
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+
+public val MyIconPack.IconCircleCheckFail: ImageVector
+    get() {
+        if (_iconCircleCheckFail != null) {
+            return _iconCircleCheckFail!!
+        }
+        _iconCircleCheckFail = Builder(name = "IconCircleCheckFail", defaultWidth = 24.0.dp,
+                defaultHeight = 24.0.dp, viewportWidth = 24.0f, viewportHeight = 24.0f).apply {
+            path(fill = SolidColor(Color(0xFFDE1135)), stroke = null, strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                    pathFillType = NonZero) {
+                moveTo(12.0f, 2.0f)
+                curveTo(6.47f, 2.0f, 2.0f, 6.47f, 2.0f, 12.0f)
+                curveTo(2.0f, 17.53f, 6.47f, 22.0f, 12.0f, 22.0f)
+                curveTo(17.53f, 22.0f, 22.0f, 17.53f, 22.0f, 12.0f)
+                curveTo(22.0f, 6.47f, 17.53f, 2.0f, 12.0f, 2.0f)
+                close()
+                moveTo(17.0f, 15.59f)
+                lineTo(15.59f, 17.0f)
+                lineTo(12.0f, 13.41f)
+                lineTo(8.41f, 17.0f)
+                lineTo(7.0f, 15.59f)
+                lineTo(10.59f, 12.0f)
+                lineTo(7.0f, 8.41f)
+                lineTo(8.41f, 7.0f)
+                lineTo(12.0f, 10.59f)
+                lineTo(15.59f, 7.0f)
+                lineTo(17.0f, 8.41f)
+                lineTo(13.41f, 12.0f)
+                lineTo(17.0f, 15.59f)
+                close()
+            }
+        }
+        .build()
+        return _iconCircleCheckFail!!
+    }
+
+private var _iconCircleCheckFail: ImageVector? = null

--- a/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/theme/Color.kt
+++ b/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/theme/Color.kt
@@ -64,3 +64,10 @@ internal val Teal30 = Color(0xFF214D56)
 internal val Teal40 = Color(0xFF3A656F)
 internal val Teal80 = Color(0xFFA2CED9)
 internal val Teal90 = Color(0xFFBEEAF6)
+
+
+val PrimaryA = Color(0xFF252525)
+val PrimaryB = Color(0xFFF5F5F5)
+val Accent = Color(0xFFFBC304)
+val Positive = Color(0xFF276EF1)
+val Negative = Color(0xFFDE1135)

--- a/feature/intro/src/main/kotlin/com/captures2024/soongan/feature/intro/IntroViewModel.kt
+++ b/feature/intro/src/main/kotlin/com/captures2024/soongan/feature/intro/IntroViewModel.kt
@@ -22,13 +22,13 @@ constructor(
     private val getAllTokenUseCase: GetAllTokenUseCase
 ) : ViewModel() {
     val introState: StateFlow<IntroState> = flow {
-//        getAllTokenUseCase().getOrNull()?.let { (accessToken, refreshToken) ->
-//            when {
-//                accessToken.isNotEmpty() && refreshToken.isNotEmpty() -> emit(IntroState.Main)
-//                else -> emit(IntroState.Sign)
-//            }
-//        } ?: emit(IntroState.Sign)
-        emit(IntroState.Main)
+        getAllTokenUseCase().getOrNull()?.let { (accessToken, refreshToken) ->
+            when {
+                accessToken.isNotEmpty() && refreshToken.isNotEmpty() -> emit(IntroState.Main)
+                else -> emit(IntroState.Sign)
+            }
+        } ?: emit(IntroState.Sign)
+//        emit(IntroState.Main)
     }.stateIn(
         scope = viewModelScope,
         initialValue = IntroState.Loading,

--- a/feature/sign/build.gradle.kts
+++ b/feature/sign/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
 
     implementation(project(":feature:privacyPolicy"))
     implementation(project(":feature:signIn"))
+    implementation(project(":feature:signUp"))
     implementation(project(":feature:termsOfUse"))
     implementation(project(":feature:navigator"))
 

--- a/feature/sign/src/main/kotlin/com/captures2024/soongan/feature/sign/navigation/SignRouteNavhost.kt
+++ b/feature/sign/src/main/kotlin/com/captures2024/soongan/feature/sign/navigation/SignRouteNavhost.kt
@@ -11,6 +11,7 @@ import com.captures2024.soongan.feature.sign.route.SignRouteState
 import com.captures2024.soongan.feature.signIn.SignInViewModel
 import com.captures2024.soongan.feature.signIn.navigation.SIGN_IN_NAVIGATION_ROUTE
 import com.captures2024.soongan.feature.signIn.navigation.signIn
+import com.captures2024.soongan.feature.signUp.navigation.signUp
 import com.captures2024.soongan.feature.termsofuse.navigation.navigateToTermsOfUse
 import com.captures2024.soongan.feature.termsofuse.navigation.termsOfUse
 
@@ -48,5 +49,6 @@ internal fun SignRouteNavHost(
         )
         termsOfUse(navigateToBack = navController::popBackStack)
         privacyPolicy(navigateToBack = navController::popBackStack)
+        signUp()
     }
 }

--- a/feature/sign/src/main/kotlin/com/captures2024/soongan/feature/sign/navigation/SignRouteNavhost.kt
+++ b/feature/sign/src/main/kotlin/com/captures2024/soongan/feature/sign/navigation/SignRouteNavhost.kt
@@ -11,6 +11,8 @@ import com.captures2024.soongan.feature.sign.route.SignRouteState
 import com.captures2024.soongan.feature.signIn.SignInViewModel
 import com.captures2024.soongan.feature.signIn.navigation.SIGN_IN_NAVIGATION_ROUTE
 import com.captures2024.soongan.feature.signIn.navigation.signIn
+import com.captures2024.soongan.feature.signUp.navigation.INPUT_NICKNAME_NAVIGATION_ROUTE
+import com.captures2024.soongan.feature.signUp.navigation.navigateToInputBirthYear
 import com.captures2024.soongan.feature.signUp.navigation.signUp
 import com.captures2024.soongan.feature.termsofuse.navigation.navigateToTermsOfUse
 import com.captures2024.soongan.feature.termsofuse.navigation.termsOfUse
@@ -31,7 +33,8 @@ internal fun SignRouteNavHost(
     NavHost(
         modifier = modifier,
         navController = navController,
-        startDestination = SIGN_IN_NAVIGATION_ROUTE,
+//        startDestination = SIGN_IN_NAVIGATION_ROUTE,
+        startDestination = INPUT_NICKNAME_NAVIGATION_ROUTE,
         enterTransition = { EnterTransition.None },
         exitTransition = { ExitTransition.None },
         popEnterTransition = { EnterTransition.None },
@@ -49,6 +52,9 @@ internal fun SignRouteNavHost(
         )
         termsOfUse(navigateToBack = navController::popBackStack)
         privacyPolicy(navigateToBack = navController::popBackStack)
-        signUp()
+        signUp(
+            navigateToBack = navController::popBackStack,
+            navigateToInputBirthYear = navController::navigateToInputBirthYear
+        )
     }
 }

--- a/feature/sign/src/main/kotlin/com/captures2024/soongan/feature/sign/navigation/SignRouteNavhost.kt
+++ b/feature/sign/src/main/kotlin/com/captures2024/soongan/feature/sign/navigation/SignRouteNavhost.kt
@@ -13,6 +13,7 @@ import com.captures2024.soongan.feature.signIn.navigation.SIGN_IN_NAVIGATION_ROU
 import com.captures2024.soongan.feature.signIn.navigation.signIn
 import com.captures2024.soongan.feature.signUp.navigation.INPUT_NICKNAME_NAVIGATION_ROUTE
 import com.captures2024.soongan.feature.signUp.navigation.navigateToInputBirthYear
+import com.captures2024.soongan.feature.signUp.navigation.navigateToInputNickname
 import com.captures2024.soongan.feature.signUp.navigation.signUp
 import com.captures2024.soongan.feature.termsofuse.navigation.navigateToTermsOfUse
 import com.captures2024.soongan.feature.termsofuse.navigation.termsOfUse
@@ -33,8 +34,7 @@ internal fun SignRouteNavHost(
     NavHost(
         modifier = modifier,
         navController = navController,
-//        startDestination = SIGN_IN_NAVIGATION_ROUTE,
-        startDestination = INPUT_NICKNAME_NAVIGATION_ROUTE,
+        startDestination = SIGN_IN_NAVIGATION_ROUTE,
         enterTransition = { EnterTransition.None },
         exitTransition = { ExitTransition.None },
         popEnterTransition = { EnterTransition.None },
@@ -45,8 +45,8 @@ internal fun SignRouteNavHost(
             googleSignIn = googleSignIn,
             kakaoSignIn = kakaoSignIn,
             signInViewModel = signInViewModel,
-            navigateToSignUp = {},
             navigateToMain = navigateToMain,
+            navigateToSignUp = navController::navigateToInputNickname,
             navigateToTermsOfUse = navController::navigateToTermsOfUse,
             navigateToPrivacyPolicy = navController::navigateToPrivacyPolicy
         )

--- a/feature/signIn/src/main/kotlin/com/captures2024/soongan/feature/signIn/SignInViewModel.kt
+++ b/feature/signIn/src/main/kotlin/com/captures2024/soongan/feature/signIn/SignInViewModel.kt
@@ -24,6 +24,10 @@ constructor(
     val uiState: StateFlow<SignInState>
         get() = _uiState
 
+    fun restoreInitState() {
+        _uiState.value = Init
+    }
+
     fun onClickSignIn(
         activeSocialSignIn: () -> Unit
     ) {
@@ -53,8 +57,9 @@ constructor(
     suspend fun finishGoogleSignIn(signInResult: SignInResult) {
         when (signInResult.data) {
             null -> {
-                Log.d(TAG, "errorMessage = ${signInResult.errorMessage}")
-                _uiState.emit(ErrorSignIn)
+                _uiState.emit(SignUp)
+//                Log.d(TAG, "errorMessage = ${signInResult.errorMessage}")
+//                _uiState.emit(ErrorSignIn)
             }
             else -> {
                 // TODO Success Logic

--- a/feature/signIn/src/main/kotlin/com/captures2024/soongan/feature/signIn/navigation/SignInNavigation.kt
+++ b/feature/signIn/src/main/kotlin/com/captures2024/soongan/feature/signIn/navigation/SignInNavigation.kt
@@ -18,8 +18,8 @@ fun NavGraphBuilder.signIn(
     googleSignIn: () -> Unit,
     kakaoSignIn: () -> Unit,
     signInViewModel: SignInViewModel,
-    navigateToSignUp: (NavOptions) -> Unit,
     navigateToMain: (Boolean) -> Unit,
+    navigateToSignUp: (NavOptions) -> Unit,
     navigateToTermsOfUse: (NavOptions) -> Unit,
     navigateToPrivacyPolicy: (NavOptions) -> Unit,
 ) {
@@ -29,6 +29,7 @@ fun NavGraphBuilder.signIn(
             googleSignIn = googleSignIn,
             kakaoSignIn = kakaoSignIn,
             navigateToMain = navigateToMain,
+            navigateToSignUp = navigateToSignUp,
             navigateToTermsOfUse = navigateToTermsOfUse,
             navigateToPrivacyPolicy = navigateToPrivacyPolicy,
             signInViewModel = signInViewModel

--- a/feature/signIn/src/main/kotlin/com/captures2024/soongan/feature/signIn/route/SignInRoute.kt
+++ b/feature/signIn/src/main/kotlin/com/captures2024/soongan/feature/signIn/route/SignInRoute.kt
@@ -2,7 +2,9 @@ package com.captures2024.soongan.feature.signIn.route
 
 import android.util.Log
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavOptions
 import com.captures2024.soongan.feature.signIn.SignInState
 import com.captures2024.soongan.feature.signIn.SignInViewModel
@@ -15,23 +17,34 @@ internal fun SignInRoute(
     googleSignIn: () -> Unit,
     kakaoSignIn: () -> Unit,
     navigateToMain: (Boolean) -> Unit,
+    navigateToSignUp: (NavOptions) -> Unit,
     navigateToTermsOfUse: (NavOptions) -> Unit,
     navigateToPrivacyPolicy: (NavOptions) -> Unit,
     signInViewModel: SignInViewModel
 ) {
-    val uiState = signInViewModel.uiState.collectAsState()
+    val uiState = signInViewModel.uiState.collectAsStateWithLifecycle()
 
     Log.d("SignInRoute", "State change SignInRoute ${uiState.value}")
 
-    when (uiState.value) {
+    when (val value = uiState.value) {
         is SignInState.Loading -> SignInLoadingScreen()
-        else -> SignInDefaultScreen(
-            onClickAppleSignIn = appleSignIn,
-            onClickGoogleSignIn = googleSignIn,
-            onClickKakaoSignIn =  kakaoSignIn,
-            navigateToMain = navigateToMain,
-            navigateToTermsOfUse = navigateToTermsOfUse,
-            navigateToPrivacyPolicy = navigateToPrivacyPolicy
-        )
+        else -> {
+            if (value is SignInState.SignUp) {
+                signInViewModel.restoreInitState()
+                LaunchedEffect(true) {
+                    val options = NavOptions.Builder().build()
+                    navigateToSignUp(options)
+                }
+            }
+
+            SignInDefaultScreen(
+                onClickAppleSignIn = appleSignIn,
+                onClickGoogleSignIn = googleSignIn,
+                onClickKakaoSignIn = kakaoSignIn,
+                navigateToMain = navigateToMain,
+                navigateToTermsOfUse = navigateToTermsOfUse,
+                navigateToPrivacyPolicy = navigateToPrivacyPolicy
+            )
+        }
     }
 }

--- a/feature/signUp/.gitignore
+++ b/feature/signUp/.gitignore
@@ -1,0 +1,35 @@
+### Android template
+# Gradle files
+.gradle/
+build/
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Log/OS Files
+*.log
+
+# Android Studio generated files and folders
+captures/
+.externalNativeBuild/
+.cxx/
+*.apk
+output.json
+
+# IntelliJ
+*.iml
+.idea/
+misc.xml
+deploymentTargetDropDown.xml
+render.experimental.xml
+
+# Keystore files
+*.jks
+*.keystore
+
+# Google Services (e.g. APIs or Firebase)
+google-services.json
+
+# Android Profiling
+*.hprof
+

--- a/feature/signUp/build.gradle.kts
+++ b/feature/signUp/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    captures("library")
+    captures("compose")
+}
+
+android {
+    namespace = "com.captures2024.soongan.feature.signUp"
+}
+
+dependencies {
+    implementation(project(":core:designSystem"))
+}

--- a/feature/signUp/build.gradle.kts
+++ b/feature/signUp/build.gradle.kts
@@ -8,5 +8,6 @@ android {
 }
 
 dependencies {
+    implementation(project(":core:common"))
     implementation(project(":core:designSystem"))
 }

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/BirthYearViewModel.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/BirthYearViewModel.kt
@@ -1,0 +1,95 @@
+package com.captures2024.soongan.feature.signUp
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class BirthYearViewModel
+@Inject
+constructor(
+
+) : ViewModel() {
+    private val _uiState = MutableStateFlow<InputBirthYearUIState>(InputBirthYearUIState.Init)
+    val uiState: StateFlow<InputBirthYearUIState>
+        get() = _uiState
+
+
+    fun initNickname(nickname: String) {
+        val currentState = _uiState.value
+
+        if (currentState !is InputBirthYearUIState.Init) {
+            return
+        }
+
+        _uiState.value = InputBirthYearUIState.ValueChanged(
+            nickname = nickname,
+            birthYear = ""
+        )
+    }
+
+    fun onValueChange(birthYear: String) {
+        val currentState = _uiState.value
+
+        when (currentState) {
+            is InputBirthYearUIState.Init,
+            is InputBirthYearUIState.Loading,
+            is InputBirthYearUIState.Success -> return
+            else -> Unit
+        }
+
+        _uiState.value = InputBirthYearUIState.ValueChanged(
+            nickname = currentState.nickname,
+            birthYear = birthYear
+        )
+    }
+
+    companion object {
+        private const val TAG = "BirthYearVM"
+    }
+}
+
+sealed class InputBirthYearUIState(
+    open val nickname: String,
+    open val birthYear: String
+) {
+    data object Init : InputBirthYearUIState(
+        nickname = "",
+        birthYear = ""
+    )
+
+    data class Loading(
+        override val nickname: String,
+        override val birthYear: String
+    ) : InputBirthYearUIState(
+        nickname = nickname,
+        birthYear = birthYear
+    )
+
+    data class ValueChanged(
+        override val nickname: String,
+        override val birthYear: String
+    ) : InputBirthYearUIState(
+        nickname = nickname,
+        birthYear = birthYear
+    )
+
+    data class Error(
+        override val nickname: String,
+        override val birthYear: String
+    ) : InputBirthYearUIState(
+        nickname = nickname,
+        birthYear = birthYear
+    )
+
+    data class Success(
+        override val nickname: String,
+        override val birthYear: String
+    ) : InputBirthYearUIState(
+        nickname = nickname,
+        birthYear = birthYear
+    )
+
+}

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/NicknameViewModel.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/NicknameViewModel.kt
@@ -16,6 +16,9 @@ constructor(
     val uiState: StateFlow<InputNickNameUIState>
         get() = _uiState
 
+    fun restoreState() {
+        _uiState.value = InputNickNameUIState.Init
+    }
 
     fun onChangedValue(nickname: String) {
         val currentState = _uiState.value

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/NicknameViewModel.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/NicknameViewModel.kt
@@ -1,0 +1,79 @@
+package com.captures2024.soongan.feature.signUp
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class NicknameViewModel
+@Inject
+constructor(
+
+) : ViewModel() {
+    private val _uiState = MutableStateFlow<InputNickNameUIState>(InputNickNameUIState.Init)
+    val uiState: StateFlow<InputNickNameUIState>
+        get() = _uiState
+
+
+    fun onChangedValue(nickname: String) {
+        val currentState = _uiState.value
+
+        if (currentState is InputNickNameUIState.Loading) {
+            return
+        }
+
+        if (nickname.length > 10) {
+            return
+        }
+
+        _uiState.value = InputNickNameUIState.ValueChanged(nickname = nickname)
+    }
+
+    fun duplicationCheck() {
+        _uiState.value = InputNickNameUIState.Success("testNick")
+
+        // TODO duplication RESTFul API Connection
+//
+//        val currentState = _uiState.value
+//        when (currentState) {
+//            is InputNickNameUIState.Init,
+//            is InputNickNameUIState.Loading,
+//            is InputNickNameUIState.Error -> {
+//                return
+//            }
+//            else -> Unit
+//        }
+//
+//
+    }
+
+    companion object {
+        private const val TAG = "NicknameVM"
+    }
+}
+
+
+sealed class InputNickNameUIState(
+    open val nickname: String
+) {
+    data object Init : InputNickNameUIState(nickname = "")
+
+    data class Loading(
+        override val nickname: String
+    ) : InputNickNameUIState(nickname = nickname)
+
+    data class ValueChanged(
+        override val nickname: String
+    ) : InputNickNameUIState(nickname = nickname)
+
+    data class Error(
+        override val nickname: String
+    ) : InputNickNameUIState(nickname = nickname)
+
+    data class Success(
+        override val nickname: String
+    ) : InputNickNameUIState(nickname = nickname)
+
+}

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/navigation/SignUpNavigation.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/navigation/SignUpNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import com.captures2024.soongan.feature.signUp.route.InputBirthYearRoute
 import com.captures2024.soongan.feature.signUp.route.InputNicknameRoute
 
 const val INPUT_NICKNAME_NAVIGATION_ROUTE = "input_nickname_route"
@@ -37,8 +38,18 @@ fun NavGraphBuilder.signUp(
         arguments = listOf(
             navArgument("nickname") { type = NavType.StringType }
         )
-    ) {
+    ) { navBackStackEntry ->
+        val nickname = navBackStackEntry.arguments?.getString("nickname")
 
+        if (nickname == null) {
+            navigateToBack()
+        } else {
+            InputBirthYearRoute(
+                nickname = nickname,
+                navigateToBack = navigateToBack,
+                navigateToHome = {}
+            )
+        }
     }
 
 }

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/navigation/SignUpNavigation.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/navigation/SignUpNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import com.captures2024.soongan.feature.signUp.route.InputNicknameRoute
 
 const val INPUT_NICKNAME_NAVIGATION_ROUTE = "input_nickname_route"
 const val INPUT_BIRTH_YEAR_NAVIGATION_ROUTE = "input_birth_year_route"
@@ -22,10 +23,14 @@ fun NavController.navigateToInputBirthYear(
 }
 
 fun NavGraphBuilder.signUp(
-
+    navigateToBack: () -> Unit,
+    navigateToInputBirthYear: (String, NavOptions) -> Unit,
 ) {
     composable(route = INPUT_NICKNAME_NAVIGATION_ROUTE) {
-
+        InputNicknameRoute(
+            navigateToBack = navigateToBack,
+            navigateToInputBirthYear = navigateToInputBirthYear
+        )
     }
     composable(
         route = "$INPUT_BIRTH_YEAR_NAVIGATION_ROUTE/{nickname}",

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/navigation/SignUpNavigation.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/navigation/SignUpNavigation.kt
@@ -1,0 +1,39 @@
+package com.captures2024.soongan.feature.signUp.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+
+const val INPUT_NICKNAME_NAVIGATION_ROUTE = "input_nickname_route"
+const val INPUT_BIRTH_YEAR_NAVIGATION_ROUTE = "input_birth_year_route"
+
+fun NavController.navigateToInputNickname(navOptions: NavOptions? = null) {
+    this.navigate(INPUT_NICKNAME_NAVIGATION_ROUTE, navOptions)
+}
+
+fun NavController.navigateToInputBirthYear(
+    nickname: String,
+    navOptions: NavOptions? = null
+) {
+    this.navigate("$INPUT_BIRTH_YEAR_NAVIGATION_ROUTE/$nickname", navOptions)
+}
+
+fun NavGraphBuilder.signUp(
+
+) {
+    composable(route = INPUT_NICKNAME_NAVIGATION_ROUTE) {
+
+    }
+    composable(
+        route = "$INPUT_BIRTH_YEAR_NAVIGATION_ROUTE/{nickname}",
+        arguments = listOf(
+            navArgument("nickname") { type = NavType.StringType }
+        )
+    ) {
+
+    }
+
+}

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/route/InputBirthYearRoute.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/route/InputBirthYearRoute.kt
@@ -1,0 +1,29 @@
+package com.captures2024.soongan.feature.signUp.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.captures2024.soongan.feature.signUp.BirthYearViewModel
+import com.captures2024.soongan.feature.signUp.ui.InputBirthYearScreen
+
+@Composable
+internal fun InputBirthYearRoute(
+    nickname: String,
+    navigateToBack: () -> Unit,
+    navigateToHome: () -> Unit,
+    birthYearViewModel: BirthYearViewModel = hiltViewModel()
+) {
+    val uiState = birthYearViewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(true) {
+        birthYearViewModel.initNickname(nickname)
+    }
+
+    InputBirthYearScreen(
+        state = uiState.value,
+        onClickBack = navigateToBack,
+        onValueChange = birthYearViewModel::onValueChange
+    )
+}

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/route/InputNicknameRoute.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/route/InputNicknameRoute.kt
@@ -1,11 +1,32 @@
 package com.captures2024.soongan.feature.signUp.route
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavOptions
+import com.captures2024.soongan.feature.signUp.InputNickNameUIState
+import com.captures2024.soongan.feature.signUp.NicknameViewModel
+import com.captures2024.soongan.feature.signUp.ui.InputNicknameScreen
 
 @Composable
 internal fun InputNicknameRoute(
-
+    navigateToBack: () -> Unit,
+    navigateToInputBirthYear: (String, NavOptions) -> Unit,
+    nicknameViewModel: NicknameViewModel = hiltViewModel()
 ) {
+    val uiState = nicknameViewModel.uiState.collectAsState()
 
+    when (val value = uiState.value) {
+        is InputNickNameUIState.Success -> {
+            val options = NavOptions.Builder().build()
+            navigateToInputBirthYear(value.nickname, options)
+        }
+        else -> Unit
+    }
 
+    InputNicknameScreen(
+        state = uiState.value,
+        onChangedNickname = nicknameViewModel::onChangedValue,
+        onClickCheckDuplication = nicknameViewModel::duplicationCheck
+    )
 }

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/route/InputNicknameRoute.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/route/InputNicknameRoute.kt
@@ -1,11 +1,13 @@
 package com.captures2024.soongan.feature.signUp.route
 
+import android.util.Log
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavOptions
 import com.captures2024.soongan.feature.signUp.InputNickNameUIState
 import com.captures2024.soongan.feature.signUp.NicknameViewModel
+import com.captures2024.soongan.feature.signUp.navigation.INPUT_NICKNAME_NAVIGATION_ROUTE
 import com.captures2024.soongan.feature.signUp.ui.InputNicknameScreen
 
 @Composable
@@ -14,10 +16,13 @@ internal fun InputNicknameRoute(
     navigateToInputBirthYear: (String, NavOptions) -> Unit,
     nicknameViewModel: NicknameViewModel = hiltViewModel()
 ) {
-    val uiState = nicknameViewModel.uiState.collectAsState()
+    val uiState = nicknameViewModel.uiState.collectAsStateWithLifecycle()
+
+    Log.d("InputNicknameRoute", "InputNicknameRoute State = ${uiState.value}")
 
     when (val value = uiState.value) {
         is InputNickNameUIState.Success -> {
+            nicknameViewModel.restoreState()
             val options = NavOptions.Builder().build()
             navigateToInputBirthYear(value.nickname, options)
         }
@@ -26,6 +31,7 @@ internal fun InputNicknameRoute(
 
     InputNicknameScreen(
         state = uiState.value,
+        onClickBack = navigateToBack,
         onChangedNickname = nicknameViewModel::onChangedValue,
         onClickCheckDuplication = nicknameViewModel::duplicationCheck
     )

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/route/InputNicknameRoute.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/route/InputNicknameRoute.kt
@@ -1,0 +1,11 @@
+package com.captures2024.soongan.feature.signUp.route
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun InputNicknameRoute(
+
+) {
+
+
+}

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/ui/InputBirthYearBodyScreen.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/ui/InputBirthYearBodyScreen.kt
@@ -1,0 +1,132 @@
+package com.captures2024.soongan.feature.signUp.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.common.Validation
+import com.captures2024.soongan.core.designsystem.component.CustomBasicTextField
+import com.captures2024.soongan.core.designsystem.component.CustomBasicTextFieldState
+import com.captures2024.soongan.core.designsystem.component.NonScaleText
+import com.captures2024.soongan.core.designsystem.theme.Negative
+import com.captures2024.soongan.core.designsystem.theme.PrimaryA
+import com.captures2024.soongan.core.designsystem.theme.PrimaryB
+import com.captures2024.soongan.core.designsystem.util.DevicePreviews
+import com.captures2024.soongan.feature.signUp.InputBirthYearUIState
+import com.captures2024.soongan.feature.signUp.R
+
+@Composable
+internal fun InputBirthYearBodyScreen(
+    modifier: Modifier = Modifier,
+    state: InputBirthYearUIState,
+    isValid: Validation.BirthYearValidState,
+    onValueChange: (String) -> Unit = {}
+) {
+    val windowInfo = LocalWindowInfo.current
+    val focusRequester = remember { FocusRequester() }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = PrimaryA),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(40.dp),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+            ) {
+                NonScaleText(
+                    text = stringResource(id = R.string.input_birth_year_nickname_title),
+                    color = Color(0xFFCACACA),
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Medium
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                NonScaleText(
+                    text = state.nickname,
+                    color = PrimaryB,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            Spacer(modifier = Modifier.height(36.dp))
+            CustomBasicTextField(
+                modifier = Modifier.focusRequester(focusRequester),
+                value = state.birthYear,
+                title = stringResource(id = R.string.input_birth_year_title),
+                hint = stringResource(id = R.string.input_birth_year_input_form_hint_text),
+                isValid = when (isValid) {
+                    Validation.BirthYearValidState.Success -> CustomBasicTextFieldState.Valid
+                    Validation.BirthYearValidState.Regex -> CustomBasicTextFieldState.NonValid
+                    Validation.BirthYearValidState.Length -> CustomBasicTextFieldState.Init
+                },
+                keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Decimal),
+                onValueChange = onValueChange
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            ) {
+                NonScaleText(
+                    text = when (isValid) {
+                        Validation.BirthYearValidState.Regex -> stringResource(id = R.string.input_birth_fail_hint_text)
+                        else -> stringResource(id = R.string.input_birth_default_hint_text)
+                    },
+                    color = when (isValid) {
+                        Validation.BirthYearValidState.Regex -> Negative
+                        else -> Color(0xFFCACACA)
+                    },
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+    }
+
+    LaunchedEffect(windowInfo) {
+        snapshotFlow { windowInfo.isWindowFocused }.collect { isWindowFocused ->
+            if (isWindowFocused) {
+                focusRequester.requestFocus()
+            }
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun InputBirthYearBodyScreenPreview() {
+    InputBirthYearBodyScreen(
+        state = InputBirthYearUIState.ValueChanged(
+            nickname = "테스트",
+            birthYear = ""
+        ),
+        isValid = Validation.BirthYearValidState.Length
+    )
+}

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/ui/InputBirthYearScreen.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/ui/InputBirthYearScreen.kt
@@ -1,0 +1,80 @@
+package com.captures2024.soongan.feature.signUp.ui
+
+import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.captures2024.soongan.core.common.Validation
+import com.captures2024.soongan.core.designsystem.theme.PrimaryA
+import com.captures2024.soongan.core.designsystem.util.DevicePreviews
+import com.captures2024.soongan.feature.signUp.InputBirthYearUIState
+import com.captures2024.soongan.feature.signUp.R
+
+@Composable
+internal fun InputBirthYearScreen(
+    modifier: Modifier = Modifier,
+    state: InputBirthYearUIState,
+    onClickBack: () -> Unit = {},
+    onValueChange: (String) -> Unit = {}
+) {
+    val isValid = Validation.isValidBirthYear(state.birthYear)
+    Log.d("InputBirthYearScreen", "isValid = $isValid")
+
+
+    Scaffold(
+        topBar = @Composable {
+            SignUpTopBar(onClickBack = onClickBack)
+        },
+        bottomBar = @Composable {
+            SignUpBottomBar(
+                modifier = Modifier.imePadding(),
+                title = stringResource(id = R.string.input_birth_year_button_title),
+                enabled = when (isValid) {
+                    Validation.BirthYearValidState.Success -> true
+                    else -> false
+                },
+                onClick = {}
+            )
+        }
+    ) { paddingValues ->
+        when (state) {
+            is InputBirthYearUIState.Init -> Box(
+                modifier = modifier
+                    .padding(paddingValues)
+                    .fillMaxSize()
+                    .background(color = PrimaryA),
+            )
+            else -> InputBirthYearBodyScreen(
+                modifier = modifier.padding(paddingValues),
+                state = state,
+                isValid = isValid,
+                onValueChange = onValueChange
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun InputBirthYearScreenInitPreview() {
+    InputBirthYearScreen(
+        state = InputBirthYearUIState.Init
+    )
+}
+
+@DevicePreviews
+@Composable
+private fun InputBirthYearScreenValueChangedPreview() {
+    InputBirthYearScreen(
+        state = InputBirthYearUIState.ValueChanged(
+            nickname = "테스트",
+            birthYear = ""
+        )
+    )
+}

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/ui/InputNicknameBodyScreen.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/ui/InputNicknameBodyScreen.kt
@@ -1,0 +1,129 @@
+package com.captures2024.soongan.feature.signUp.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.common.Validation
+import com.captures2024.soongan.core.designsystem.component.CustomBasicTextField
+import com.captures2024.soongan.core.designsystem.component.CustomBasicTextFieldState
+import com.captures2024.soongan.core.designsystem.component.NonScaleText
+import com.captures2024.soongan.core.designsystem.theme.Negative
+import com.captures2024.soongan.core.designsystem.theme.PrimaryA
+import com.captures2024.soongan.core.designsystem.util.DevicePreviews
+import com.captures2024.soongan.feature.signUp.InputNickNameUIState
+import com.captures2024.soongan.feature.signUp.R
+
+@Composable
+internal fun InputNicknameBodyScreen(
+    modifier: Modifier = Modifier,
+    state: InputNickNameUIState,
+    isValid: Validation.NicknameValidState,
+    onChangedNickname: (String) -> Unit = {},
+) {
+    val windowInfo = LocalWindowInfo.current
+    val focusRequester = remember { FocusRequester() }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = PrimaryA),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(40.dp),
+        ) {
+            CustomBasicTextField(
+                modifier = Modifier.focusRequester(focusRequester),
+                value = state.nickname,
+                title = stringResource(id = R.string.input_nickname_input_title),
+                hint = stringResource(id = R.string.input_nickname_input_form_hint_text),
+                isValid = when {
+                    state is InputNickNameUIState.Error || isValid == Validation.NicknameValidState.Regex -> CustomBasicTextFieldState.NonValid
+                    isValid == Validation.NicknameValidState.Success -> CustomBasicTextFieldState.Valid
+                    else -> CustomBasicTextFieldState.Init
+                },
+                onValueChange = onChangedNickname
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                NonScaleText(
+                    text = when {
+                        state is InputNickNameUIState.Error -> stringResource(id = R.string.input_nickname_fail_duplication_hint_text)
+                        isValid == Validation.NicknameValidState.Regex -> stringResource(id = R.string.input_nickname_fail_regex_hint_text)
+                        else -> stringResource(id = R.string.input_nickname_default_hint_text)
+                    },
+                    color = when {
+                        state is InputNickNameUIState.Error || isValid == Validation.NicknameValidState.Regex -> Negative
+                        else -> Color(0xFFCACACA)
+                    },
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Medium
+                )
+                NonScaleText(
+                    text = "${state.nickname.length}/10",
+                    color = Color(0xFFCACACA),
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+    }
+
+    LaunchedEffect(windowInfo) {
+        snapshotFlow { windowInfo.isWindowFocused }.collect { isWindowFocused ->
+            if (isWindowFocused) {
+                focusRequester.requestFocus()
+            }
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun InputNicknameBodyScreenPreview() {
+    InputNicknameBodyScreen(
+        state = InputNickNameUIState.ValueChanged(nickname = "abcd"),
+        isValid = Validation.NicknameValidState.Success,
+    ) {
+
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun InputNicknameBodyScreenFailPreview() {
+    InputNicknameBodyScreen(
+        state = InputNickNameUIState.ValueChanged(nickname = "@!abcd"),
+        isValid = Validation.NicknameValidState.Regex,
+    ) {
+
+    }
+}

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/ui/InputNicknameScreen.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/ui/InputNicknameScreen.kt
@@ -1,0 +1,156 @@
+package com.captures2024.soongan.feature.signUp.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.common.Validation
+import com.captures2024.soongan.core.designsystem.component.CustomBasicTextField
+import com.captures2024.soongan.core.designsystem.component.CustomBasicTextFieldState
+import com.captures2024.soongan.core.designsystem.component.NonScaleText
+import com.captures2024.soongan.core.designsystem.theme.Negative
+import com.captures2024.soongan.core.designsystem.theme.PrimaryA
+import com.captures2024.soongan.core.designsystem.util.DevicePreviews
+import com.captures2024.soongan.feature.signUp.InputNickNameUIState
+import com.captures2024.soongan.feature.signUp.R
+import kotlinx.coroutines.delay
+
+@Composable
+internal fun InputNicknameScreen(
+    state: InputNickNameUIState,
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit = {},
+    onChangedNickname: (String) -> Unit = {},
+    onClickCheckDuplication: () -> Unit = {}
+) {
+    val isValid = Validation.isValidNickname(nickname = state.nickname)
+
+    val windowInfo = LocalWindowInfo.current
+    val focusRequester = remember { FocusRequester() }
+
+    Scaffold(
+        topBar = @Composable {
+            SignUpTopBar(onClickBack = onClickBack)
+        },
+        bottomBar = @Composable {
+            SignUpBottomBar(
+                modifier = Modifier.imePadding(),
+                title = stringResource(id = R.string.btn_nickname_input_title),
+                enabled = when (isValid) {
+                    Validation.NicknameValidState.Success -> true
+                    else -> false
+                },
+                onClick = onClickCheckDuplication
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .background(color = PrimaryA)
+                .padding(paddingValues),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(40.dp),
+            ) {
+                CustomBasicTextField(
+                    modifier = Modifier.focusRequester(focusRequester),
+                    value = state.nickname,
+                    title = stringResource(id = R.string.input_nickname_input_title),
+                    isValid = when {
+                        state is InputNickNameUIState.Error || isValid == Validation.NicknameValidState.Regex -> CustomBasicTextFieldState.NonValid
+                        isValid == Validation.NicknameValidState.Success -> CustomBasicTextFieldState.Valid
+                        else -> CustomBasicTextFieldState.Init
+                    },
+                    onValueChange = onChangedNickname
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    NonScaleText(
+                        text = when {
+                            state is InputNickNameUIState.Error -> stringResource(id = R.string.input_nickname_fail_duplication_hint_text)
+                            isValid == Validation.NicknameValidState.Regex -> stringResource(id = R.string.input_nickname_fail_regex_hint_text)
+                            else -> stringResource(id = R.string.input_nickname_default_hint_text)
+                        },
+                        color = when {
+                            state is InputNickNameUIState.Error || isValid == Validation.NicknameValidState.Regex -> Negative
+                            else -> Color(0xFFCACACA)
+                        },
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                    NonScaleText(
+                        text = "${state.nickname.length}/10",
+                        color = Color(0xFFCACACA),
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(windowInfo) {
+        snapshotFlow { windowInfo.isWindowFocused }.collect { isWindowFocused ->
+            if (isWindowFocused) {
+                focusRequester.requestFocus()
+            }
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun InputNicknameScreenPreview() {
+    InputNicknameScreen(
+        state = InputNickNameUIState.Init
+    )
+}
+
+@DevicePreviews
+@Composable
+private fun InputNicknameScreenFirstCasePreview() {
+    InputNicknameScreen(
+        state = InputNickNameUIState.ValueChanged(nickname = "abcd")
+    )
+}
+
+@DevicePreviews
+@Composable
+private fun InputNicknameScreenSecondCasePreview() {
+    InputNicknameScreen(
+        state = InputNickNameUIState.ValueChanged(nickname = "ab")
+    )
+}

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/ui/InputNicknameScreen.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/ui/InputNicknameScreen.kt
@@ -1,43 +1,15 @@
 package com.captures2024.soongan.feature.signUp.ui
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.captures2024.soongan.core.common.Validation
-import com.captures2024.soongan.core.designsystem.component.CustomBasicTextField
-import com.captures2024.soongan.core.designsystem.component.CustomBasicTextFieldState
-import com.captures2024.soongan.core.designsystem.component.NonScaleText
-import com.captures2024.soongan.core.designsystem.theme.Negative
-import com.captures2024.soongan.core.designsystem.theme.PrimaryA
 import com.captures2024.soongan.core.designsystem.util.DevicePreviews
 import com.captures2024.soongan.feature.signUp.InputNickNameUIState
 import com.captures2024.soongan.feature.signUp.R
-import kotlinx.coroutines.delay
 
 @Composable
 internal fun InputNicknameScreen(
@@ -48,9 +20,6 @@ internal fun InputNicknameScreen(
     onClickCheckDuplication: () -> Unit = {}
 ) {
     val isValid = Validation.isValidNickname(nickname = state.nickname)
-
-    val windowInfo = LocalWindowInfo.current
-    val focusRequester = remember { FocusRequester() }
 
     Scaffold(
         topBar = @Composable {
@@ -68,66 +37,12 @@ internal fun InputNicknameScreen(
             )
         }
     ) { paddingValues ->
-        Box(
-            modifier = modifier
-                .fillMaxSize()
-                .background(color = PrimaryA)
-                .padding(paddingValues),
-            contentAlignment = Alignment.Center
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(40.dp),
-            ) {
-                CustomBasicTextField(
-                    modifier = Modifier.focusRequester(focusRequester),
-                    value = state.nickname,
-                    title = stringResource(id = R.string.input_nickname_input_title),
-                    isValid = when {
-                        state is InputNickNameUIState.Error || isValid == Validation.NicknameValidState.Regex -> CustomBasicTextFieldState.NonValid
-                        isValid == Validation.NicknameValidState.Success -> CustomBasicTextFieldState.Valid
-                        else -> CustomBasicTextFieldState.Init
-                    },
-                    onValueChange = onChangedNickname
-                )
-                Spacer(modifier = Modifier.height(12.dp))
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 12.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                ) {
-                    NonScaleText(
-                        text = when {
-                            state is InputNickNameUIState.Error -> stringResource(id = R.string.input_nickname_fail_duplication_hint_text)
-                            isValid == Validation.NicknameValidState.Regex -> stringResource(id = R.string.input_nickname_fail_regex_hint_text)
-                            else -> stringResource(id = R.string.input_nickname_default_hint_text)
-                        },
-                        color = when {
-                            state is InputNickNameUIState.Error || isValid == Validation.NicknameValidState.Regex -> Negative
-                            else -> Color(0xFFCACACA)
-                        },
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.Medium
-                    )
-                    NonScaleText(
-                        text = "${state.nickname.length}/10",
-                        color = Color(0xFFCACACA),
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.Medium
-                    )
-                }
-            }
-        }
-    }
-
-    LaunchedEffect(windowInfo) {
-        snapshotFlow { windowInfo.isWindowFocused }.collect { isWindowFocused ->
-            if (isWindowFocused) {
-                focusRequester.requestFocus()
-            }
-        }
+        InputNicknameBodyScreen(
+            modifier = modifier.padding(paddingValues),
+            state = state,
+            isValid = isValid,
+            onChangedNickname = onChangedNickname
+        )
     }
 }
 
@@ -136,21 +51,5 @@ internal fun InputNicknameScreen(
 private fun InputNicknameScreenPreview() {
     InputNicknameScreen(
         state = InputNickNameUIState.Init
-    )
-}
-
-@DevicePreviews
-@Composable
-private fun InputNicknameScreenFirstCasePreview() {
-    InputNicknameScreen(
-        state = InputNickNameUIState.ValueChanged(nickname = "abcd")
-    )
-}
-
-@DevicePreviews
-@Composable
-private fun InputNicknameScreenSecondCasePreview() {
-    InputNicknameScreen(
-        state = InputNickNameUIState.ValueChanged(nickname = "ab")
     )
 }

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/ui/SignUpBottomBar.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/ui/SignUpBottomBar.kt
@@ -1,0 +1,91 @@
+package com.captures2024.soongan.feature.signUp.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.component.NonScaleText
+import com.captures2024.soongan.core.designsystem.theme.Positive
+import com.captures2024.soongan.core.designsystem.theme.PrimaryA
+import com.captures2024.soongan.core.designsystem.theme.PrimaryB
+import com.captures2024.soongan.core.designsystem.util.DevicePreviews
+import com.captures2024.soongan.feature.signUp.R
+
+@Composable
+internal fun SignUpBottomBar(
+    modifier: Modifier = Modifier,
+    title: String,
+    enabled: Boolean,
+    onClick: () -> Unit = {}
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(115.dp)
+            .background(color = PrimaryA)
+            .padding(
+                horizontal = 40.dp,
+                vertical = 15.dp
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        NonScaleText(
+            text = title,
+            color = PrimaryB,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Button(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .height(48.dp),
+            onClick = onClick,
+            enabled = enabled,
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Positive,
+                contentColor = PrimaryB,
+                disabledContainerColor = Color(0xFFA7A7A7),
+            ),
+        ) {
+            NonScaleText(
+                text = stringResource(id = R.string.btn_next_text),
+                color = Color.White,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun SignUpBottomBarNegativePreview() {
+    SignUpBottomBar(
+        title = "다음이 마지막 단계입니다!",
+        enabled = false
+    )
+}
+
+@DevicePreviews
+@Composable
+private fun SignUpBottomBarPositivePreview() {
+    SignUpBottomBar(
+        title = "다음이 마지막 단계입니다!",
+        enabled = true
+    )
+}

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/ui/SignUpTopBar.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/ui/SignUpTopBar.kt
@@ -1,0 +1,62 @@
+package com.captures2024.soongan.feature.signUp.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.component.NonScaleText
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconBack
+import com.captures2024.soongan.core.designsystem.theme.PrimaryA
+import com.captures2024.soongan.core.designsystem.theme.PrimaryB
+import com.captures2024.soongan.core.designsystem.util.DevicePreviews
+import com.captures2024.soongan.feature.signUp.R
+
+@Composable
+internal fun SignUpTopBar(
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit = {}
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(60.dp)
+            .background(color = PrimaryA)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = MyIconPack.IconBack,
+            contentDescription = "",
+            modifier = Modifier.clickable {
+                onClickBack()
+            },
+            tint = PrimaryB
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        NonScaleText(
+            text = stringResource(id = R.string.sign_up_text),
+            color = PrimaryB,
+            fontSize = 24.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun SignUpTopBarPreview() {
+    SignUpTopBar()
+}

--- a/feature/signUp/src/main/res/values/strings.xml
+++ b/feature/signUp/src/main/res/values/strings.xml
@@ -7,10 +7,23 @@
     <string name="btn_next_text">다음</string>
 
     <!-- InputNicknameScreen -->
+    <string name="btn_nickname_input_title">다음이 마지막 단계입니다!</string>
+
+    <!-- InputNicknameScreen -->
     <string name="input_nickname_input_title">닉네임</string>
+    <string name="input_nickname_input_form_hint_text">사용자명을 입력해주세요.</string>
     <string name="input_nickname_default_hint_text">3–10자리 숫자, 영문, 한글로 입력해주세요</string>
     <string name="input_nickname_fail_regex_hint_text">특수문자는 제거해주세요</string>
     <string name="input_nickname_fail_duplication_hint_text">아이디가 중복되었습니다.</string>
-    <string name="btn_nickname_input_title">다음이 마지막 단계입니다!</string>
+
+    <!-- InputBirthYearBodyScreen -->
+    <string name="input_birth_year_nickname_title">닉네임</string>
+    <string name="input_birth_year_title">출생연도</string>
+    <string name="input_birth_year_input_form_hint_text">YYYY</string>
+    <string name="input_birth_default_hint_text">출생연도 숫자 4자리 기입해주세요</string>
+    <string name="input_birth_fail_hint_text">1950-2009이내의 기간을 입력해주세요.</string>
+
+    <!-- InputBirthYearScreen -->
+    <string name="input_birth_year_button_title">마지막 단계입니다!</string>
 
 </resources>

--- a/feature/signUp/src/main/res/values/strings.xml
+++ b/feature/signUp/src/main/res/values/strings.xml
@@ -1,0 +1,16 @@
+<resources>
+
+    <!-- SignUpTopBar -->
+    <string name="sign_up_text">회원가입</string>
+
+    <!-- SignUpBottomBar -->
+    <string name="btn_next_text">다음</string>
+
+    <!-- InputNicknameScreen -->
+    <string name="input_nickname_input_title">닉네임</string>
+    <string name="input_nickname_default_hint_text">3–10자리 숫자, 영문, 한글로 입력해주세요</string>
+    <string name="input_nickname_fail_regex_hint_text">특수문자는 제거해주세요</string>
+    <string name="input_nickname_fail_duplication_hint_text">아이디가 중복되었습니다.</string>
+    <string name="btn_nickname_input_title">다음이 마지막 단계입니다!</string>
+
+</resources>

--- a/feature/welcome/src/main/kotlin/com/captures2024/soongan/feature/welcome/route/WelcomeRoute.kt
+++ b/feature/welcome/src/main/kotlin/com/captures2024/soongan/feature/welcome/route/WelcomeRoute.kt
@@ -3,6 +3,7 @@ package com.captures2024.soongan.feature.welcome.route
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavOptions
 import com.captures2024.soongan.feature.welcome.WelcomeUiState
 import com.captures2024.soongan.feature.welcome.WelcomeViewModel
@@ -14,7 +15,7 @@ internal fun WelcomeRoute(
     navigateToHome: (NavOptions) -> Unit,
     welcomeViewModel: WelcomeViewModel = hiltViewModel()
 ) {
-    val uiState = welcomeViewModel.uiState.collectAsState()
+    val uiState = welcomeViewModel.uiState.collectAsStateWithLifecycle()
 
     if (uiState.value is WelcomeUiState.MoveHome) {
         val navOptions = NavOptions.Builder()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,6 +46,7 @@ include(
     ":feature:profile",
     ":feature:sign",
     ":feature:signIn",
+    ":feature:signUp",
     ":feature:termsOfUse",
     ":feature:welcome",
 )


### PR DESCRIPTION
# [feat/sign_up] 초회자 회원가입 UI

## 개요
- https://github.com/captures-2024/soongan-android/issues/5

## 작업 사항
- 로그인 이후 계정이 서버에 존재하지 않는 경우를 위한 회원가입 수단 적용
- Input Nickname UI 구현
- Input BirhYear UI 구현
- 차후 네트워크 통신이 들어가는 경우 수정 필요

## 수정 사항(optional)
- Navigation Back Stack 오류 수정
    - 해당 사항의 경우 back stack으로 이동할 시 기존의 state가 다음 화면으로 전환을 가르키고 있는 상황이어서 navigation시 상태 값을 init으로 변경하는 방식으로 적용