### PR TITLE
[SG-80] bottom bar flicker 이슈

### DIFF
--- a/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/theme/Dimensions.kt
+++ b/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/theme/Dimensions.kt
@@ -1,0 +1,7 @@
+package com.captures2024.soongan.core.designsystem.theme
+
+import androidx.compose.ui.unit.dp
+
+object Dimensions {
+    val bottomBarHeight = 80.dp
+}

--- a/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/util/ModifierExt.kt
+++ b/core/designSystem/src/main/kotlin/com/captures2024/soongan/core/designsystem/util/ModifierExt.kt
@@ -1,0 +1,7 @@
+package com.captures2024.soongan.core.designsystem.util
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import com.captures2024.soongan.core.designsystem.theme.Dimensions
+
+fun Modifier.sgBottomBarPadding() = this.padding(bottom = Dimensions.bottomBarHeight)

--- a/feature/awards/src/main/kotlin/com/captures2024/soongan/feature/awards/route/AwardsRoute.kt
+++ b/feature/awards/src/main/kotlin/com/captures2024/soongan/feature/awards/route/AwardsRoute.kt
@@ -1,9 +1,13 @@
 package com.captures2024.soongan.feature.awards.route
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.captures2024.soongan.core.designsystem.util.sgBottomBarPadding
 import com.captures2024.soongan.feature.awards.ui.AwardsScreen
 
 @Composable
 internal fun AwardsRoute() {
-    AwardsScreen()
+    AwardsScreen(
+        modifier = Modifier.sgBottomBarPadding()
+    )
 }

--- a/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/route/FeedRoute.kt
+++ b/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/route/FeedRoute.kt
@@ -1,9 +1,13 @@
 package com.captures2024.soongan.feature.feed.route
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.captures2024.soongan.core.designsystem.util.sgBottomBarPadding
 import com.captures2024.soongan.feature.feed.ui.FeedScreen
 
 @Composable
 internal fun FeedRoute() {
-    FeedScreen()
+    FeedScreen(
+        modifier = Modifier.sgBottomBarPadding()
+    )
 }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomeRoute.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomeRoute.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.captures2024.soongan.core.design.R
+import com.captures2024.soongan.core.designsystem.util.sgBottomBarPadding
 import com.captures2024.soongan.core.model.UserPost
 import com.captures2024.soongan.feature.home.HomeViewModel
 import com.captures2024.soongan.feature.home.state.home.HomeIntent
@@ -35,7 +36,7 @@ internal fun HomeRoute(
             painter = painterResource(id = R.drawable.background_home_gallery),
             contentScale = ContentScale.Crop
         )
-        .padding(top = 100.dp)
+        .sgBottomBarPadding()
 
     LaunchedEffect(key1 = Unit) {
         homeViewModel.sideEffect.collect { effect ->
@@ -50,8 +51,8 @@ internal fun HomeRoute(
     }
 
     HomeScreen(
-        modifier = modifier,
         uiState = uiState,
+        modifier = modifier,
         onClickPlus = { homeViewModel.intent(HomeIntent.OnClickPlus) },
         onClickMyPost = { homeViewModel.intent(HomeIntent.OnClickMyPost(it)) },
         onToggleWeeklyDaily = { homeViewModel.intent(HomeIntent.OnToggleWeeklyDaily) },

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/home/HomeScreen.kt
@@ -29,8 +29,8 @@ import com.captures2024.soongan.feature.home.ui.home.component.HomePeriodToggleB
 
 @Composable
 internal fun HomeScreen(
-    modifier: Modifier = Modifier,
     uiState: HomeUIState,
+    modifier: Modifier = Modifier,
     onClickPlus: () -> Unit = {},
     onClickMyPost: (UserPost.PhotoPost) -> Unit = {},
     onToggleWeeklyDaily: () -> Unit = {},
@@ -38,7 +38,9 @@ internal fun HomeScreen(
     onClickRightArrow: () -> Unit = {},
 ) {
     Column(
-        modifier = modifier.padding(horizontal = 32.dp),
+        modifier = modifier
+            .padding(top = 88.dp, bottom = 40.dp)
+            .padding(horizontal = 32.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         HomeScreenTopBar()
@@ -57,7 +59,6 @@ internal fun HomeScreen(
         HomeScreenDeadLine(modifier = Modifier.align(Alignment.End))
         WeightSpacer(1f)
         HomeScreenFooter(
-            modifier = Modifier.padding(bottom = 40.dp),
             onClickInfo = onClickInfo,
             onClickRightArrow = onClickRightArrow
         )
@@ -91,11 +92,17 @@ private fun HomeScreenToggle(
 
 @Composable
 private fun HomeScreenDeadLine(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
-        ContestPeriodText(stringResource(id = com.captures2024.soongan.feature.home.R.string.start_date), "2024.05.10")
-        ContestPeriodText(stringResource(id = com.captures2024.soongan.feature.home.R.string.end_date), "2024.05.10")
+        ContestPeriodText(
+            stringResource(id = com.captures2024.soongan.feature.home.R.string.start_date),
+            "2024.05.10"
+        )
+        ContestPeriodText(
+            stringResource(id = com.captures2024.soongan.feature.home.R.string.end_date),
+            "2024.05.10"
+        )
     }
 }
 
@@ -108,7 +115,6 @@ private fun HomeScreenPreview() {
             painter = painterResource(id = R.drawable.background_home_gallery),
             contentScale = ContentScale.Crop,
         )
-        .padding(top = 100.dp)
 
     HomeScreen(
         modifier = modifier,
@@ -125,7 +131,6 @@ private fun HomeScreenMultiPostPreview() {
             painter = painterResource(id = R.drawable.background_home_gallery),
             contentScale = ContentScale.Crop,
         )
-        .padding(top = 100.dp)
 
     HomeScreen(
         modifier = modifier,

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/HomePostScreenBottomBar.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/HomePostScreenBottomBar.kt
@@ -24,6 +24,7 @@ import com.captures2024.soongan.core.designsystem.icon.MyIconPack
 import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconFillHeart
 import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillComment
 import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillMenu
+import com.captures2024.soongan.core.designsystem.theme.Dimensions
 import com.captures2024.soongan.core.designsystem.theme.SGColor
 import com.captures2024.soongan.core.designsystem.theme.dropShadow
 import com.captures2024.soongan.core.designsystem.util.DevicePreviews
@@ -38,7 +39,7 @@ internal fun HomePostScreenBottomBar(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .height(83.dp)
+            .height(Dimensions.bottomBarHeight)
             .dropShadow(
                 shape = RoundedCornerShape(0.dp),
                 color = SGColor.black.copy(alpha = 0.3f),

--- a/feature/main/src/main/kotlin/com/captures2024/soongan/feature/main/navigation/MainRouteNavHost.kt
+++ b/feature/main/src/main/kotlin/com/captures2024/soongan/feature/main/navigation/MainRouteNavHost.kt
@@ -1,7 +1,10 @@
 package com.captures2024.soongan.feature.main.navigation
 
-import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
@@ -45,10 +48,10 @@ internal fun MainRouteNavHost(
                 nickname = nickname,
             )
         },
-        enterTransition = { EnterTransition.None },
+        enterTransition = { fadeIn() + scaleIn(initialScale = 0.9f) },
         exitTransition = { ExitTransition.None },
-        popEnterTransition = { EnterTransition.None },
-        popExitTransition = { ExitTransition.None }
+        popEnterTransition = { fadeIn() + scaleIn(initialScale = 0.9f) },
+        popExitTransition = { fadeOut() + scaleOut(targetScale = 0.5f) }
     ) {
         welcome(
             navigateToHome = navController::navigateToHome,

--- a/feature/main/src/main/kotlin/com/captures2024/soongan/feature/main/ui/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/captures2024/soongan/feature/main/ui/MainScreen.kt
@@ -11,7 +11,6 @@ import com.captures2024.soongan.feature.main.navigation.MainRouteNavHost
 import com.captures2024.soongan.feature.main.navigation.TopLevelDestination
 import com.captures2024.soongan.feature.main.route.MainRouteState
 
-@Suppress("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 internal fun MainScreen(
     isGuestMode: Boolean,

--- a/feature/main/src/main/kotlin/com/captures2024/soongan/feature/main/ui/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/captures2024/soongan/feature/main/ui/MainScreen.kt
@@ -1,5 +1,6 @@
 package com.captures2024.soongan.feature.main.ui
 
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -10,12 +11,14 @@ import com.captures2024.soongan.feature.main.navigation.MainRouteNavHost
 import com.captures2024.soongan.feature.main.navigation.TopLevelDestination
 import com.captures2024.soongan.feature.main.route.MainRouteState
 
+@Suppress("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 internal fun MainScreen(
     isGuestMode: Boolean,
     routeState: MainRouteState,
     nickname: String,
 ) = Scaffold(
+    modifier = Modifier.navigationBarsPadding(),
     bottomBar = {
         val isNotViewBottomBar = isNotViewBottomBar(
             currentDestination = routeState.currentDestination,
@@ -31,9 +34,9 @@ internal fun MainScreen(
             )
         }
     }
-) { padding ->
+) { innerPadding ->
     MainRouteNavHost(
-        modifier = Modifier.padding(padding),
+        modifier = Modifier.padding(top = innerPadding.calculateTopPadding()),
         isGuestMode = isGuestMode,
         routeState = routeState,
         nickname = nickname,
@@ -50,14 +53,9 @@ private fun isNotViewBottomBar(
     currentDestination: NavDestination?,
     topLevelDestinations: List<TopLevelDestination>
 ): Boolean {
-    var isNotViewBottomBar = true
-//    Timber.tag("isNotViewBottomBar").d("currentDestination = $currentDestination")
-    for (topLevelDestination in topLevelDestinations) {
-        if (currentDestination.isTopLevelDestinationInHierarchy(topLevelDestination)) {
-            isNotViewBottomBar = false
-            break
-        }
-    }
+    for (topLevelDestination in topLevelDestinations)
+        if (currentDestination.isTopLevelDestinationInHierarchy(topLevelDestination))
+            return false
 
-    return isNotViewBottomBar
+    return true
 }

--- a/feature/profile/src/main/kotlin/com/captures2024/soongan/feature/profile/route/ProfileRoute.kt
+++ b/feature/profile/src/main/kotlin/com/captures2024/soongan/feature/profile/route/ProfileRoute.kt
@@ -4,8 +4,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.captures2024.soongan.core.designsystem.util.sgBottomBarPadding
 import com.captures2024.soongan.core.model.UserPost
 import com.captures2024.soongan.core.model.UserProfile
 import com.captures2024.soongan.feature.profile.ProfileViewModel
@@ -38,6 +40,7 @@ internal fun ProfileRoute(
 
     ProfileScreen(
         uiState = uiState,
+        modifier = Modifier.sgBottomBarPadding(),
         onClickNotification = { profileViewModel.intent(ProfileIntent.OnClickNotification) },
         onClickMenu = { profileViewModel.intent(ProfileIntent.OnClickMenu) },
         onClickUserPhoto = { profileViewModel.intent(ProfileIntent.OnClickPhoto(it)) }

--- a/feature/profile/src/main/kotlin/com/captures2024/soongan/feature/profile/ui/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/kotlin/com/captures2024/soongan/feature/profile/ui/profile/ProfileScreen.kt
@@ -25,10 +25,11 @@ internal fun ProfileScreen(
         modifier = modifier
             .fillMaxSize()
             .background(color = Color.White)
-            .padding(top = 52.dp)
+            .padding(top = 26.dp)
     ) {
         ProfileScreenHeader(
             userProfile = uiState.userProfile,
+            modifier = Modifier.padding(start = 20.dp, end = 16.dp),
             onClickNotification = onClickNotification,
             onClickMenu = onClickMenu
         )

--- a/feature/profile/src/main/kotlin/com/captures2024/soongan/feature/profile/ui/profile/ProfileScreenHeader.kt
+++ b/feature/profile/src/main/kotlin/com/captures2024/soongan/feature/profile/ui/profile/ProfileScreenHeader.kt
@@ -5,11 +5,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Badge
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -40,9 +42,11 @@ internal fun ProfileScreenHeader(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(start = 20.dp, end = 16.dp)
     ) {
-        ProfileCard(userProfile = userProfile)
+        ProfileCard(
+            userProfile = userProfile,
+            modifier = Modifier.padding(top = 8.dp)
+        )
         WeightSpacer(1f)
         IconBox(
             onClickNotification = onClickNotification,
@@ -53,8 +57,8 @@ internal fun ProfileScreenHeader(
 
 @Composable
 private fun ProfileCard(
-    modifier: Modifier = Modifier,
     userProfile: UserProfile,
+    modifier: Modifier = Modifier,
 ) {
     Row(modifier = modifier) {
         AsyncImage(
@@ -71,7 +75,7 @@ private fun ProfileCard(
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Medium,
                 fontFamily = PoppinsFontFamily,
-                letterSpacing = 0.sp,
+                letterSpacing = (-0.5).sp,
                 lineHeight = 20.sp
             )
             HeightSpacer(8.dp)
@@ -80,8 +84,8 @@ private fun ProfileCard(
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Normal,
                 fontFamily = NanumSquareNeoFontFamily,
-                letterSpacing = 0.sp,
-                lineHeight = 16.sp
+                letterSpacing = (-0.5).sp,
+                lineHeight = 12.sp
             )
         }
     }
@@ -95,11 +99,15 @@ private fun IconBox(
 ) {
     Row(modifier = modifier) {
         Box(
-            modifier = Modifier.clickable {
-                onClickNotification()
-            }
+            modifier = Modifier
+                .size(40.dp)
+                .clickable { onClickNotification() },
+            contentAlignment = Alignment.Center
         ) {
             Badge(
+                modifier = Modifier
+                    .size(8.dp)
+                    .offset(x = (-6).dp, y = (-6).dp),
                 containerColor = Color(0xffFBC304)
             )
             Icon(
@@ -107,11 +115,12 @@ private fun IconBox(
                 contentDescription = "notification icon"
             )
         }
-        WidthSpacer(16.dp)
+        WidthSpacer(8.dp)
         Box(
-            modifier = Modifier.clickable {
-                onClickMenu()
-            }
+            modifier = Modifier
+                .size(40.dp)
+                .clickable { onClickMenu() },
+            contentAlignment = Alignment.Center
         ) {
             Icon(
                 imageVector = MyIconPack.IconNonFillMenu,
@@ -125,9 +134,9 @@ private fun IconBox(
 @DevicePreviews
 @Composable
 private fun ProfileScreenHeaderPreview() {
-        ProfileScreenHeader(
-            userProfile = UserProfile(),
-            onClickNotification = {},
-            onClickMenu = {}
-        )
+    ProfileScreenHeader(
+        userProfile = UserProfile(),
+        onClickNotification = {},
+        onClickMenu = {}
+    )
 }


### PR DESCRIPTION
# [SG-80] bottomBar flicker 이슈
- scaffold 내 bottomBar padding 값으로 인해 부드럽지 못한 화면 전환이 일어남

## 작업 사항
- bottomBar를 지니는 화면 별 padding 값 조정
- ProfileCard 디자인 일부 수정

## GIF
|Before|After|
|--|--|
|![flicker_before](https://github.com/user-attachments/assets/37a5d092-7c42-4488-a4cd-566f5f968068)|![flicker_after](https://github.com/user-attachments/assets/3633f35e-dac3-4370-8659-8267e9efce46)|


## 추가
수정해보면서 slide 애니메이션 등을 도입하여 더 자연스러운 전환을 시도해봤으나
scaffold 내에서 bottomBar가 있는 한 먼저 사라지거나 나타나서
해결을 위한 bottomBar 상태 관리가 복잡해질 것 같아 padding 부분만 건드려보았어요.

[SG-80]: https://captures2024.atlassian.net/browse/SG-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ