### PR TITLE
[SG-82] 사진 게시글 등록 API 연결

### DIFF
--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/RemoteDataSourceModule.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/RemoteDataSourceModule.kt
@@ -4,10 +4,12 @@ import com.captures2024.soongan.core.data.remote.AuthDataSource
 import com.captures2024.soongan.core.data.remote.FcmDataSource
 import com.captures2024.soongan.core.data.remote.HomeDataSource
 import com.captures2024.soongan.core.data.remote.MembersDataSource
+import com.captures2024.soongan.core.data.remote.WeeklyContestDataSource
 import com.captures2024.soongan.core.data.remote.impl.AuthDataSourceImpl
 import com.captures2024.soongan.core.data.remote.impl.FcmDataSourceImpl
 import com.captures2024.soongan.core.data.remote.impl.HomeDataSourceImpl
 import com.captures2024.soongan.core.data.remote.impl.MembersDataSourceImpl
+import com.captures2024.soongan.core.data.remote.impl.WeeklyContestDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -33,4 +35,8 @@ abstract class RemoteDataSourceModule {
     @Binds
     @Singleton
     abstract fun bindHomeDataSource(homeDataSourceImpl: HomeDataSourceImpl): HomeDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindWeeklyContestDataSource(weeklyContestDataSourceImpl: WeeklyContestDataSourceImpl): WeeklyContestDataSource
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/RepositoryModule.kt
@@ -5,11 +5,13 @@ import com.captures2024.soongan.core.data.repository.FcmRepository
 import com.captures2024.soongan.core.data.repository.HomeRepository
 import com.captures2024.soongan.core.data.repository.MembersRepository
 import com.captures2024.soongan.core.data.repository.TokenRepository
+import com.captures2024.soongan.core.data.repository.WeeklyContestRepository
 import com.captures2024.soongan.core.data.repository.impl.AuthRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.FcmRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.HomeRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.MembersRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.TokenRepositoryImpl
+import com.captures2024.soongan.core.data.repository.impl.WeeklyContestRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -39,4 +41,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindHomeRepository(homeRepositoryImpl: HomeRepositoryImpl): HomeRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindWeeklyContestRepository(weeklyContestRepositoryImpl: WeeklyContestRepositoryImpl): WeeklyContestRepository
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/ServiceModule.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/ServiceModule.kt
@@ -4,6 +4,7 @@ import com.captures2024.soongan.core.data.service.AuthService
 import com.captures2024.soongan.core.data.service.FcmService
 import com.captures2024.soongan.core.data.service.HomeService
 import com.captures2024.soongan.core.data.service.MembersService
+import com.captures2024.soongan.core.data.service.WeeklyContestService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -30,4 +31,8 @@ object ServiceModule {
     @Singleton
     @Provides
     internal fun provideHomeService(retrofit: Retrofit): HomeService = retrofit.create(HomeService::class.java)
+
+    @Singleton
+    @Provides
+    internal fun provideWeeklyContestService(retrofit: Retrofit): WeeklyContestService = retrofit.create(WeeklyContestService::class.java)
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/WeeklyContestMapper.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/WeeklyContestMapper.kt
@@ -1,0 +1,11 @@
+package com.captures2024.soongan.core.data.mapper
+
+import com.captures2024.soongan.core.model.dto.PostInfoDto
+import com.captures2024.soongan.core.model.network.response.weekly.contests.RegisterPostResponse
+
+fun RegisterPostResponse.toPostInfoDto(): PostInfoDto = PostInfoDto(
+    postId = this.postId,
+    subject = this.subject,
+    imageUrl = this.imageUrl,
+    registerNickname = this.registerNickname,
+)

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/WeeklyContestDataSource.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/WeeklyContestDataSource.kt
@@ -1,0 +1,12 @@
+package com.captures2024.soongan.core.data.remote
+
+import com.captures2024.soongan.core.model.dto.PostInfoDto
+
+interface WeeklyContestDataSource {
+
+    suspend fun registerPost(
+        weeklyContestRound: Int,
+        subject: String,
+        imageFile: String,
+    ): PostInfoDto?
+}

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/WeeklyContestDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/WeeklyContestDataSourceImpl.kt
@@ -1,0 +1,32 @@
+package com.captures2024.soongan.core.data.remote.impl
+
+import android.content.Context
+import com.captures2024.soongan.core.data.mapper.toPostInfoDto
+import com.captures2024.soongan.core.data.remote.WeeklyContestDataSource
+import com.captures2024.soongan.core.data.service.WeeklyContestService
+import com.captures2024.soongan.core.data.utils.safeAPICall
+import com.captures2024.soongan.core.data.utils.toImageMultiPart
+import com.captures2024.soongan.core.data.utils.toTextRequestBody
+import com.captures2024.soongan.core.model.dto.PostInfoDto
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class WeeklyContestDataSourceImpl
+@Inject
+constructor(
+    @ApplicationContext private val context: Context,
+    private val service: WeeklyContestService,
+) : WeeklyContestDataSource {
+
+    override suspend fun registerPost(
+        weeklyContestRound: Int,
+        subject: String,
+        imageFile: String
+    ): PostInfoDto? = safeAPICall {
+        service.registerPost(
+            weeklyContestRound = weeklyContestRound.toString().toTextRequestBody(),
+            subject = subject.toTextRequestBody(),
+            imageFile = imageFile.toImageMultiPart(context, "imageFile"),
+        )
+    }.body?.responseData?.toPostInfoDto()
+}

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/WeeklyContestRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/WeeklyContestRepository.kt
@@ -1,0 +1,12 @@
+package com.captures2024.soongan.core.data.repository
+
+import com.captures2024.soongan.core.model.dto.PostInfoDto
+
+interface WeeklyContestRepository {
+
+    suspend fun registerPost(
+        weeklyContestRound: Int,
+        subject: String,
+        imageFile: String
+    ): PostInfoDto
+}

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/WeeklyContestRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/WeeklyContestRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.captures2024.soongan.core.data.repository.impl
+
+import com.captures2024.soongan.core.data.remote.WeeklyContestDataSource
+import com.captures2024.soongan.core.data.repository.WeeklyContestRepository
+import com.captures2024.soongan.core.model.dto.PostInfoDto
+import javax.inject.Inject
+
+class WeeklyContestRepositoryImpl
+@Inject
+constructor(
+    private val weeklyContestDataSource: WeeklyContestDataSource
+) : WeeklyContestRepository {
+
+    override suspend fun registerPost(
+        weeklyContestRound: Int,
+        subject: String,
+        imageFile: String
+    ): PostInfoDto {
+        val postInfoDto = weeklyContestDataSource.registerPost(
+            weeklyContestRound = weeklyContestRound,
+            subject = subject,
+            imageFile = imageFile,
+        )
+
+        return postInfoDto ?: throw NullPointerException("postInfoDto is null")
+    }
+}

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/WeeklyContestService.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/WeeklyContestService.kt
@@ -1,0 +1,23 @@
+package com.captures2024.soongan.core.data.service
+
+import com.captures2024.soongan.core.model.network.response.BaseResponse
+import com.captures2024.soongan.core.model.network.response.weekly.contests.RegisterPostResponse
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import retrofit2.Response
+import retrofit2.http.Headers
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+
+interface WeeklyContestService {
+
+    @Headers("Authorization: true")
+    @Multipart
+    @POST("weekly/contests/posts")
+    suspend fun registerPost(
+        @Part("weeklyContestRound") weeklyContestRound: RequestBody?,
+        @Part("subject") subject: RequestBody?,
+        @Part imageFile: MultipartBody.Part?,
+    ): Response<BaseResponse<RegisterPostResponse>>
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/weekly/contests/RegisterPostUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/weekly/contests/RegisterPostUseCase.kt
@@ -1,0 +1,29 @@
+package com.captures2024.soongan.core.domain.usecase.weekly.contests
+
+import com.captures2024.soongan.core.data.repository.WeeklyContestRepository
+import com.captures2024.soongan.core.domain.runSuspendCatching
+import javax.inject.Inject
+
+class RegisterPostUseCase
+@Inject
+constructor(
+    private val weeklyContestRepository: WeeklyContestRepository
+) {
+
+    suspend operator fun invoke(params: Params): Result<Boolean> = runSuspendCatching {
+        val result = weeklyContestRepository.registerPost(
+            weeklyContestRound = params.weeklyContestRound,
+            subject = params.subject,
+            imageFile = params.imageFile,
+        )
+
+        return@runSuspendCatching result.subject == params.subject
+    }
+
+
+    data class Params(
+        val weeklyContestRound: Int,
+        val subject: String,
+        val imageFile: String,
+    )
+}

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/PostInfoDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/PostInfoDto.kt
@@ -2,7 +2,9 @@ package com.captures2024.soongan.core.model.dto
 
 data class PostInfoDto(
     val postId: Int = -1,
+    val subject: String = "",
     val imageUrl: String = "",
+    val registerNickname: String = "",
     val likeCount: Int = 0,
     val commentCount: Int = 0,
 )

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/weekly/contests/RegisterPostResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/weekly/contests/RegisterPostResponse.kt
@@ -1,0 +1,16 @@
+package com.captures2024.soongan.core.model.network.response.weekly.contests
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterPostResponse(
+    @SerialName("postId")
+    val postId: Int,
+    @SerialName("subject")
+    val subject: String,
+    @SerialName("imageUrl")
+    val imageUrl: String,
+    @SerialName("registerNickname")
+    val registerNickname: String,
+)

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/RegistrationPostViewModel.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/RegistrationPostViewModel.kt
@@ -3,6 +3,7 @@ package com.captures2024.soongan.feature.home
 import androidx.lifecycle.SavedStateHandle
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.common.base.BaseViewModel
+import com.captures2024.soongan.core.domain.usecase.weekly.contests.RegisterPostUseCase
 import com.captures2024.soongan.feature.home.state.registration_post.RegistrationPostIntent
 import com.captures2024.soongan.feature.home.state.registration_post.RegistrationPostSideEffect
 import com.captures2024.soongan.feature.home.state.registration_post.RegistrationPostUIState
@@ -14,6 +15,7 @@ internal class RegistrationPostViewModel
 @Inject
 constructor(
     private val analyticsHelper: AnalyticsHelper,
+    private val registerPostUseCase: RegisterPostUseCase,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<RegistrationPostUIState, RegistrationPostSideEffect, RegistrationPostIntent>(savedStateHandle) {
 
@@ -108,7 +110,7 @@ constructor(
         }
     }
 
-    private fun handleOnClickSubmitRemote(intent: RegistrationPostIntent.OnClickSubmitRemote) {
+    private suspend fun handleOnClickSubmitRemote(intent: RegistrationPostIntent.OnClickSubmitRemote) {
         analyticsHelper.d(message = "handleOnClickSubmitRemote - intent: $intent")
 
         val submitData = currentState
@@ -123,6 +125,18 @@ constructor(
             return
         }
 
-        TODO("Submit Remote")
+        val result = registerPostUseCase(
+            params = RegisterPostUseCase.Params(
+                weeklyContestRound = 1,
+                subject = submitData.title,
+                imageFile = submitData.currentMedia.toString(),
+            )
+        ).getOrNull() ?: TODO("fail case")
+
+        when (result) {
+            true -> postSideEffect(RegistrationPostSideEffect.NavigateToPost)
+
+            false -> TODO("fail case")
+        }
     }
 }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomeRoute.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomeRoute.kt
@@ -2,6 +2,7 @@ package com.captures2024.soongan.feature.home.route
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -9,6 +10,9 @@ import androidx.compose.ui.draw.paint
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.captures2024.soongan.core.design.R
 import com.captures2024.soongan.core.designsystem.util.sgBottomBarPadding
@@ -48,6 +52,24 @@ internal fun HomeRoute(
 
                 is HomeSideEffect.NavigateToHomeGallery -> navigateToGallery()
             }
+        }
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> homeViewModel.intent(HomeIntent.Init)
+
+                else -> Unit
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
 

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomeRoute.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomeRoute.kt
@@ -2,7 +2,6 @@ package com.captures2024.soongan.feature.home.route
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -11,12 +10,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.captures2024.soongan.core.design.R
 import com.captures2024.soongan.core.designsystem.util.sgBottomBarPadding
-import com.captures2024.soongan.core.model.UserPost
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import com.captures2024.soongan.feature.home.HomeViewModel
 import com.captures2024.soongan.feature.home.state.home.HomeIntent
@@ -55,22 +52,8 @@ internal fun HomeRoute(
         }
     }
 
-    val lifecycleOwner = LocalLifecycleOwner.current
-
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            when (event) {
-                Lifecycle.Event.ON_RESUME -> homeViewModel.intent(HomeIntent.Init)
-
-                else -> Unit
-            }
-        }
-
-        lifecycleOwner.lifecycle.addObserver(observer)
-
-        onDispose {
-            lifecycleOwner.lifecycle.removeObserver(observer)
-        }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        homeViewModel.intent(HomeIntent.Init)
     }
 
     HomeScreen(

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/registration_post/RegistrationPostScreen.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/registration_post/RegistrationPostScreen.kt
@@ -5,13 +5,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.paint
@@ -25,7 +25,6 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.captures2024.soongan.core.designsystem.component.HeightSpacer
 import com.captures2024.soongan.core.designsystem.component.NonScaleText
-import com.captures2024.soongan.core.designsystem.component.shimmerBrush
 import com.captures2024.soongan.core.designsystem.theme.NanumSquareNeoFontFamily
 import com.captures2024.soongan.core.designsystem.theme.SGColor
 import com.captures2024.soongan.core.designsystem.theme.dropShadow
@@ -41,8 +40,6 @@ internal fun RegistrationPostScreen(
     onTitleValueChanged: (String) -> Unit = {},
     onClickSubmit: () -> Unit = {},
 ) {
-    val showShimmer = remember { mutableStateOf(true) }
-
     Scaffold(
         modifier = modifier.fillMaxSize()
             .background(color = SGColor.tempPrimaryD)
@@ -77,14 +74,8 @@ internal fun RegistrationPostScreen(
                         .build(),
                     contentDescription = "photo",
                     modifier = modifier
-                        .background(
-                            shimmerBrush(
-                                targetValue = 1300f,
-                                showShimmer = showShimmer.value
-                            )
-                        )
-                        .width(353.dp)
-                        .height(353.dp)
+                        .widthIn(max = 353.dp)
+                        .heightIn(max = 353.dp)
                         .dropShadow(
                             shape = RoundedCornerShape(0.dp),
                             color = SGColor.black.copy(alpha = 0.25f),
@@ -92,7 +83,7 @@ internal fun RegistrationPostScreen(
                             offsetX = 6.dp,
                             offsetY = 6.dp,
                         ),
-                    contentScale = ContentScale.FillWidth,
+                    contentScale = ContentScale.Fit,
                 )
             }
             HeightSpacer(36.dp)

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/registration_post/RegistrationPostScreenTopBar.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/registration_post/RegistrationPostScreenTopBar.kt
@@ -50,6 +50,7 @@ internal fun RegistrationPostScreenTopBar(
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center,
             fontFamily = NanumSquareNeoFontFamily,
+            color = SGColor.primaryA,
         )
     }
 }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/registration_post/TilteInpuEditText.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/registration_post/TilteInpuEditText.kt
@@ -10,12 +10,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -33,6 +37,8 @@ internal fun TitleInputEditText(
     value: String,
     onValueChange: (String) -> Unit,
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
     Column(horizontalAlignment = Alignment.End) {
         BasicTextField(
             value = value,
@@ -77,7 +83,13 @@ internal fun TitleInputEditText(
                         )
                     }
                 }
-            }
+            },
+            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    keyboardController?.hide()
+                }
+            )
         )
         HeightSpacer(8.dp)
         Row(

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/registration_post/TilteInpuEditText.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/registration_post/TilteInpuEditText.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -37,7 +37,7 @@ internal fun TitleInputEditText(
     value: String,
     onValueChange: (String) -> Unit,
 ) {
-    val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
 
     Column(horizontalAlignment = Alignment.End) {
         BasicTextField(
@@ -87,7 +87,7 @@ internal fun TitleInputEditText(
             keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
             keyboardActions = KeyboardActions(
                 onDone = {
-                    keyboardController?.hide()
+                    focusManager.clearFocus()
                 }
             )
         )


### PR DESCRIPTION
# [SG-82] 사진 게시글 등록 API 연결

## 작업 사항
- weekly contests post 하는 api 연결
- profile 변경 시나리오와 같게 multipart로 구현
- 실패 케이스와 등록 성공 이후 다음 이동 시나리오는 게시글 조회 화면 작업 이후 연동하는 것으로 예상

## 세부 사항
- weekly contest 관련 service, datasource, repository, usecase 구현
- post info dto param 추가

## 비고
- 현재 API 요청시 email로 member를 찾을 수 없는 API 관련 현상이 발생하여 문의한 상태

[SG-82]: https://captures2024.atlassian.net/browse/SG-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ