### PR TITLE
[feat/sign_network] Sign API 통신 적용

### DIFF
--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/MembersMapper.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/MembersMapper.kt
@@ -1,0 +1,14 @@
+package com.captures2024.soongan.core.data.mapper
+
+import com.captures2024.soongan.core.model.dto.UserDto
+import com.captures2024.soongan.core.model.dto.UserInfoDto
+import com.captures2024.soongan.core.model.network.response.members.GetMemberInformationResponse
+
+internal fun GetMemberInformationResponse.toUserInfoDto() = UserInfoDto(
+    user = UserDto(
+        email = this.email,
+        nickname = this.nickname ?: "",
+        birthDate = this.birthDate ?: ""
+    ),
+    profileImage = this.profileImage ?: ""
+)

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/MembersDataSource.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/MembersDataSource.kt
@@ -1,5 +1,6 @@
 package com.captures2024.soongan.core.data.remote
 
+import com.captures2024.soongan.core.model.dto.UserDto
 import com.captures2024.soongan.core.model.dto.UserInfoDto
 import com.captures2024.soongan.core.model.network.SocialSignType
 import com.captures2024.soongan.core.model.network.response.members.GetMemberInformationResponse
@@ -27,7 +28,7 @@ interface MembersDataSource {
 
     suspend fun registerNickname(
         nickname: String
-    ): RegisterNicknameResponse?
+    ): UserDto?
 
     suspend fun getMemberInformation(): UserInfoDto?
 

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/MembersDataSource.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/MembersDataSource.kt
@@ -1,5 +1,6 @@
 package com.captures2024.soongan.core.data.remote
 
+import com.captures2024.soongan.core.model.dto.UserInfoDto
 import com.captures2024.soongan.core.model.network.SocialSignType
 import com.captures2024.soongan.core.model.network.response.members.GetMemberInformationResponse
 import com.captures2024.soongan.core.model.network.response.members.RegisterNicknameResponse
@@ -28,7 +29,7 @@ interface MembersDataSource {
         nickname: String
     ): RegisterNicknameResponse?
 
-    suspend fun getMemberInformation(): GetMemberInformationResponse?
+    suspend fun getMemberInformation(): UserInfoDto?
 
     suspend fun isDuplicateNickname(
         nickname: String

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/MembersDataSource.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/MembersDataSource.kt
@@ -1,13 +1,37 @@
 package com.captures2024.soongan.core.data.remote
 
 import com.captures2024.soongan.core.model.network.SocialSignType
-import com.captures2024.soongan.core.model.network.response.SignWithTokenResponse
+import com.captures2024.soongan.core.model.network.response.members.GetMemberInformationResponse
+import com.captures2024.soongan.core.model.network.response.members.RegisterNicknameResponse
+import com.captures2024.soongan.core.model.network.response.members.ReissueTokenResponse
+import com.captures2024.soongan.core.model.network.response.members.SignInWithTokenResponse
 
 interface MembersDataSource {
 
-    suspend fun signWithToken(
+    suspend fun withdrawWithToken(): Boolean
+
+    suspend fun signOutWithToken(): Boolean
+
+    suspend fun signInWithToken(
         type: SocialSignType,
         token: String
-    ): SignWithTokenResponse?
+    ): SignInWithTokenResponse?
+
+    suspend fun reissueToken(
+        accessToken: String,
+        refreshToken: String
+    ): ReissueTokenResponse?
+
+    suspend fun registerProfileImage()
+
+    suspend fun registerNickname(
+        nickname: String
+    ): RegisterNicknameResponse?
+
+    suspend fun getMemberInformation(): GetMemberInformationResponse?
+
+    suspend fun isDuplicateNickname(
+        nickname: String
+    ): Boolean?
 
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/MembersDataSource.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/MembersDataSource.kt
@@ -33,6 +33,6 @@ interface MembersDataSource {
 
     suspend fun isDuplicateNickname(
         nickname: String
-    ): Boolean?
+    ): Boolean
 
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/MembersDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/MembersDataSourceImpl.kt
@@ -1,8 +1,10 @@
 package com.captures2024.soongan.core.data.remote.impl
 
+import com.captures2024.soongan.core.data.mapper.toUserInfoDto
 import com.captures2024.soongan.core.data.remote.MembersDataSource
 import com.captures2024.soongan.core.data.service.MembersService
 import com.captures2024.soongan.core.data.utils.safeAPICall
+import com.captures2024.soongan.core.model.dto.UserInfoDto
 import com.captures2024.soongan.core.model.network.SocialSignType
 import com.captures2024.soongan.core.model.network.request.members.ReissueTokenRequest
 import com.captures2024.soongan.core.model.network.request.members.SignWithTokenRequest
@@ -71,9 +73,9 @@ constructor(
         )
     }.body
 
-    override suspend fun getMemberInformation(): GetMemberInformationResponse? = safeAPICall {
+    override suspend fun getMemberInformation(): UserInfoDto? = safeAPICall {
         service.getMemberInformation()
-    }.body
+    }.body?.toUserInfoDto()
 
     override suspend fun isDuplicateNickname(
         nickname: String

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/MembersDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/MembersDataSourceImpl.kt
@@ -4,8 +4,12 @@ import com.captures2024.soongan.core.data.remote.MembersDataSource
 import com.captures2024.soongan.core.data.service.MembersService
 import com.captures2024.soongan.core.data.utils.safeAPICall
 import com.captures2024.soongan.core.model.network.SocialSignType
-import com.captures2024.soongan.core.model.network.request.SignWithTokenRequest
-import com.captures2024.soongan.core.model.network.response.SignWithTokenResponse
+import com.captures2024.soongan.core.model.network.request.members.ReissueTokenRequest
+import com.captures2024.soongan.core.model.network.request.members.SignWithTokenRequest
+import com.captures2024.soongan.core.model.network.response.members.GetMemberInformationResponse
+import com.captures2024.soongan.core.model.network.response.members.RegisterNicknameResponse
+import com.captures2024.soongan.core.model.network.response.members.ReissueTokenResponse
+import com.captures2024.soongan.core.model.network.response.members.SignInWithTokenResponse
 import javax.inject.Inject
 
 class MembersDataSourceImpl
@@ -13,17 +17,77 @@ class MembersDataSourceImpl
 constructor(
     private val service: MembersService
 ) : MembersDataSource {
+    override suspend fun withdrawWithToken(): Boolean {
+        val result = safeAPICall { service.withdrawWithToken() }
 
-    override suspend fun signWithToken(
+        return when (result.body) {
+            null -> false
+            else -> true
+        }
+    }
+
+    override suspend fun signOutWithToken(): Boolean {
+        val result = safeAPICall { service.signOutWithToken() }
+
+        return when (result.body) {
+            null -> false
+            else -> true
+        }
+    }
+
+    override suspend fun signInWithToken(
         type: SocialSignType,
         token: String
-    ): SignWithTokenResponse? = safeAPICall {
-        service.signWithToken(
+    ): SignInWithTokenResponse? = safeAPICall {
+        service.signInWithToken(
             request = SignWithTokenRequest(
                 provider = type.provider,
                 idToken = token
             )
         )
     }.body
+
+    override suspend fun reissueToken(
+        accessToken: String,
+        refreshToken: String
+    ): ReissueTokenResponse? = safeAPICall {
+        service.reissueToken(
+            request = ReissueTokenRequest(
+                accessToken = accessToken,
+                refreshToken = refreshToken
+            )
+        )
+    }.body
+
+    override suspend fun registerProfileImage() {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun registerNickname(
+        nickname: String
+    ): RegisterNicknameResponse? = safeAPICall {
+        service.registerNickname(
+            nickname = nickname
+        )
+    }.body
+
+    override suspend fun getMemberInformation(): GetMemberInformationResponse? = safeAPICall {
+        service.getMemberInformation()
+    }.body
+
+    override suspend fun isDuplicateNickname(
+        nickname: String
+    ): Boolean {
+        val result = safeAPICall {
+            service.isDuplicateNickname(
+                nickname = nickname
+            )
+        }
+
+        return when (result.body) {
+            null -> false
+            else -> result.body
+        }
+    }
 
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/MembersDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/MembersDataSourceImpl.kt
@@ -4,6 +4,7 @@ import com.captures2024.soongan.core.data.mapper.toUserInfoDto
 import com.captures2024.soongan.core.data.remote.MembersDataSource
 import com.captures2024.soongan.core.data.service.MembersService
 import com.captures2024.soongan.core.data.utils.safeAPICall
+import com.captures2024.soongan.core.model.dto.UserDto
 import com.captures2024.soongan.core.model.dto.UserInfoDto
 import com.captures2024.soongan.core.model.network.SocialSignType
 import com.captures2024.soongan.core.model.network.request.members.ReissueTokenRequest
@@ -67,11 +68,23 @@ constructor(
 
     override suspend fun registerNickname(
         nickname: String
-    ): RegisterNicknameResponse? = safeAPICall {
-        service.registerNickname(
-            nickname = nickname
-        )
-    }.body
+    ): UserDto? {
+        val result = safeAPICall {
+            service.registerNickname(
+                nickname = nickname
+            )
+        }.body
+
+
+        return when (result) {
+            null -> null
+            else -> UserDto(
+                email = result.id,
+                nickname = result.nickname,
+                birthDate = ""
+            )
+        }
+    }
 
     override suspend fun getMemberInformation(): UserInfoDto? = safeAPICall {
         service.getMemberInformation()

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/MembersRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/MembersRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.captures2024.soongan.core.data.repository
 import com.captures2024.soongan.core.data.remote.MembersDataSource
 import com.captures2024.soongan.core.datastore.TokenDataSource
 import com.captures2024.soongan.core.domain.repository.MembersRepository
+import com.captures2024.soongan.core.model.dto.UserInfoDto
 import com.captures2024.soongan.core.model.network.SocialSignType
 import com.captures2024.soongan.core.model.entity.ResultConditionEntity
 import timber.log.Timber
@@ -88,10 +89,12 @@ constructor(
         TODO("Not yet implemented")
     }
 
-    override suspend fun getMemberInformation() {
-        val result = membersDataSource.getMemberInformation()
+    override suspend fun getMemberInformation(): UserInfoDto {
+        val userInfoDto = membersDataSource.getMemberInformation() ?: throw NullPointerException()
 
-        Timber.tag("MembersRepository").d("getMemberInformation, result = $result")
+        Timber.tag("getMemberInformation").d("userInfoDto = $userInfoDto")
+
+        return userInfoDto
     }
 
     override suspend fun isDuplicateNickname(nickname: String): ResultConditionEntity {

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/MembersRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/MembersRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.captures2024.soongan.core.datastore.TokenDataSource
 import com.captures2024.soongan.core.domain.repository.MembersRepository
 import com.captures2024.soongan.core.model.network.SocialSignType
 import com.captures2024.soongan.core.model.entity.ResultConditionEntity
+import timber.log.Timber
 import javax.inject.Inject
 
 class MembersRepositoryImpl
@@ -13,11 +14,27 @@ constructor(
     private val tokenDataSource: TokenDataSource,
     private val membersDataSource: MembersDataSource
 ) : MembersRepository {
+    override suspend fun withdrawMember(): ResultConditionEntity = when (membersDataSource.withdrawWithToken()) {
+        true -> {
+            tokenDataSource.clearAllToken()
+            ResultConditionEntity(result = true)
+        }
+        false -> ResultConditionEntity(result = false)
+    }
+
+    override suspend fun signOutSocialPlatform(): ResultConditionEntity = when (membersDataSource.signOutWithToken()) {
+        true -> {
+            tokenDataSource.clearAllToken()
+            ResultConditionEntity(result = true)
+        }
+        false -> ResultConditionEntity(result = false)
+    }
+
     override suspend fun signingSocialPlatform(
         type: SocialSignType,
         token: String
     ): ResultConditionEntity {
-        val tokenResult = membersDataSource.signWithToken(type, token) ?: return ResultConditionEntity(result = false)
+        val tokenResult = membersDataSource.signInWithToken(type, token) ?: return ResultConditionEntity(result = false)
 
         tokenDataSource.setAccessToken(tokenResult.accessToken)
         tokenDataSource.setRefreshToken(tokenResult.refreshToken)
@@ -33,4 +50,52 @@ constructor(
             }
         }
     }
+
+    override suspend fun reissueToken(): ResultConditionEntity {
+        val currentAccessToken = tokenDataSource.getAccessToken()
+        val currentRefreshToken = tokenDataSource.getRefreshToken()
+
+        if (currentAccessToken.isEmpty() || currentRefreshToken.isEmpty()) {
+            return ResultConditionEntity(result = false)
+        }
+
+        val tokenResult = membersDataSource.reissueToken(
+            accessToken = currentAccessToken,
+            refreshToken = currentRefreshToken
+        ) ?: return ResultConditionEntity(result = false)
+
+        tokenDataSource.setAccessToken(tokenResult.accessToken)
+        tokenDataSource.setRefreshToken(tokenResult.refreshToken)
+
+        val savedAccessToken = tokenDataSource.getAccessToken()
+        val savedRefreshToken = tokenDataSource.getRefreshToken()
+
+        return when {
+            savedAccessToken == tokenResult.accessToken && savedRefreshToken == tokenResult.refreshToken -> ResultConditionEntity(result = true)
+            else -> {
+                tokenDataSource.clearAllToken()
+                ResultConditionEntity(result = false)
+            }
+        }
+    }
+
+    override suspend fun registerProfileImage() {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun registerNickname(nickname: String): ResultConditionEntity {
+        val result = membersDataSource.registerNickname(nickname = nickname) ?: return ResultConditionEntity(result = false)
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getMemberInformation() {
+        val result = membersDataSource.getMemberInformation()
+
+        Timber.tag("MembersRepository").d("getMemberInformation, result = $result")
+    }
+
+    override suspend fun isDuplicateNickname(nickname: String): ResultConditionEntity {
+        TODO("Not yet implemented")
+    }
+
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/MembersRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/MembersRepositoryImpl.kt
@@ -98,7 +98,9 @@ constructor(
     }
 
     override suspend fun isDuplicateNickname(nickname: String): ResultConditionEntity {
-        TODO("Not yet implemented")
+        val result = membersDataSource.isDuplicateNickname(nickname)
+
+        return ResultConditionEntity(result)
     }
 
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/MembersService.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/MembersService.kt
@@ -1,17 +1,95 @@
 package com.captures2024.soongan.core.data.service
 
-import com.captures2024.soongan.core.model.network.request.SignWithTokenRequest
-import com.captures2024.soongan.core.model.network.response.SignWithTokenResponse
+import com.captures2024.soongan.core.model.network.request.members.ReissueTokenRequest
+import com.captures2024.soongan.core.model.network.request.members.SignWithTokenRequest
+import com.captures2024.soongan.core.model.network.response.members.GetMemberInformationResponse
+import com.captures2024.soongan.core.model.network.response.members.RegisterNicknameResponse
+import com.captures2024.soongan.core.model.network.response.members.ReissueTokenResponse
+import com.captures2024.soongan.core.model.network.response.members.SignInWithTokenResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
 import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.PATCH
+import retrofit2.http.Query
 
 interface MembersService {
 
-//    @Headers("Authorization: true")
+    /**
+     * 회원 탈퇴 API
+     *
+     * 회원을 탈퇴합니다.
+     **/
+    @POST("members/withdraw")
+    suspend fun withdrawWithToken(): Response<Unit>
+
+    /**
+     * 로그아웃 API
+     *
+     * 로그인시 발급한 JWT를 말소합니다.
+     **/
+    @POST("members/logout")
+    suspend fun signOutWithToken(): Response<Unit>
+
+    /**
+     * 로그인 API
+     *
+     * idToken을 이용하여 로그인을 수행하고, JWT를 발급합니다.
+     **/
     @POST("members/login")
-    suspend fun signWithToken(
+    suspend fun signInWithToken(
         @Body request: SignWithTokenRequest
-    ): Response<SignWithTokenResponse>
+    ): Response<SignInWithTokenResponse>
+
+    /**
+     * JWT 갱신 API
+     *
+     * Refresh Token을 이용하여 JWT를 갱신합니다.
+     **/
+    @PATCH("members/refresh")
+    suspend fun reissueToken(
+        @Body request: ReissueTokenRequest
+    ): Response<ReissueTokenResponse>
+
+    /**
+     * 프로필 사진 변경 API
+     *
+     * 프로필 사진을 변경합니다.
+     **/
+    @PATCH("members/profile-image")
+    suspend fun registerProfileImage(
+        /* TODO */
+    )
+
+    /**
+     * 닉네임 변경 API
+     *
+     * 닉네임을 변경합니다.
+     **/
+    @PATCH("members/nickname")
+    suspend fun registerNickname(
+        @Query("newNickname") nickname: String
+    ): Response<RegisterNicknameResponse>
+
+    /**
+     * 회원 정보 조회 API
+     *
+     * JWT를 읽어 로그인한 회원의 정보를 조회합니다.
+     **/
+    @Headers("Authorization: true")
+    @GET("members")
+    suspend fun getMemberInformation(): Response<GetMemberInformationResponse>
+
+    /**
+     * 닉네임 중복 확인 API
+     *
+     * 닉네임이 중복되는지 확인합니다.
+     * @return true면 사용 가능, false면 중복.
+     **/
+    @GET("members/check-nickname")
+    suspend fun isDuplicateNickname(
+        @Query("nickname") nickname: String
+    ): Response<Boolean>
 
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/MembersService.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/MembersService.kt
@@ -21,6 +21,7 @@ interface MembersService {
      *
      * 회원을 탈퇴합니다.
      **/
+    @Headers("Authorization: true")
     @POST("members/withdraw")
     suspend fun withdrawWithToken(): Response<Unit>
 
@@ -29,6 +30,7 @@ interface MembersService {
      *
      * 로그인시 발급한 JWT를 말소합니다.
      **/
+    @Headers("Authorization: true")
     @POST("members/logout")
     suspend fun signOutWithToken(): Response<Unit>
 
@@ -47,6 +49,7 @@ interface MembersService {
      *
      * Refresh Token을 이용하여 JWT를 갱신합니다.
      **/
+    @Headers("Authorization: false")
     @PATCH("members/refresh")
     suspend fun reissueToken(
         @Body request: ReissueTokenRequest
@@ -57,6 +60,7 @@ interface MembersService {
      *
      * 프로필 사진을 변경합니다.
      **/
+    @Headers("Authorization: true")
     @PATCH("members/profile-image")
     suspend fun registerProfileImage(
         /* TODO */
@@ -67,6 +71,7 @@ interface MembersService {
      *
      * 닉네임을 변경합니다.
      **/
+    @Headers("Authorization: true")
     @PATCH("members/nickname")
     suspend fun registerNickname(
         @Query("newNickname") nickname: String
@@ -87,6 +92,7 @@ interface MembersService {
      * 닉네임이 중복되는지 확인합니다.
      * @return true면 사용 가능, false면 중복.
      **/
+    @Headers("Authorization: true")
     @GET("members/check-nickname")
     suspend fun isDuplicateNickname(
         @Query("nickname") nickname: String

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/RunSuspendCatching.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/RunSuspendCatching.kt
@@ -1,5 +1,6 @@
 package com.captures2024.soongan.core.domain
 
+import timber.log.Timber
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -10,6 +11,11 @@ internal inline fun <T> runSuspendCatching(block: () -> T): Result<T> {
     contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
     return runCatching(block).also { result ->
         val exception = result.exceptionOrNull()
+
+        if (exception != null) {
+            Timber.tag("runSuspendCatching").e("exception = $exception")
+        }
+
         if (exception is CancellationException) throw exception
     }
 }

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/repository/MembersRepository.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/repository/MembersRepository.kt
@@ -2,27 +2,27 @@ package com.captures2024.soongan.core.domain.repository
 
 import com.captures2024.soongan.core.model.dto.UserInfoDto
 import com.captures2024.soongan.core.model.network.SocialSignType
-import com.captures2024.soongan.core.model.entity.ResultConditionEntity
+import com.captures2024.soongan.core.model.dto.ResultConditionDto
 
 interface MembersRepository {
 
-    suspend fun withdrawMember(): ResultConditionEntity
+    suspend fun withdrawMember(): ResultConditionDto
 
-    suspend fun signOutSocialPlatform(): ResultConditionEntity
+    suspend fun signOutSocialPlatform(): ResultConditionDto
 
     suspend fun signingSocialPlatform(
         type: SocialSignType,
         token: String
-    ): ResultConditionEntity
+    ): ResultConditionDto
 
-    suspend fun reissueToken(): ResultConditionEntity
+    suspend fun reissueToken(): ResultConditionDto
 
     suspend fun registerProfileImage()
 
-    suspend fun registerNickname(nickname: String): ResultConditionEntity
+    suspend fun registerNickname(nickname: String): ResultConditionDto
 
     suspend fun getMemberInformation(): UserInfoDto
 
-    suspend fun isDuplicateNickname(nickname: String): ResultConditionEntity
+    suspend fun isDuplicateNickname(nickname: String): ResultConditionDto
 
 }

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/repository/MembersRepository.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/repository/MembersRepository.kt
@@ -5,9 +5,23 @@ import com.captures2024.soongan.core.model.entity.ResultConditionEntity
 
 interface MembersRepository {
 
+    suspend fun withdrawMember(): ResultConditionEntity
+
+    suspend fun signOutSocialPlatform(): ResultConditionEntity
+
     suspend fun signingSocialPlatform(
         type: SocialSignType,
         token: String
     ): ResultConditionEntity
+
+    suspend fun reissueToken(): ResultConditionEntity
+
+    suspend fun registerProfileImage()
+
+    suspend fun registerNickname(nickname: String): ResultConditionEntity
+
+    suspend fun getMemberInformation()
+
+    suspend fun isDuplicateNickname(nickname: String): ResultConditionEntity
 
 }

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/repository/MembersRepository.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/repository/MembersRepository.kt
@@ -1,5 +1,6 @@
 package com.captures2024.soongan.core.domain.repository
 
+import com.captures2024.soongan.core.model.dto.UserInfoDto
 import com.captures2024.soongan.core.model.network.SocialSignType
 import com.captures2024.soongan.core.model.entity.ResultConditionEntity
 
@@ -20,7 +21,7 @@ interface MembersRepository {
 
     suspend fun registerNickname(nickname: String): ResultConditionEntity
 
-    suspend fun getMemberInformation()
+    suspend fun getMemberInformation(): UserInfoDto
 
     suspend fun isDuplicateNickname(nickname: String): ResultConditionEntity
 

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/GetMemberInformationUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/GetMemberInformationUseCase.kt
@@ -1,0 +1,19 @@
+package com.captures2024.soongan.core.domain.usecase.members
+
+import com.captures2024.soongan.core.domain.repository.MembersRepository
+import com.captures2024.soongan.core.domain.runSuspendCatching
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class GetMemberInformationUseCase
+@Inject
+constructor(
+    private val repository: MembersRepository
+) {
+
+    suspend operator fun invoke(): Result<Unit> = runSuspendCatching {
+        repository.getMemberInformation()
+    }
+
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/IsAllowNicknameUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/IsAllowNicknameUseCase.kt
@@ -1,0 +1,19 @@
+package com.captures2024.soongan.core.domain.usecase.members
+
+import com.captures2024.soongan.core.domain.repository.MembersRepository
+import com.captures2024.soongan.core.domain.runSuspendCatching
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class IsAllowNicknameUseCase
+@Inject
+constructor(
+    private val repository: MembersRepository
+) {
+
+    suspend operator fun invoke(nickname: String): Result<Boolean> = runSuspendCatching {
+        repository.isDuplicateNickname(nickname).result
+    }
+
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/IsAllowUserInfoUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/IsAllowUserInfoUseCase.kt
@@ -1,0 +1,29 @@
+package com.captures2024.soongan.core.domain.usecase.members
+
+import com.captures2024.soongan.core.domain.repository.MembersRepository
+import com.captures2024.soongan.core.domain.runSuspendCatching
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class IsAllowUserInfoUseCase
+@Inject
+constructor(
+    private val repository: MembersRepository
+) {
+
+    suspend operator fun invoke(): Result<Boolean> = runSuspendCatching {
+        val userInfo = repository.getMemberInformation()
+
+        if (userInfo.user.nickname.isEmpty()) {
+            return@runSuspendCatching false
+        }
+
+        if (userInfo.user.birthDate.isEmpty()) {
+            return@runSuspendCatching false
+        }
+
+        return@runSuspendCatching true
+    }
+
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/RegisterNicknameUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/RegisterNicknameUseCase.kt
@@ -1,0 +1,19 @@
+package com.captures2024.soongan.core.domain.usecase.members
+
+import com.captures2024.soongan.core.domain.repository.MembersRepository
+import com.captures2024.soongan.core.domain.runSuspendCatching
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RegisterNicknameUseCase
+@Inject
+constructor(
+    private val repository: MembersRepository
+) {
+
+    suspend operator fun invoke(nickname: String) = runSuspendCatching {
+        repository.registerNickname(nickname)
+    }
+
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/ReissueTokenUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/ReissueTokenUseCase.kt
@@ -6,14 +6,14 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class GetMemberInformationUseCase
+class ReissueTokenUseCase
 @Inject
 constructor(
     private val repository: MembersRepository
 ) {
 
-    suspend operator fun invoke(): Result<Unit> = runSuspendCatching {
-        repository.getMemberInformation()
+    suspend operator fun invoke(): Result<Boolean> = runSuspendCatching {
+        repository.reissueToken().result
     }
 
 }

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/ResultConditionDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/ResultConditionDto.kt
@@ -1,0 +1,5 @@
+package com.captures2024.soongan.core.model.dto
+
+data class ResultConditionDto(
+    val result: Boolean
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/UserDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/UserDto.kt
@@ -1,0 +1,7 @@
+package com.captures2024.soongan.core.model.dto
+
+data class UserDto(
+    val email: String,
+    val nickname: String,
+    val birthDate: String,
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/UserInfoDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/UserInfoDto.kt
@@ -1,0 +1,6 @@
+package com.captures2024.soongan.core.model.dto
+
+data class UserInfoDto(
+    val user: UserDto,
+    val profileImage: String
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/entity/ResultConditionEntity.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/entity/ResultConditionEntity.kt
@@ -1,5 +1,0 @@
-package com.captures2024.soongan.core.model.entity
-
-data class ResultConditionEntity(
-    val result: Boolean
-)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/request/members/ReissueTokenRequest.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/request/members/ReissueTokenRequest.kt
@@ -1,0 +1,12 @@
+package com.captures2024.soongan.core.model.network.request.members
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReissueTokenRequest(
+    @SerialName("accessToken")
+    val accessToken: String,
+    @SerialName("refreshToken")
+    val refreshToken: String,
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/request/members/SignWithTokenRequest.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/request/members/SignWithTokenRequest.kt
@@ -1,4 +1,4 @@
-package com.captures2024.soongan.core.model.network.request
+package com.captures2024.soongan.core.model.network.request.members
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/members/GetMemberInformationResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/members/GetMemberInformationResponse.kt
@@ -1,0 +1,36 @@
+package com.captures2024.soongan.core.model.network.response.members
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetMemberInformationResponse(
+    @SerialName("id")
+    val id: Int,
+    @SerialName("email")
+    val email: String,
+    @SerialName("nickname")
+    val nickname: String = "",
+    @SerialName("birthDate")
+    val birth: String = "",
+    @SerialName("profileImageUrl")
+    val profileImage: String,
+    @SerialName("createdAt")
+    val createdAt: String,
+    @SerialName("updatedAt")
+    val updatedAt: String,
+    @SerialName("withdrawalAt")
+    val withdrawalAt: String,
+    @SerialName("isEnabled")
+    val isEnabled: Boolean,
+    @SerialName("username")
+    val username: String,
+    @SerialName("password")
+    val password: String,
+    @SerialName("isAccountNonExpired")
+    val isAccountNonExpired: Boolean,
+    @SerialName("isAccountNonLocked")
+    val isAccountNonLocked: Boolean,
+    @SerialName("isCredentialsNonExpired")
+    val isCredentialsNonExpired: Boolean,
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/members/GetMemberInformationResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/members/GetMemberInformationResponse.kt
@@ -5,32 +5,12 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class GetMemberInformationResponse(
-    @SerialName("id")
-    val id: Int,
     @SerialName("email")
     val email: String,
     @SerialName("nickname")
-    val nickname: String = "",
+    val nickname: String?,
     @SerialName("birthDate")
-    val birth: String = "",
+    val birthDate: String?,
     @SerialName("profileImageUrl")
-    val profileImage: String,
-    @SerialName("createdAt")
-    val createdAt: String,
-    @SerialName("updatedAt")
-    val updatedAt: String,
-    @SerialName("withdrawalAt")
-    val withdrawalAt: String,
-    @SerialName("isEnabled")
-    val isEnabled: Boolean,
-    @SerialName("username")
-    val username: String,
-    @SerialName("password")
-    val password: String,
-    @SerialName("isAccountNonExpired")
-    val isAccountNonExpired: Boolean,
-    @SerialName("isAccountNonLocked")
-    val isAccountNonLocked: Boolean,
-    @SerialName("isCredentialsNonExpired")
-    val isCredentialsNonExpired: Boolean,
+    val profileImage: String?,
 )

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/members/RegisterNicknameResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/members/RegisterNicknameResponse.kt
@@ -1,0 +1,12 @@
+package com.captures2024.soongan.core.model.network.response.members
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterNicknameResponse(
+    @SerialName("memberEmail")
+    val id: String,
+    @SerialName("updatedNickname")
+    val nickname: String
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/members/ReissueTokenResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/members/ReissueTokenResponse.kt
@@ -1,12 +1,12 @@
-package com.captures2024.soongan.core.model.network.response
+package com.captures2024.soongan.core.model.network.response.members
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class SignWithTokenResponse(
+data class ReissueTokenResponse(
     @SerialName("accessToken")
     val accessToken: String,
     @SerialName("refreshToken")
-    val refreshToken: String
+    val refreshToken: String,
 )

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/members/SignInWithTokenResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/members/SignInWithTokenResponse.kt
@@ -1,0 +1,12 @@
+package com.captures2024.soongan.core.model.network.response.members
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SignInWithTokenResponse(
+    @SerialName("accessToken")
+    val accessToken: String,
+    @SerialName("refreshToken")
+    val refreshToken: String
+)

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -9,6 +9,7 @@ android {
 
 dependencies {
     implementation(project(":core:datastore"))
+    implementation(project(":core:domain"))
 
     implementation(libs.bundles.retrofit)
     implementation(platform(libs.okhttp.bom))

--- a/core/network/src/main/kotlin/com/captures2024/soongan/core/network/AuthInterceptor.kt
+++ b/core/network/src/main/kotlin/com/captures2024/soongan/core/network/AuthInterceptor.kt
@@ -16,32 +16,34 @@ constructor(
     override fun intercept(chain: Interceptor.Chain): Response = with(chain) {
         val defaultRequest = request()
 
-        val isAccessToken = defaultRequest.headers["Authorization"]
+        val isAccessToken = defaultRequest.headers[AUTH_HEADER]
 
         return@with when (isAccessToken) {
             "true" -> {
                 val accessToken = runBlocking { tokenDataSource.getAccessToken() }
 
                 val newRequest = defaultRequest.newBuilder()
-                    .header("Authorization", "Bearer $accessToken")
-                    .addHeader("User-Agent", "ANDROID")
+                    .header(AUTH_HEADER, "$AUTH_PREFIX $accessToken")
+                    .addHeader(AGENT_HEADER, OS)
                     .build()
 
                 proceed(newRequest)
             }
+
             "false" -> {
                 val refreshToken = runBlocking { tokenDataSource.getRefreshToken() }
 
                 val newRequest = defaultRequest.newBuilder()
-                    .header("Authorization", "Bearer $refreshToken")
-                    .addHeader("User-Agent", "ANDROID")
+                    .header(AUTH_HEADER, "$AUTH_PREFIX $refreshToken")
+                    .addHeader(AGENT_HEADER, OS)
                     .build()
 
                 proceed(newRequest)
             }
+
             else -> {
                 val newRequest = defaultRequest.newBuilder()
-                    .addHeader("User-Agent", "ANDROID")
+                    .addHeader(AGENT_HEADER, OS)
                     .build()
 
                 proceed(newRequest)
@@ -49,4 +51,10 @@ constructor(
         }
     }
 
+    companion object {
+        private const val AUTH_HEADER = "Authorization"
+        private const val AUTH_PREFIX = "Bearer"
+        private const val AGENT_HEADER = "User-Agent"
+        private const val OS = "ANDROID"
+    }
 }

--- a/core/network/src/main/kotlin/com/captures2024/soongan/core/network/SoonGanAuthenticator.kt
+++ b/core/network/src/main/kotlin/com/captures2024/soongan/core/network/SoonGanAuthenticator.kt
@@ -1,8 +1,7 @@
 package com.captures2024.soongan.core.network
 
-import android.content.Context
 import com.captures2024.soongan.core.datastore.TokenDataSource
-import dagger.hilt.android.qualifiers.ApplicationContext
+import com.captures2024.soongan.core.domain.usecase.members.ReissueTokenUseCase
 import kotlinx.coroutines.runBlocking
 import okhttp3.Authenticator
 import okhttp3.Request
@@ -13,7 +12,7 @@ import javax.inject.Inject
 class SoonGanAuthenticator
 @Inject
 constructor(
-    private val tokenDataSource: TokenDataSource,
+    private val tokenDataSource: TokenDataSource
 ) : Authenticator {
     override fun authenticate(route: Route?, response: Response): Request? {
         if (response.request.header("Authorization") == null) {
@@ -23,15 +22,15 @@ constructor(
         if (response.code == 401) {
             val refreshToken = runBlocking { tokenDataSource.getRefreshToken() }
 
-            val newTokens = runCatching {
-                runBlocking {
-//                    api.refreshToken("Bearer $refreshToken")
-                }
-            }.onSuccess {
-                // TODO setAccessToken, setRefreshToken
+            val reissueResult = runCatching {
 //                runBlocking {
-//                    tokenDataSource.setAccessToken()
-//                    tokenDataSource.setRefreshToken()
+//                    val result = reissueTokenUseCase().getOrThrow()
+//
+//                    return@runBlocking if (result) {
+//                        tokenDataSource.getAccessToken()
+//                    } else {
+//                        tokenDataSource.getAccessToken()
+//                    }
 //                }
             }.onFailure {
                 runBlocking {

--- a/feature/intro/src/main/kotlin/com/captures2024/soongan/feature/intro/IntroViewModel.kt
+++ b/feature/intro/src/main/kotlin/com/captures2024/soongan/feature/intro/IntroViewModel.kt
@@ -2,14 +2,9 @@ package com.captures2024.soongan.feature.intro
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.captures2024.soongan.core.domain.usecase.members.GetMemberInformationUseCase
-import com.captures2024.soongan.core.domain.usecase.token.GetAccessTokenUseCase
+import com.captures2024.soongan.core.domain.usecase.members.IsAllowUserInfoUseCase
 import com.captures2024.soongan.core.domain.usecase.token.GetAllTokenUseCase
-import com.captures2024.soongan.core.domain.usecase.token.GetRefreshTokenUseCase
-import com.captures2024.soongan.feature.intro.IntroActivityUiState.Loading
-import com.captures2024.soongan.feature.intro.IntroActivityUiState.Success
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
@@ -21,17 +16,22 @@ class IntroViewModel
 @Inject
 constructor(
     private val getAllTokenUseCase: GetAllTokenUseCase,
-    private val getMemberInformationUseCase: GetMemberInformationUseCase
+    private val isAllowUserInfoUseCase: IsAllowUserInfoUseCase
 ) : ViewModel() {
     val introState: StateFlow<IntroState> = flow {
-        getMemberInformationUseCase()
-        getAllTokenUseCase().getOrNull()?.let { (accessToken, refreshToken) ->
-            when {
-                accessToken.isNotEmpty() && refreshToken.isNotEmpty() -> emit(IntroState.Main)
-                else -> emit(IntroState.Sign)
-            }
-        } ?: emit(IntroState.Sign)
-//        emit(IntroState.Main)
+        val (accessToken, refreshToken) = getAllTokenUseCase().getOrNull() ?: return@flow emit(IntroState.Sign)
+
+        if (accessToken.isEmpty() && refreshToken.isEmpty()) {
+            emit(IntroState.Sign)
+            return@flow
+        }
+
+        val isAllow = isAllowUserInfoUseCase().getOrNull() ?: return@flow emit(IntroState.Sign)
+
+        when (isAllow) {
+            true -> emit(IntroState.Main)
+            false -> emit(IntroState.Sign)
+        }
     }.stateIn(
         scope = viewModelScope,
         initialValue = IntroState.Loading,

--- a/feature/intro/src/main/kotlin/com/captures2024/soongan/feature/intro/IntroViewModel.kt
+++ b/feature/intro/src/main/kotlin/com/captures2024/soongan/feature/intro/IntroViewModel.kt
@@ -2,6 +2,7 @@ package com.captures2024.soongan.feature.intro
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.captures2024.soongan.core.domain.usecase.members.GetMemberInformationUseCase
 import com.captures2024.soongan.core.domain.usecase.token.GetAccessTokenUseCase
 import com.captures2024.soongan.core.domain.usecase.token.GetAllTokenUseCase
 import com.captures2024.soongan.core.domain.usecase.token.GetRefreshTokenUseCase
@@ -19,9 +20,11 @@ import javax.inject.Inject
 class IntroViewModel
 @Inject
 constructor(
-    private val getAllTokenUseCase: GetAllTokenUseCase
+    private val getAllTokenUseCase: GetAllTokenUseCase,
+    private val getMemberInformationUseCase: GetMemberInformationUseCase
 ) : ViewModel() {
     val introState: StateFlow<IntroState> = flow {
+        getMemberInformationUseCase()
         getAllTokenUseCase().getOrNull()?.let { (accessToken, refreshToken) ->
             when {
                 accessToken.isNotEmpty() && refreshToken.isNotEmpty() -> emit(IntroState.Main)

--- a/feature/signUp/build.gradle.kts
+++ b/feature/signUp/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
     implementation(project(":core:common"))
     implementation(project(":core:designSystem"))
     implementation(project(":core:domain"))
+    implementation(project(":core:model"))
 }

--- a/feature/signUp/build.gradle.kts
+++ b/feature/signUp/build.gradle.kts
@@ -10,4 +10,5 @@ android {
 dependencies {
     implementation(project(":core:common"))
     implementation(project(":core:designSystem"))
+    implementation(project(":core:domain"))
 }

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/NicknameViewModel.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/NicknameViewModel.kt
@@ -3,18 +3,19 @@ package com.captures2024.soongan.feature.signUp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.captures2024.soongan.core.domain.usecase.members.IsAllowNicknameUseCase
+import com.captures2024.soongan.core.domain.usecase.members.RegisterNicknameUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class NicknameViewModel
 @Inject
 constructor(
-    private val isAllowNicknameUseCase: IsAllowNicknameUseCase
+    private val isAllowNicknameUseCase: IsAllowNicknameUseCase,
+    private val registerNicknameUseCase: RegisterNicknameUseCase
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<InputNickNameUIState>(InputNickNameUIState.Init)
     val uiState: StateFlow<InputNickNameUIState>
@@ -43,19 +44,28 @@ constructor(
             is InputNickNameUIState.Init,
             is InputNickNameUIState.Loading,
             is InputNickNameUIState.Error -> return
+
             else -> viewModelScope.launch {
                 _uiState.emit(InputNickNameUIState.Loading(currentState.nickname))
 
                 val isAllow = isAllowNicknameUseCase(currentState.nickname).getOrNull() ?: return@launch _uiState.emit(InputNickNameUIState.Error(currentState.nickname))
 
-                when (isAllow) {
-                    true -> {
-                        // TODO 회원 정보 수정
-                        _uiState.emit(InputNickNameUIState.Success(currentState.nickname))
-                    }
-                    false -> _uiState.emit(InputNickNameUIState.Error(currentState.nickname))
+                if (!isAllow) {
+                    _uiState.emit(InputNickNameUIState.Error(currentState.nickname))
+                    return@launch
                 }
+
+                registerNickname(currentState.nickname)
             }
+        }
+    }
+
+    private suspend fun registerNickname(nickname: String) {
+        val isRegister = registerNicknameUseCase(nickname).getOrNull() ?: return _uiState.emit(InputNickNameUIState.Error(nickname))
+
+        when (isRegister.result) {
+            true -> _uiState.emit(InputNickNameUIState.Success(nickname))
+            false -> _uiState.emit(InputNickNameUIState.Error(nickname))
         }
     }
 


### PR DESCRIPTION
# [feat/sign_network] Sign API 통신 적용

## 개요
- https://github.com/captures-2024/soongan-android/issues/31

## 작업 사항
- Member Service API 추가
- 랜딩페이지에서 토큰 검사를 통해 유저 정보 체크하여 플로우 진행
- 닉네임 중복, 등록 추가

## 수정 사항(optional)
- x