### PR TITLE
[SG-16] 카카오 로그인

### DIFF
--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/RemoteDataSourceModule.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/RemoteDataSourceModule.kt
@@ -1,7 +1,9 @@
 package com.captures2024.soongan.core.data.di
 
+import com.captures2024.soongan.core.data.remote.AuthDataSource
 import com.captures2024.soongan.core.data.remote.FcmDataSource
 import com.captures2024.soongan.core.data.remote.MembersDataSource
+import com.captures2024.soongan.core.data.remote.impl.AuthDataSourceImpl
 import com.captures2024.soongan.core.data.remote.impl.FcmDataSourceImpl
 import com.captures2024.soongan.core.data.remote.impl.MembersDataSourceImpl
 import dagger.Binds
@@ -21,4 +23,8 @@ abstract class RemoteDataSourceModule {
     @Binds
     @Singleton
     abstract fun bindFcmDataSource(fcmDataSourceImpl: FcmDataSourceImpl): FcmDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindAuthDataSource(authDataSourceImpl: AuthDataSourceImpl): AuthDataSource
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/RepositoryModule.kt
@@ -1,8 +1,10 @@
 package com.captures2024.soongan.core.data.di
 
+import com.captures2024.soongan.core.data.repository.AuthRepository
 import com.captures2024.soongan.core.data.repository.FcmRepository
 import com.captures2024.soongan.core.data.repository.MembersRepository
 import com.captures2024.soongan.core.data.repository.TokenRepository
+import com.captures2024.soongan.core.data.repository.impl.AuthRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.FcmRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.MembersRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.TokenRepositoryImpl
@@ -27,4 +29,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindFcmRepository(fcmRepositoryImpl: FcmRepositoryImpl): FcmRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindAuthRepository(authRepositoryImpl: AuthRepositoryImpl): AuthRepository
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/ServiceModule.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/ServiceModule.kt
@@ -1,5 +1,6 @@
 package com.captures2024.soongan.core.data.di
 
+import com.captures2024.soongan.core.data.service.AuthService
 import com.captures2024.soongan.core.data.service.FcmService
 import com.captures2024.soongan.core.data.service.MembersService
 import dagger.Module
@@ -20,4 +21,8 @@ object ServiceModule {
     @Singleton
     @Provides
     internal fun provideFcmService(retrofit: Retrofit): FcmService = retrofit.create(FcmService::class.java)
+
+    @Singleton
+    @Provides
+    internal fun provideAuthService(retrofit: Retrofit): AuthService = retrofit.create(AuthService::class.java)
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/AuthDataSource.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/AuthDataSource.kt
@@ -1,0 +1,23 @@
+package com.captures2024.soongan.core.data.remote
+
+import com.captures2024.soongan.core.model.network.SocialSignType
+import com.captures2024.soongan.core.model.network.response.members.ReissueTokenResponse
+import com.captures2024.soongan.core.model.network.response.members.SignInWithTokenResponse
+
+interface AuthDataSource {
+
+    suspend fun withdrawWithToken(): Boolean
+
+    suspend fun signOutWithToken(): Boolean
+
+    suspend fun signInWithToken(
+        type: SocialSignType,
+        token: String,
+        fcmToken: String,
+    ): SignInWithTokenResponse?
+
+    suspend fun reissueToken(
+        accessToken: String,
+        refreshToken: String,
+    ): ReissueTokenResponse?
+}

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/MembersDataSource.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/MembersDataSource.kt
@@ -8,21 +8,6 @@ import com.captures2024.soongan.core.model.network.response.members.SignInWithTo
 
 interface MembersDataSource {
 
-    suspend fun withdrawWithToken(): Boolean
-
-    suspend fun signOutWithToken(): Boolean
-
-    suspend fun signInWithToken(
-        type: SocialSignType,
-        token: String,
-        fcmToken: String,
-    ): SignInWithTokenResponse?
-
-    suspend fun reissueToken(
-        accessToken: String,
-        refreshToken: String,
-    ): ReissueTokenResponse?
-
     suspend fun registerProfileImage()
 
     suspend fun registerNickname(

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/AuthDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/AuthDataSourceImpl.kt
@@ -1,0 +1,62 @@
+package com.captures2024.soongan.core.data.remote.impl
+
+import com.captures2024.soongan.core.data.remote.AuthDataSource
+import com.captures2024.soongan.core.data.service.AuthService
+import com.captures2024.soongan.core.data.utils.safeAPICall
+import com.captures2024.soongan.core.model.network.SocialSignType
+import com.captures2024.soongan.core.model.network.request.members.ReissueTokenRequest
+import com.captures2024.soongan.core.model.network.request.members.SignWithTokenRequest
+import com.captures2024.soongan.core.model.network.response.members.ReissueTokenResponse
+import com.captures2024.soongan.core.model.network.response.members.SignInWithTokenResponse
+import javax.inject.Inject
+
+class AuthDataSourceImpl
+@Inject
+constructor(
+    private val service: AuthService,
+)  : AuthDataSource {
+
+    override suspend fun withdrawWithToken(): Boolean {
+        val result = safeAPICall { service.withdrawWithToken() }
+
+        return when (result.body) {
+            null -> false
+            else -> true
+        }
+    }
+
+    override suspend fun signOutWithToken(): Boolean {
+        val result = safeAPICall { service.signOutWithToken() }
+
+        return when (result.body) {
+            null -> false
+            else -> true
+        }
+    }
+
+    override suspend fun signInWithToken(
+        type: SocialSignType,
+        token: String,
+        fcmToken: String,
+    ): SignInWithTokenResponse? = safeAPICall {
+        service.signInWithToken(
+            request = SignWithTokenRequest(
+                provider = type.provider,
+                idToken = token,
+                fcmToken = fcmToken,
+            ),
+        )
+    }.body?.responseData
+
+    override suspend fun reissueToken(
+        accessToken: String,
+        refreshToken: String,
+    ): ReissueTokenResponse? = safeAPICall {
+        service.reissueToken(
+            request = ReissueTokenRequest(
+                accessToken = accessToken,
+                refreshToken = refreshToken,
+            ),
+        )
+    }.body?.responseData
+}

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/MembersDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/MembersDataSourceImpl.kt
@@ -18,49 +18,6 @@ class MembersDataSourceImpl
 constructor(
     private val service: MembersService,
 ) : MembersDataSource {
-    override suspend fun withdrawWithToken(): Boolean {
-        val result = safeAPICall { service.withdrawWithToken() }
-
-        return when (result.body) {
-            null -> false
-            else -> true
-        }
-    }
-
-    override suspend fun signOutWithToken(): Boolean {
-        val result = safeAPICall { service.signOutWithToken() }
-
-        return when (result.body) {
-            null -> false
-            else -> true
-        }
-    }
-
-    override suspend fun signInWithToken(
-        type: SocialSignType,
-        token: String,
-        fcmToken: String,
-    ): SignInWithTokenResponse? = safeAPICall {
-        service.signInWithToken(
-            request = SignWithTokenRequest(
-                provider = type.provider,
-                idToken = token,
-                fcmToken = fcmToken,
-            ),
-        )
-    }.body?.responseData
-
-    override suspend fun reissueToken(
-        accessToken: String,
-        refreshToken: String,
-    ): ReissueTokenResponse? = safeAPICall {
-        service.reissueToken(
-            request = ReissueTokenRequest(
-                accessToken = accessToken,
-                refreshToken = refreshToken,
-            ),
-        )
-    }.body?.responseData
 
     override suspend fun registerProfileImage() {
         TODO("Not yet implemented")

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/AuthRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/AuthRepository.kt
@@ -1,0 +1,19 @@
+package com.captures2024.soongan.core.data.repository
+
+import com.captures2024.soongan.core.model.dto.ResultConditionDto
+import com.captures2024.soongan.core.model.network.SocialSignType
+
+interface AuthRepository {
+
+    suspend fun withdrawMember(): ResultConditionDto
+
+    suspend fun signOutSocialPlatform(): ResultConditionDto
+
+    suspend fun signingSocialPlatform(
+        type: SocialSignType,
+        token: String,
+        fcmToken: String,
+    ): ResultConditionDto
+
+    suspend fun reissueToken(): ResultConditionDto
+}

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/MembersRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/MembersRepository.kt
@@ -6,18 +6,6 @@ import com.captures2024.soongan.core.model.dto.ResultConditionDto
 
 interface MembersRepository {
 
-    suspend fun withdrawMember(): ResultConditionDto
-
-    suspend fun signOutSocialPlatform(): ResultConditionDto
-
-    suspend fun signingSocialPlatform(
-        type: SocialSignType,
-        token: String,
-        fcmToken: String,
-    ): ResultConditionDto
-
-    suspend fun reissueToken(): ResultConditionDto
-
     suspend fun registerProfileImage()
 
     suspend fun registerNickname(nickname: String): ResultConditionDto

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/AuthRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/AuthRepositoryImpl.kt
@@ -1,0 +1,86 @@
+package com.captures2024.soongan.core.data.repository.impl
+
+import com.captures2024.soongan.core.data.remote.AuthDataSource
+import com.captures2024.soongan.core.data.repository.AuthRepository
+import com.captures2024.soongan.core.datastore.TokenDataSource
+import com.captures2024.soongan.core.model.dto.ResultConditionDto
+import com.captures2024.soongan.core.model.network.SocialSignType
+import javax.inject.Inject
+
+class AuthRepositoryImpl
+@Inject
+constructor(
+    private val tokenDataSource: TokenDataSource,
+    private val authDataSource: AuthDataSource
+) : AuthRepository {
+
+    override suspend fun withdrawMember(): ResultConditionDto = when (authDataSource.withdrawWithToken()) {
+        true -> {
+            tokenDataSource.clearAllToken()
+            ResultConditionDto(result = true)
+        }
+        false -> ResultConditionDto(result = false)
+    }
+
+    override suspend fun signOutSocialPlatform(): ResultConditionDto = when (authDataSource.signOutWithToken()) {
+        true -> {
+            tokenDataSource.clearAllToken()
+            ResultConditionDto(result = true)
+        }
+        false -> ResultConditionDto(result = false)
+    }
+
+    override suspend fun signingSocialPlatform(
+        type: SocialSignType,
+        token: String,
+        fcmToken: String,
+    ): ResultConditionDto {
+        val tokenResult = authDataSource.signInWithToken(
+            type = type,
+            token = token,
+            fcmToken = fcmToken,
+        ) ?: return ResultConditionDto(result = false)
+
+        tokenDataSource.setAccessToken(tokenResult.accessToken)
+        tokenDataSource.setRefreshToken(tokenResult.refreshToken)
+
+        val savedAccessToken = tokenDataSource.getAccessToken()
+        val savedRefreshToken = tokenDataSource.getRefreshToken()
+
+        return when {
+            savedAccessToken == tokenResult.accessToken && savedRefreshToken == tokenResult.refreshToken -> ResultConditionDto(result = true)
+            else -> {
+                tokenDataSource.clearAllToken()
+                ResultConditionDto(result = false)
+            }
+        }
+    }
+
+    override suspend fun reissueToken(): ResultConditionDto {
+        val currentAccessToken = tokenDataSource.getAccessToken()
+        val currentRefreshToken = tokenDataSource.getRefreshToken()
+
+        if (currentAccessToken.isEmpty() || currentRefreshToken.isEmpty()) {
+            return ResultConditionDto(result = false)
+        }
+
+        val tokenResult = authDataSource.reissueToken(
+            accessToken = currentAccessToken,
+            refreshToken = currentRefreshToken,
+        ) ?: return ResultConditionDto(result = false)
+
+        tokenDataSource.setAccessToken(tokenResult.accessToken)
+        tokenDataSource.setRefreshToken(tokenResult.refreshToken)
+
+        val savedAccessToken = tokenDataSource.getAccessToken()
+        val savedRefreshToken = tokenDataSource.getRefreshToken()
+
+        return when {
+            savedAccessToken == tokenResult.accessToken && savedRefreshToken == tokenResult.refreshToken -> ResultConditionDto(result = true)
+            else -> {
+                tokenDataSource.clearAllToken()
+                ResultConditionDto(result = false)
+            }
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/MembersRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/MembersRepositoryImpl.kt
@@ -11,78 +11,8 @@ import javax.inject.Inject
 class MembersRepositoryImpl
 @Inject
 constructor(
-    private val tokenDataSource: TokenDataSource,
     private val membersDataSource: MembersDataSource,
 ) : MembersRepository {
-    override suspend fun withdrawMember(): ResultConditionDto = when (membersDataSource.withdrawWithToken()) {
-        true -> {
-            tokenDataSource.clearAllToken()
-            ResultConditionDto(result = true)
-        }
-        false -> ResultConditionDto(result = false)
-    }
-
-    override suspend fun signOutSocialPlatform(): ResultConditionDto = when (membersDataSource.signOutWithToken()) {
-        true -> {
-            tokenDataSource.clearAllToken()
-            ResultConditionDto(result = true)
-        }
-        false -> ResultConditionDto(result = false)
-    }
-
-    override suspend fun signingSocialPlatform(
-        type: SocialSignType,
-        token: String,
-        fcmToken: String,
-    ): ResultConditionDto {
-        val tokenResult = membersDataSource.signInWithToken(
-            type = type,
-            token = token,
-            fcmToken = fcmToken,
-        ) ?: return ResultConditionDto(result = false)
-
-        tokenDataSource.setAccessToken(tokenResult.accessToken)
-        tokenDataSource.setRefreshToken(tokenResult.refreshToken)
-
-        val savedAccessToken = tokenDataSource.getAccessToken()
-        val savedRefreshToken = tokenDataSource.getRefreshToken()
-
-        return when {
-            savedAccessToken == tokenResult.accessToken && savedRefreshToken == tokenResult.refreshToken -> ResultConditionDto(result = true)
-            else -> {
-                tokenDataSource.clearAllToken()
-                ResultConditionDto(result = false)
-            }
-        }
-    }
-
-    override suspend fun reissueToken(): ResultConditionDto {
-        val currentAccessToken = tokenDataSource.getAccessToken()
-        val currentRefreshToken = tokenDataSource.getRefreshToken()
-
-        if (currentAccessToken.isEmpty() || currentRefreshToken.isEmpty()) {
-            return ResultConditionDto(result = false)
-        }
-
-        val tokenResult = membersDataSource.reissueToken(
-            accessToken = currentAccessToken,
-            refreshToken = currentRefreshToken,
-        ) ?: return ResultConditionDto(result = false)
-
-        tokenDataSource.setAccessToken(tokenResult.accessToken)
-        tokenDataSource.setRefreshToken(tokenResult.refreshToken)
-
-        val savedAccessToken = tokenDataSource.getAccessToken()
-        val savedRefreshToken = tokenDataSource.getRefreshToken()
-
-        return when {
-            savedAccessToken == tokenResult.accessToken && savedRefreshToken == tokenResult.refreshToken -> ResultConditionDto(result = true)
-            else -> {
-                tokenDataSource.clearAllToken()
-                ResultConditionDto(result = false)
-            }
-        }
-    }
 
     override suspend fun registerProfileImage() {
         TODO("Not yet implemented")

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/AuthService.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/AuthService.kt
@@ -1,0 +1,54 @@
+package com.captures2024.soongan.core.data.service
+
+import com.captures2024.soongan.core.model.network.request.members.ReissueTokenRequest
+import com.captures2024.soongan.core.model.network.request.members.SignWithTokenRequest
+import com.captures2024.soongan.core.model.network.response.BaseResponse
+import com.captures2024.soongan.core.model.network.response.members.ReissueTokenResponse
+import com.captures2024.soongan.core.model.network.response.members.SignInWithTokenResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.Headers
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+
+interface AuthService {
+
+    /**
+     * 회원 탈퇴 API
+     *
+     * 회원을 탈퇴합니다.
+     **/
+    @Headers("Authorization: true")
+    @POST("auth/withdraw")
+    suspend fun withdrawWithToken(): Response<Unit>
+
+    /**
+     * 로그아웃 API
+     *
+     * 로그인시 발급한 JWT를 말소합니다.
+     **/
+    @Headers("Authorization: true")
+    @POST("auth/logout")
+    suspend fun signOutWithToken(): Response<Unit>
+
+    /**
+     * 로그인 API
+     *
+     * idToken을 이용하여 로그인을 수행하고, JWT를 발급합니다.
+     **/
+    @POST("auth/login")
+    suspend fun signInWithToken(
+        @Body request: SignWithTokenRequest,
+    ): Response<BaseResponse<SignInWithTokenResponse>>
+
+    /**
+     * JWT 갱신 API
+     *
+     * Refresh Token을 이용하여 JWT를 갱신합니다.
+     **/
+    @Headers("Authorization: false")
+    @PATCH("auth/refresh")
+    suspend fun reissueToken(
+        @Body request: ReissueTokenRequest,
+    ): Response<BaseResponse<ReissueTokenResponse>>
+}

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/MembersService.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/MembersService.kt
@@ -18,45 +18,6 @@ import retrofit2.http.Query
 interface MembersService {
 
     /**
-     * 회원 탈퇴 API
-     *
-     * 회원을 탈퇴합니다.
-     **/
-    @Headers("Authorization: true")
-    @POST("members/withdraw")
-    suspend fun withdrawWithToken(): Response<Unit>
-
-    /**
-     * 로그아웃 API
-     *
-     * 로그인시 발급한 JWT를 말소합니다.
-     **/
-    @Headers("Authorization: true")
-    @POST("members/logout")
-    suspend fun signOutWithToken(): Response<Unit>
-
-    /**
-     * 로그인 API
-     *
-     * idToken을 이용하여 로그인을 수행하고, JWT를 발급합니다.
-     **/
-    @POST("members/login")
-    suspend fun signInWithToken(
-        @Body request: SignWithTokenRequest,
-    ): Response<BaseResponse<SignInWithTokenResponse>>
-
-    /**
-     * JWT 갱신 API
-     *
-     * Refresh Token을 이용하여 JWT를 갱신합니다.
-     **/
-    @Headers("Authorization: false")
-    @PATCH("members/refresh")
-    suspend fun reissueToken(
-        @Body request: ReissueTokenRequest,
-    ): Response<BaseResponse<ReissueTokenResponse>>
-
-    /**
      * 프로필 사진 변경 API
      *
      * 프로필 사진을 변경합니다.

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/auth/ReissueTokenUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/auth/ReissueTokenUseCase.kt
@@ -1,13 +1,13 @@
-package com.captures2024.soongan.core.domain.usecase.members
+package com.captures2024.soongan.core.domain.usecase.auth
 
-import com.captures2024.soongan.core.data.repository.MembersRepository
+import com.captures2024.soongan.core.data.repository.AuthRepository
 import com.captures2024.soongan.core.domain.runSuspendCatching
 import javax.inject.Inject
 
 class ReissueTokenUseCase
 @Inject
 constructor(
-    private val repository: MembersRepository,
+    private val repository: AuthRepository,
 ) {
 
     suspend operator fun invoke(): Result<Boolean> = runSuspendCatching {

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/auth/SigningGoogleUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/auth/SigningGoogleUseCase.kt
@@ -1,6 +1,6 @@
-package com.captures2024.soongan.core.domain.usecase.members
+package com.captures2024.soongan.core.domain.usecase.auth
 
-import com.captures2024.soongan.core.data.repository.MembersRepository
+import com.captures2024.soongan.core.data.repository.AuthRepository
 import com.captures2024.soongan.core.domain.runSuspendCatching
 import com.captures2024.soongan.core.model.network.SocialSignType
 import javax.inject.Inject
@@ -8,7 +8,7 @@ import javax.inject.Inject
 class SigningGoogleUseCase
 @Inject
 constructor(
-    private val repository: MembersRepository,
+    private val repository: AuthRepository,
 ) {
 
     suspend operator fun invoke(

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/auth/SigningKakaoUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/auth/SigningKakaoUseCase.kt
@@ -1,6 +1,6 @@
-package com.captures2024.soongan.core.domain.usecase.members
+package com.captures2024.soongan.core.domain.usecase.auth
 
-import com.captures2024.soongan.core.data.repository.MembersRepository
+import com.captures2024.soongan.core.data.repository.AuthRepository
 import com.captures2024.soongan.core.domain.runSuspendCatching
 import com.captures2024.soongan.core.model.network.SocialSignType
 import javax.inject.Inject
@@ -8,7 +8,7 @@ import javax.inject.Inject
 class SigningKakaoUseCase
 @Inject
 constructor(
-    private val repository: MembersRepository,
+    private val repository: AuthRepository,
 ) {
 
     suspend operator fun invoke(

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/SigningKakaoUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/SigningKakaoUseCase.kt
@@ -11,11 +11,14 @@ constructor(
     private val repository: MembersRepository,
 ) {
 
-    suspend operator fun invoke(token: String): Result<Boolean> = runSuspendCatching {
+    suspend operator fun invoke(
+        token: String,
+        fcmToken: String
+    ): Result<Boolean> = runSuspendCatching {
         repository.signingSocialPlatform(
             type = SocialSignType.KAKAO,
             token = token,
-            fcmToken = "",
+            fcmToken = fcmToken,
         ).result
     }
 }

--- a/feature/sign/src/main/kotlin/com/captures2024/soongan/feature/sign/SignActivity.kt
+++ b/feature/sign/src/main/kotlin/com/captures2024/soongan/feature/sign/SignActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.analytics.utils.LogElementArgument
 import com.captures2024.soongan.core.android.utils.LocalAnalyticsHelper
 import com.captures2024.soongan.core.android.helper.NetworkMonitor
 import com.captures2024.soongan.core.auth.GoogleAuthUiClient
@@ -143,6 +144,12 @@ class SignActivity : ComponentActivity(), KakaoLoginCallback {
         accessToken: String?,
         refreshToken: String?,
     ) {
+        analyticsHelper.d(
+            LogElementArgument("accessToken", accessToken.toString()),
+            LogElementArgument("refreshToken", refreshToken.toString()),
+            message = "onSuccessKakaoLogin"
+        )
+
         signInViewModel.intent(
             SignInIntent.CompleteSignKakao(
                 accessToken = accessToken ?: "",
@@ -152,6 +159,11 @@ class SignActivity : ComponentActivity(), KakaoLoginCallback {
     }
 
     override fun onFailureKakaoLogin(error: Throwable?) {
+        analyticsHelper.e(
+            throwable = error,
+            message = "onFailureKakaoLogin",
+        )
+
         signInViewModel.intent(SignInIntent.FailedSignKakao)
     }
 

--- a/feature/signIn/src/main/kotlin/com/captures2024/soongan/feature/signIn/SignInViewModel.kt
+++ b/feature/signIn/src/main/kotlin/com/captures2024/soongan/feature/signIn/SignInViewModel.kt
@@ -5,8 +5,8 @@ import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.common.base.BaseViewModel
 import com.captures2024.soongan.core.domain.usecase.fcm.InitFcmUseCase
 import com.captures2024.soongan.core.domain.usecase.members.IsAllowUserInfoUseCase
-import com.captures2024.soongan.core.domain.usecase.members.SigningGoogleUseCase
-import com.captures2024.soongan.core.domain.usecase.members.SigningKakaoUseCase
+import com.captures2024.soongan.core.domain.usecase.auth.SigningGoogleUseCase
+import com.captures2024.soongan.core.domain.usecase.auth.SigningKakaoUseCase
 import com.captures2024.soongan.feature.signIn.state.SignInIntent
 import com.captures2024.soongan.feature.signIn.state.SignInSideEffect
 import com.captures2024.soongan.feature.signIn.state.SignInUIState

--- a/feature/signIn/src/main/kotlin/com/captures2024/soongan/feature/signIn/SignInViewModel.kt
+++ b/feature/signIn/src/main/kotlin/com/captures2024/soongan/feature/signIn/SignInViewModel.kt
@@ -122,19 +122,24 @@ constructor(
     private fun kakaoSignIn(token: String) = launch {
         val result = signingKakaoUseCase(
             token = token,
-            fcmToken = currentState.fcmToken
+            fcmToken = currentState.fcmToken,
         ).getOrNull()
 
         if (result == null) {
-            analyticsHelper.d(message = "result is null")
+            analyticsHelper.d(
+                message = "result is null",
+            )
             intent(SignInIntent.FailedSignKakao)
             return@launch
         }
 
-        analyticsHelper.d(message = "result = $result")
+        analyticsHelper.d(
+            message = "result = $result",
+        )
 
         when (result) {
             true -> isAllowCheck()
+
             false -> failedSignIn()
         }
     }

--- a/feature/signIn/src/main/kotlin/com/captures2024/soongan/feature/signIn/SignInViewModel.kt
+++ b/feature/signIn/src/main/kotlin/com/captures2024/soongan/feature/signIn/SignInViewModel.kt
@@ -54,7 +54,7 @@ constructor(
 
             is SignInIntent.CompleteSignGoogle -> googleSignIn(token = intent.token)
 
-            is SignInIntent.CompleteSignKakao -> TODO()
+            is SignInIntent.CompleteSignKakao -> kakaoSignIn(token = intent.accessToken)
 
             is SignInIntent.FetchFCMToken -> fetchFcmToken(token = intent.token)
 
@@ -117,6 +117,26 @@ constructor(
             copy(isLoading = true)
         }
         postSideEffect(SignInSideEffect.KakaoSignIn)
+    }
+
+    private fun kakaoSignIn(token: String) = launch {
+        val result = signingKakaoUseCase(
+            token = token,
+            fcmToken = currentState.fcmToken
+        ).getOrNull()
+
+        if (result == null) {
+            analyticsHelper.d(message = "result is null")
+            intent(SignInIntent.FailedSignKakao)
+            return@launch
+        }
+
+        analyticsHelper.d(message = "result = $result")
+
+        when (result) {
+            true -> isAllowCheck()
+            false -> failedSignIn()
+        }
     }
 
     private fun fetchFcmToken(token: String) {


### PR DESCRIPTION
# [SG-16] 카카오 로그인
- https://captures2024.atlassian.net/browse/SG-16

## 변경 사항
- 백엔드 API 라우트 구조 변경에 따른 수정
    - auth
        - service 생성
        - datasource 생성
        - repository 생성
        - usecase 경로 수정

- 카카오 로그인 토큰 수정 및 기존 구글 로그인 성공 시나리오에 연결

## 기록
- [[SG-16] 카카오 로그인 success logic 적용](https://github.com/captures-2024/soongan-android/commit/ceb24d2fe4c6567f7826bc10c0406c381ef432c3)
- [[SG-16] 컨벤션 적용](https://github.com/captures-2024/soongan-android/commit/f98f660f82ca766e35753a934044b6c6b5802858)
- [[SG-16] 백엔드 auth api endpoint 구조 변경에 따른 라우트 수정](https://github.com/captures-2024/soongan-android/commit/4a05967564bf14ee7085d271ed9de7935d51966b)

[SG-16]: https://captures2024.atlassian.net/browse/SG-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SG-16]: https://captures2024.atlassian.net/browse/SG-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SG-16]: https://captures2024.atlassian.net/browse/SG-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SG-16]: https://captures2024.atlassian.net/browse/SG-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ