### PR TITLE
[SG-42] 신고 사유 입력 UI

### DIFF
--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/common/report/ReportBottomSheetDialog.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/common/report/ReportBottomSheetDialog.kt
@@ -1,4 +1,4 @@
-package com.captures2024.soongan.feature.home.ui.photo
+package com.captures2024.soongan.feature.home.ui.post.common.report
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -28,7 +28,7 @@ import com.captures2024.soongan.feature.home.utils.ReportType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun PostReportBottomSheetDialog(
+internal fun ReportBottomSheetDialog(
     modifier: Modifier = Modifier,
     reportState: PhotoDetailModalState.Open.ReportOpen,
     onClickReport: (ReportType) -> Unit,
@@ -72,14 +72,14 @@ internal fun PostReportBottomSheetDialog(
             },
         ) { paddingValues ->
             when (reportState.reportType) {
-                ReportType.NONE -> PostReportDefaultScreen(
+                ReportType.NONE -> ReportSelectScreen(
                     modifier = Modifier.padding(paddingValues),
                     onClickReport = onClickReport
                 )
-                ReportType.FINISH -> PostReportFinishScreen(
+                ReportType.FINISH -> ReportCompleteScreen(
                     onClickConfirm = closeSheet
                 )
-                else -> PostReportDetailScreen(
+                else -> ReportConfirmScreen(
                     modifier = Modifier.padding(paddingValues),
                     reportType = reportState.reportType,
                     onClickSubmit = { onClickReport(ReportType.FINISH) }
@@ -89,12 +89,10 @@ internal fun PostReportBottomSheetDialog(
     }
 }
 
-
-
 @DevicePreviews
 @Composable
 private fun PostReportBottomSheetDialogPreview() {
-    PostReportBottomSheetDialog(
+    ReportBottomSheetDialog(
         reportState = PhotoDetailModalState.Open.ReportOpen(),
         onClickReport = {},
         closeSheet = {}

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/common/report/ReportCompleteScreen.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/common/report/ReportCompleteScreen.kt
@@ -1,4 +1,4 @@
-package com.captures2024.soongan.feature.home.ui.photo
+package com.captures2024.soongan.feature.home.ui.post.common.report
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -29,7 +28,7 @@ import com.captures2024.soongan.core.designsystem.util.DevicePreviews
 import com.captures2024.soongan.feature.home.R
 
 @Composable
-internal fun PostReportFinishScreen(
+internal fun ReportCompleteScreen(
     modifier: Modifier = Modifier,
     onClickConfirm: () -> Unit
 ) {
@@ -88,7 +87,7 @@ internal fun PostReportFinishScreen(
 @Composable
 private fun PostReportFinishScreenPreview() {
     Box(modifier = Modifier.background(Color.White)) {
-        PostReportFinishScreen {
+        ReportCompleteScreen {
 
         }
     }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/common/report/ReportConfirmScreen.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/common/report/ReportConfirmScreen.kt
@@ -1,4 +1,4 @@
-package com.captures2024.soongan.feature.home.ui.photo
+package com.captures2024.soongan.feature.home.ui.post.common.report
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -28,7 +28,7 @@ import com.captures2024.soongan.feature.home.R
 import com.captures2024.soongan.feature.home.utils.ReportType
 
 @Composable
-internal fun PostReportDetailScreen(
+internal fun ReportConfirmScreen(
     modifier: Modifier = Modifier,
     reportType: ReportType,
     onClickSubmit: () -> Unit
@@ -94,7 +94,7 @@ internal fun PostReportDetailScreen(
 @Composable
 private fun PostReportDetailScreenPreview() {
     Box(modifier = Modifier.background(Color.White)) {
-        PostReportDetailScreen(
+        ReportConfirmScreen(
             reportType = ReportType.INAPPROPRIATE_IMAGE_OR_LANGUAGE
         ) {
 

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/common/report/ReportReasonScreen.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/common/report/ReportReasonScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.captures2024.soongan.core.designsystem.component.HeightSpacer
@@ -30,6 +29,7 @@ import com.captures2024.soongan.core.designsystem.theme.PretendardFontFamily
 import com.captures2024.soongan.core.designsystem.theme.PrimaryA
 import com.captures2024.soongan.core.designsystem.theme.PrimaryB
 import com.captures2024.soongan.core.designsystem.theme.PrimaryC
+import com.captures2024.soongan.core.designsystem.util.DevicePreviews
 import com.captures2024.soongan.feature.home.R
 
 @Composable
@@ -137,8 +137,10 @@ private fun ReportButton(
     }
 }
 
-@Preview
+@DevicePreviews
 @Composable
 private fun ReportReasonScreenPreview() {
-    ReportReasonScreen { }
+    Column {
+        ReportReasonScreen { }
+    }
 }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/common/report/ReportReasonScreen.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/common/report/ReportReasonScreen.kt
@@ -1,6 +1,8 @@
 package com.captures2024.soongan.feature.home.ui.post.common.report
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -62,7 +65,8 @@ private fun ReportReasonInput(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .background(PrimaryB, RoundedCornerShape(8.dp))
+            .background(Color.White, RoundedCornerShape(8.dp))
+            .border(BorderStroke(1.dp, PrimaryA.copy(alpha = 0.15f)), RoundedCornerShape(8.dp))
             .height(160.dp)
     ) {
         BasicTextField(
@@ -81,7 +85,7 @@ private fun ReportReasonInput(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(PrimaryB, shape = RoundedCornerShape(8.dp))
+                        .background(Color.White, shape = RoundedCornerShape(8.dp))
                 ) {
                     if (text.isEmpty()) {
                         Text(

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/common/report/ReportReasonScreen.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/common/report/ReportReasonScreen.kt
@@ -1,0 +1,144 @@
+package com.captures2024.soongan.feature.home.ui.post.common.report
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.component.NonScaleText
+import com.captures2024.soongan.core.designsystem.theme.Negative
+import com.captures2024.soongan.core.designsystem.theme.PretendardFontFamily
+import com.captures2024.soongan.core.designsystem.theme.PrimaryA
+import com.captures2024.soongan.core.designsystem.theme.PrimaryB
+import com.captures2024.soongan.core.designsystem.theme.PrimaryC
+import com.captures2024.soongan.feature.home.R
+
+@Composable
+internal fun ReportReasonScreen(
+    modifier: Modifier = Modifier,
+    onClickSubmit: (String) -> Unit
+) {
+    var reason by remember { mutableStateOf("") }
+    val isEnabled = reason.isNotEmpty()
+
+    Column(modifier = modifier) {
+        ReportReasonInput(
+            text = reason,
+            onTextChange = { reason = it }
+        )
+        HeightSpacer(48.dp)
+        ReportButton(
+            onClickSubmit = { onClickSubmit(reason) },
+            enabled = isEnabled
+        )
+    }
+}
+
+@Composable
+private fun ReportReasonInput(
+    text: String,
+    onTextChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(PrimaryB, RoundedCornerShape(8.dp))
+            .height(160.dp)
+    ) {
+        BasicTextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            value = text,
+            onValueChange = { newText ->
+                if (newText.length <= 200) onTextChange(newText)
+            },
+            textStyle = TextStyle(
+                fontSize = 16.sp,
+                color = PrimaryA
+            ),
+            decorationBox = { innerTextField ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(PrimaryB, shape = RoundedCornerShape(8.dp))
+                ) {
+                    if (text.isEmpty()) {
+                        Text(
+                            text = stringResource(R.string.report_reason_input_text),
+                            fontSize = 16.sp,
+                            color = PrimaryA.copy(alpha = 0.3f)
+                        )
+                    }
+                    innerTextField()
+                }
+            }
+        )
+
+        Text(
+            text = "${text.length}/200",
+            fontSize = 12.sp,
+            color = if (text.length < 200) PrimaryA else Negative,
+            modifier = Modifier
+                .padding(8.dp)
+                .align(Alignment.BottomEnd)
+        )
+    }
+}
+
+@Composable
+private fun ReportButton(
+    modifier: Modifier = Modifier,
+    onClickSubmit: () -> Unit,
+    enabled: Boolean
+) {
+    Box(
+        modifier = modifier
+            .height(40.dp)
+            .fillMaxWidth()
+            .background(
+                color = if (enabled) PrimaryA else PrimaryC,
+                shape = RoundedCornerShape(8.dp)
+            )
+            .clickable(enabled = enabled) {
+                onClickSubmit()
+
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        NonScaleText(
+            text = stringResource(id = R.string.report_submit_text),
+            color = PrimaryB,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium,
+            lineHeight = 20.sp,
+            fontFamily = PretendardFontFamily
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ReportReasonScreenPreview() {
+    ReportReasonScreen { }
+}

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/common/report/ReportSelectScreen.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/common/report/ReportSelectScreen.kt
@@ -1,4 +1,4 @@
-package com.captures2024.soongan.feature.home.ui.photo
+package com.captures2024.soongan.feature.home.ui.post.common.report
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -25,7 +25,7 @@ import com.captures2024.soongan.core.designsystem.util.DevicePreviews
 import com.captures2024.soongan.feature.home.utils.ReportType
 
 @Composable
-internal fun PostReportDefaultScreen(
+internal fun ReportSelectScreen(
     modifier: Modifier = Modifier,
     onClickReport: (ReportType) -> Unit,
 ) {
@@ -94,7 +94,7 @@ private fun PostReportDefaultBody(
 @Composable
 private fun PostReportScreenPreview() {
     Box(modifier = Modifier.background(Color.White)) {
-        PostReportDefaultScreen {
+        ReportSelectScreen {
 
         }
     }

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -23,10 +23,10 @@
     <string name="home_post_comment_bottom_sheet_dialog_title">댓글</string>
     <string name="home_post_comment_bottom_sheet_dialog_input_hint">댓글이 들어갈 공간입니다.</string>
 
-<!--  PostReportBottomSheetDialog  -->
+<!--  ReportBottomSheetDialog  -->
     <string name="report_title_text">신고</string>
 
-<!--  PostReportDetailScreen  -->
+<!--  ReportConfirmScreen  -->
     <string name="report_inappropriate_image_or_language_text">부적절한 사진 게시 및 언행</string>
     <string name="report_hate_speech_text">욕설, 혐오, 비하 등이 포함된 표현</string>
     <string name="report_copyright_infringement_text">도용, 초상권, 저작권 등 타인의 권리 침해</string>
@@ -38,7 +38,10 @@
     <string name="report_suffix_text">로 정말 신고하시겠습니까?</string>
     <string name="report_submit_text">신고 제출</string>
 
-<!--  PostReportFinishScreen  -->
+<!--  ReportReasonScreen  -->
+    <string name="report_reason_input_text">신고 사유를 입력해주세요</string>
+
+<!--  ReportCompleteScreen  -->
     <string name="report_finish_text">신고가 완료됐습니다.\n\n해당 게시물은 숨김처리 되었습니다.\n\n3일 이내로 검토 후 조치가 이뤄질 예정입니다.\n결과가 나오면 알림으로 알려드리겠습니다.\n감사합니다.</string>
     <string name="report_confirm_text">확인</string>
 


### PR DESCRIPTION
# [SG-42] 신고 사유 입력 UI

## 작업 사항
- 트리 구조 변경
- 입력 창 구현

## 세부 사항
```Shell
// 기존 경로
photo
├── PostReportBottomSheetDialog.kt
├── PostReportDefaultScreen.kt
├── PostReportDetailScreen.kt
└── PostReportFinishScreen.kt

// 현재 경로
.Post
├── HomePostScreen.kt
├── ...
├── comment
│   ├── HomePostCommentBottomSheetDialog.kt
│   ├── ...
└── common
    └── report // 해당 위치
        ├── ReportBottomSheetDialog.kt
        ├── ReportCompleteScreen.kt
        ├── ReportConfirmScreen.kt
        ├── ReportReasonScreen.kt
        └── ReportSelectScreen.kt
```
게시물과 댓글에 신고 기능이 적용되고 있어요.
post-common 위치에 report로 변경했어요.

## 스크린샷
<img width="380" alt="image" src="https://github.com/user-attachments/assets/aea7c8de-d418-41b7-9535-ee7858709f48">
<img width="375" alt="image" src="https://github.com/user-attachments/assets/10fec4af-8f65-46c1-9534-092a3c1246a1">

[SG-42]: https://captures2024.atlassian.net/browse/SG-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ