### PR TITLE
[SG-74] 회원가입 nickname 미설정 되는 현상

### DIFF
--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/MembersDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/MembersDataSourceImpl.kt
@@ -6,7 +6,8 @@ import com.captures2024.soongan.core.data.service.MembersService
 import com.captures2024.soongan.core.data.utils.safeAPICall
 import com.captures2024.soongan.core.model.dto.ResultConditionDto
 import com.captures2024.soongan.core.model.dto.UserInfoDto
-import com.captures2024.soongan.core.model.network.request.members.PatchProfileRequest
+import okhttp3.MediaType
+import okhttp3.RequestBody
 import javax.inject.Inject
 
 class MembersDataSourceImpl
@@ -18,14 +19,13 @@ constructor(
     override suspend fun patchProfile(
         nickname: String?,
         selfIntroduction: String?,
-        profileImage: String?
+        profileImage: String?,
     ): UserInfoDto? = safeAPICall {
         service.patchProfile(
-            request = PatchProfileRequest(
-                nickname = nickname,
-                selfIntroduction = selfIntroduction,
-                profileImage = profileImage,
-            )
+            nickname = nickname?.let { RequestBody.create(MediaType.parse("text/plain"), nickname) },
+            selfIntroduction = selfIntroduction?.let { RequestBody.create(MediaType.parse("text/plain"), selfIntroduction) },
+            profileImage = null,
+//            profileImage = MultipartBody.Part.createFormData("profileImage", imageFile.name, imageRequestBody),
         )
     }.body?.responseData?.toUserInfoDto()
 

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/MembersService.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/MembersService.kt
@@ -1,23 +1,28 @@
 package com.captures2024.soongan.core.data.service
 
-import com.captures2024.soongan.core.model.network.request.members.PatchProfileRequest
 import com.captures2024.soongan.core.model.network.response.BaseResponse
 import com.captures2024.soongan.core.model.network.response.members.GetMemberInfoResponse
 import com.captures2024.soongan.core.model.network.response.members.PatchBirthYearResponse
 import com.captures2024.soongan.core.model.network.response.members.PatchProfileResponse
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import retrofit2.Response
-import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Headers
+import retrofit2.http.Multipart
 import retrofit2.http.PATCH
+import retrofit2.http.Part
 import retrofit2.http.Query
 
 interface MembersService {
 
     @Headers("Authorization: true")
+    @Multipart
     @PATCH("members/profile")
     suspend fun patchProfile(
-        @Body request: PatchProfileRequest
+        @Part("nickname") nickname: RequestBody?,
+        @Part("selfIntroduction") selfIntroduction: RequestBody?,
+        @Part profileImage: MultipartBody.Part?,
     ): Response<BaseResponse<PatchProfileResponse>>
 
     @Headers("Authorization: true")

--- a/core/network/src/main/kotlin/com/captures2024/soongan/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/captures2024/soongan/core/network/di/NetworkModule.kt
@@ -10,6 +10,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import okhttp3.Authenticator
 import okhttp3.MediaType.Companion.toMediaType
@@ -21,11 +22,13 @@ import javax.inject.Singleton
 
 private const val MaxTimeoutMillis = 60_000L
 
+@OptIn(ExperimentalSerializationApi::class)
 private val jsonRule = Json {
     encodeDefaults = true
     ignoreUnknownKeys = true
     prettyPrint = true
     isLenient = true
+    explicitNulls = false
 }
 
 private val jsonConverterFactory = jsonRule.asConverterFactory("application/json".toMediaType())

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/intent/SignIntent.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/intent/SignIntent.kt
@@ -4,44 +4,102 @@ import com.captures2024.soongan.core.common.base.UIIntent
 
 sealed interface SignIntent : UIIntent {
 
+    /**
+     * SignUIState에 fcmToken을 fetch 해야할 때
+     *
+     * @property fcmToken fetch 할 fcm Token
+     */
     data class FetchFcmToken(
         val fcmToken: String,
     ): SignIntent
 
+    /**
+     * 사용자가 게스트 모드로 진입하려고 할 때 발생하는 인텐트
+     */
     data object OnClickGuestMode : SignIntent
 
+    /**
+     * 사용자가 구글 로그인을 시도할 때 발생하는 인텐트
+     */
     data object OnClickSignGoogle : SignIntent
 
+    /**
+     * 사용자가 카카오 로그인을 시도할 때 발생하는 인텐트
+     */
     data object OnClickSignKakao : SignIntent
 
+    /**
+     * 사용자가 이용약관을 확인하려고 할 때 발생하는 인텐트
+     */
     data object OnClickTermsOfUse : SignIntent
 
+    /**
+     * 사용자가 개인정보 보호정책을 확인하려고 할 때 발생하는 인텐트
+     */
     data object OnClickPrivacyPolicy : SignIntent
 
+    /**
+     * 사용자가 구글 로그인 과정을 취소했을 때 발생하는 인텐트
+     */
     data object CanceledSignGoogle : SignIntent
 
+    /**
+     * 사용자가 카카오 로그인 과정을 취소했을 때 발생하는 인텐트
+     */
     data object CanceledSignKakao : SignIntent
 
+    /**
+     * 구글 로그인이 성공적으로 완료되었을 때 발생하는 인텐트
+     *
+     * @property token 구글로부터 받은 인증 토큰
+     */
     data class CompleteSignGoogle(
         val token: String,
     ) : SignIntent
 
+    /**
+     * 카카오 로그인이 성공적으로 완료되었을 때 발생하는 인텐트
+     *
+     * @property accessToken 카카오로부터 받은 access 토큰
+     * @property refreshToken 토큰 갱신을 위해 카카오로부터 받은 refresh 토큰
+     */
     data class CompleteSignKakao(
         val accessToken: String,
         val refreshToken: String,
     ) : SignIntent
 
+    /**
+     * 구글 로그인 시도가 실패했을 때 발생하는 인텐트
+     */
     data object FailedSignGoogle : SignIntent
 
+    /**
+     * 카카오 로그인 시도가 실패했을 때 발생하는 인텐트
+     */
     data object FailedSignKakao : SignIntent
 
+    /**
+     * 사용자 데이터 동기화가 실패했을 때 발생하는 인텐트
+     */
     data object FailedSyncData : SignIntent
 
+    /**
+     * 사용자 데이터 동기화가 성공적으로 완료되었을 때 발생하는 인텐트
+     *
+     * @property nickname 사용자의 닉네임 (nullable)
+     * @property birthYear 사용자의 출생연도 (nullable)
+     */
     data class SuccessSyncData(
         val nickname: String?,
         val birthYear: Int?,
     ) : SignIntent
 
+    /**
+     * 사용자의 닉네임과 출생연도 입력이 모두 완료되었을 때 발생하는 인텐트
+     *
+     * @property nickname 사용자의 닉네임
+     * @property birthYear 사용자의 출생연도
+     */
     data class SuccessPathBirth(
         val nickname: String,
         val birthYear: Int,

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/NicknameViewModel.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/NicknameViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.common.base.BaseViewModel
 import com.captures2024.soongan.core.domain.usecase.members.IsVerifiedNicknameUseCase
+import com.captures2024.soongan.core.domain.usecase.members.PatchProfileNicknameUseCase
 import com.captures2024.soongan.feature.signUp.state.nickname.NicknameIntent
 import com.captures2024.soongan.feature.signUp.state.nickname.NicknameSideEffect
 import com.captures2024.soongan.feature.signUp.state.nickname.NicknameUIState
@@ -16,7 +17,7 @@ internal class NicknameViewModel
 constructor(
     private val analyticsHelper: AnalyticsHelper,
     private val isVerifiedNicknameUseCase: IsVerifiedNicknameUseCase,
-    private val patchNicknameUseCase: IsVerifiedNicknameUseCase,
+    private val patchNicknameUseCase: PatchProfileNicknameUseCase,
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel<NicknameUIState, NicknameSideEffect, NicknameIntent>(savedStateHandle) {
 


### PR DESCRIPTION
# [SG-74] 회원가입 nickname 미설정 되는 현상

## 변경 사항
- SignIntent 주석 추가
- Json Rule을 통하여 field가 null인 경우 field 제외
- nickname viewmodel에 잘못 import된 usecase 변경
- patch profile api form-data 송신으로 변경

[SG-74]: https://captures2024.atlassian.net/browse/SG-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ