### PR TITLE
[SG-85] 갤러리 게시글 조회

### DIFF
--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/WeeklyContestMapper.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/WeeklyContestMapper.kt
@@ -1,7 +1,25 @@
 package com.captures2024.soongan.core.data.mapper
 
+import com.captures2024.soongan.core.model.dto.GalleryDto
+import com.captures2024.soongan.core.model.dto.GalleryPostDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
+import com.captures2024.soongan.core.model.network.response.weekly.contests.GetGalleryResponse
+import com.captures2024.soongan.core.model.network.response.weekly.contests.GetGalleryPostInfoResponse
 import com.captures2024.soongan.core.model.network.response.weekly.contests.RegisterPostResponse
+
+fun GetGalleryResponse.toGalleryDto(): GalleryDto = GalleryDto(
+    round = this.round,
+    subject = this.subject,
+    posts = this.posts.map { it.toGalleryPostDto() },
+    hasNext = this.pageInfo.hasNext
+)
+
+fun GetGalleryPostInfoResponse.toGalleryPostDto(): GalleryPostDto = GalleryPostDto(
+    nickname = this.nickname,
+    profileImageUrl = this.profileImageUrl,
+    postId = this.postId,
+    imageUrl = this.imageUrl
+)
 
 fun RegisterPostResponse.toPostInfoDto(): PostInfoDto = PostInfoDto(
     postId = this.postId,

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/WeeklyContestDataSource.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/WeeklyContestDataSource.kt
@@ -1,8 +1,16 @@
 package com.captures2024.soongan.core.data.remote
 
+import com.captures2024.soongan.core.model.dto.GalleryDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 
 interface WeeklyContestDataSource {
+
+    suspend fun getGalleryInfo(
+        round: Int?,
+        orderType: String,
+        page: Int,
+        pageSize: Int,
+    ): GalleryDto?
 
     suspend fun registerPost(
         weeklyContestRound: Int,

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/WeeklyContestDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/WeeklyContestDataSourceImpl.kt
@@ -1,12 +1,14 @@
 package com.captures2024.soongan.core.data.remote.impl
 
 import android.content.Context
+import com.captures2024.soongan.core.data.mapper.toGalleryDto
 import com.captures2024.soongan.core.data.mapper.toPostInfoDto
 import com.captures2024.soongan.core.data.remote.WeeklyContestDataSource
 import com.captures2024.soongan.core.data.service.WeeklyContestService
 import com.captures2024.soongan.core.data.utils.safeAPICall
 import com.captures2024.soongan.core.data.utils.toImageMultiPart
 import com.captures2024.soongan.core.data.utils.toTextRequestBody
+import com.captures2024.soongan.core.model.dto.GalleryDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -17,6 +19,19 @@ constructor(
     @ApplicationContext private val context: Context,
     private val service: WeeklyContestService,
 ) : WeeklyContestDataSource {
+    override suspend fun getGalleryInfo(
+        round: Int?,
+        orderType: String,
+        page: Int,
+        pageSize: Int,
+    ): GalleryDto? = safeAPICall {
+        service.getGalleryInfo(
+            round = round,
+            orderType = orderType,
+            page = page,
+            pageSize = pageSize
+        )
+    }.body?.responseData?.toGalleryDto()
 
     override suspend fun registerPost(
         weeklyContestRound: Int,

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/WeeklyContestRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/WeeklyContestRepository.kt
@@ -1,8 +1,16 @@
 package com.captures2024.soongan.core.data.repository
 
+import com.captures2024.soongan.core.model.dto.GalleryDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 
 interface WeeklyContestRepository {
+
+    suspend fun getGalleryInfo(
+        round: Int?,
+        orderType: String,
+        page: Int,
+        pageSize: Int,
+    ): GalleryDto
 
     suspend fun registerPost(
         weeklyContestRound: Int,

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/WeeklyContestRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/WeeklyContestRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.captures2024.soongan.core.data.repository.impl
 
 import com.captures2024.soongan.core.data.remote.WeeklyContestDataSource
 import com.captures2024.soongan.core.data.repository.WeeklyContestRepository
+import com.captures2024.soongan.core.model.dto.GalleryDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import javax.inject.Inject
 
@@ -10,6 +11,22 @@ class WeeklyContestRepositoryImpl
 constructor(
     private val weeklyContestDataSource: WeeklyContestDataSource
 ) : WeeklyContestRepository {
+
+    override suspend fun getGalleryInfo(
+        round: Int?,
+        orderType: String,
+        page: Int,
+        pageSize: Int,
+    ): GalleryDto {
+        val galleryInfo = weeklyContestDataSource.getGalleryInfo(
+            round = round,
+            orderType = orderType,
+            page = page,
+            pageSize = pageSize
+        )
+
+        return galleryInfo ?: throw java.lang.NullPointerException("galleryDto is null")
+    }
 
     override suspend fun registerPost(
         weeklyContestRound: Int,

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/WeeklyContestService.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/WeeklyContestService.kt
@@ -1,16 +1,28 @@
 package com.captures2024.soongan.core.data.service
 
 import com.captures2024.soongan.core.model.network.response.BaseResponse
+import com.captures2024.soongan.core.model.network.response.weekly.contests.GetGalleryResponse
 import com.captures2024.soongan.core.model.network.response.weekly.contests.RegisterPostResponse
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.Response
+import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
+import retrofit2.http.Query
 
 interface WeeklyContestService {
+
+    @Headers("Authorization: true")
+    @GET("weekly/contests/posts")
+    suspend fun getGalleryInfo(
+        @Query("round") round: Int?,
+        @Query("orderCriteria") orderType: String,
+        @Query("page") page: Int,
+        @Query("pageSize") pageSize: Int,
+    ): Response<BaseResponse<GetGalleryResponse>>
 
     @Headers("Authorization: true")
     @Multipart

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/weekly/contests/GetGalleryUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/weekly/contests/GetGalleryUseCase.kt
@@ -1,0 +1,32 @@
+package com.captures2024.soongan.core.domain.usecase.weekly.contests
+
+import com.captures2024.soongan.core.data.repository.WeeklyContestRepository
+import com.captures2024.soongan.core.domain.runSuspendCatching
+import com.captures2024.soongan.core.model.dto.GalleryDto
+import javax.inject.Inject
+
+class GetGalleryUseCase
+@Inject
+constructor(
+    private val weeklyContestRepository: WeeklyContestRepository
+) {
+
+    suspend operator fun invoke(params: Params): Result<GalleryDto> = runSuspendCatching {
+        val galleryDto = weeklyContestRepository.getGalleryInfo(
+            round = params.round,
+            orderType = params.orderType,
+            page = params.page,
+            pageSize = params.pageSize
+        )
+
+        return@runSuspendCatching galleryDto
+    }
+
+
+    data class Params(
+        val round: Int?,
+        val orderType: String,
+        val page: Int,
+        val pageSize: Int,
+    )
+}

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/GalleryDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/GalleryDto.kt
@@ -1,0 +1,15 @@
+package com.captures2024.soongan.core.model.dto
+
+data class GalleryDto(
+    val round: Int? = null,
+    val subject: String = "",
+    val posts: List<GalleryPostDto> = emptyList(),
+    val hasNext: Boolean = false,
+)
+
+data class GalleryPostDto(
+    val nickname: String = "",
+    val profileImageUrl: String = "",
+    val postId: Int = -1,
+    val imageUrl: String = "",
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/weekly/contests/GetGalleryPageInfoResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/weekly/contests/GetGalleryPageInfoResponse.kt
@@ -1,0 +1,14 @@
+package com.captures2024.soongan.core.model.network.response.weekly.contests
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetGalleryPageInfoResponse(
+    @SerialName("page")
+    val page: Int,
+    @SerialName("size")
+    val size: Int,
+    @SerialName("hasNext")
+    val hasNext: Boolean,
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/weekly/contests/GetGalleryPostInfoResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/weekly/contests/GetGalleryPostInfoResponse.kt
@@ -1,0 +1,16 @@
+package com.captures2024.soongan.core.model.network.response.weekly.contests
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetGalleryPostInfoResponse(
+    @SerialName("nickname")
+    val nickname: String,
+    @SerialName("profileImageUrl")
+    val profileImageUrl: String,
+    @SerialName("postId")
+    val postId: Int,
+    @SerialName("imageUrl")
+    val imageUrl: String,
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/weekly/contests/GetGalleryResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/weekly/contests/GetGalleryResponse.kt
@@ -1,0 +1,16 @@
+package com.captures2024.soongan.core.model.network.response.weekly.contests
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetGalleryResponse(
+    @SerialName("round")
+    val round: Int?,
+    @SerialName("subject")
+    val subject: String,
+    @SerialName("posts")
+    val posts: List<GetGalleryPostInfoResponse>,
+    @SerialName("pageInfo")
+    val pageInfo: GetGalleryPageInfoResponse,
+)

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/HomeGalleryViewModel.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/HomeGalleryViewModel.kt
@@ -10,6 +10,7 @@ import com.captures2024.soongan.feature.home.state.home_gallery.HomeGallerySideE
 import com.captures2024.soongan.feature.home.state.home_gallery.HomeGalleryUIState
 import com.captures2024.soongan.feature.home.utils.PaginationStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import javax.inject.Inject
 
 @HiltViewModel
@@ -76,7 +77,11 @@ constructor(
             )
         ) return@launch
 
-        setUpLoading(isInitPage = (page == 0), isRefreshing = isRefreshing)
+        val isInitPage = (page == 0)
+
+        setUpLoading(isInitPage = isInitPage, isRefreshing = isRefreshing)
+
+        delay(2_000)
 
         getGalleryUseCase(
             params = GetGalleryUseCase.Params(
@@ -104,7 +109,6 @@ constructor(
                 copy(
                     isRefreshing = false,
                     paginationStatus = PaginationStatus.ERROR
-
                 )
             }
         }
@@ -112,6 +116,7 @@ constructor(
         analyticsHelper.d(
             logVariable = arrayOf(
                 LogElementArgument("pagingStatus", "${currentState.paginationStatus}"),
+                LogElementArgument("posts", "${currentState.posts}"),
                 LogElementArgument("page", "${currentState.nextPage}"),
                 LogElementArgument("haspage", "${currentState.hasNextPage}"),
             ),
@@ -150,17 +155,9 @@ constructor(
 //        postSideEffect(HomeGallerySideEffect.NavigateToHomePost(intent.post))
     }
 
-    private fun initMockUpPost() {
-        reduce {
-            copy(
-//                galleryInfo = samplePhotos
-            )
-        }
-    }
-
     companion object {
         private const val TAG = "HomeGalleryVM"
 
-        private const val PAGE_SIZE = 10
+        private const val PAGE_SIZE = 20
     }
 }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/HomeGalleryViewModel.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/HomeGalleryViewModel.kt
@@ -1,13 +1,14 @@
 package com.captures2024.soongan.feature.home
 
 import androidx.lifecycle.SavedStateHandle
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.analytics.utils.LogElementArgument
 import com.captures2024.soongan.core.common.base.BaseViewModel
-import com.captures2024.soongan.core.model.UserPost
-import com.captures2024.soongan.core.model.mock.samplePhotos
+import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetGalleryUseCase
 import com.captures2024.soongan.feature.home.state.home_gallery.HomeGalleryIntent
 import com.captures2024.soongan.feature.home.state.home_gallery.HomeGallerySideEffect
 import com.captures2024.soongan.feature.home.state.home_gallery.HomeGalleryUIState
-import com.captures2024.soongan.feature.home.utils.GalleryPhotoSortFilter
+import com.captures2024.soongan.feature.home.utils.PaginationStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -15,10 +16,13 @@ import javax.inject.Inject
 internal class HomeGalleryViewModel
 @Inject
 constructor(
-    savedStateHandle: SavedStateHandle
+    private val analyticsHelper: AnalyticsHelper,
+    private val getGalleryUseCase: GetGalleryUseCase,
+    savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<HomeGalleryUIState, HomeGallerySideEffect, HomeGalleryIntent>(savedStateHandle) {
+
     init {
-        initMockUpPost()
+        intent(HomeGalleryIntent.Init)
     }
 
     override fun createInitialState(savedStateHandle: SavedStateHandle): HomeGalleryUIState {
@@ -26,19 +30,93 @@ constructor(
     }
 
     override fun handleClientException(throwable: Throwable) {
-        TODO("Not yet implemented")
+        analyticsHelper.e(throwable = throwable)
     }
 
     override suspend fun handleIntent(intent: HomeGalleryIntent) {
         when (intent) {
+            is HomeGalleryIntent.Init -> fetchPostPage(page = 0)
+
+            is HomeGalleryIntent.RefreshGallery -> fetchPostPage(page = 0, isRefreshing = true)
+
+            is HomeGalleryIntent.LoadNextPage -> fetchPostPage(page = currentState.nextPage)
+
             is HomeGalleryIntent.OnBottomModalDismissRequest -> onBottomModalDismissRequest()
 
             is HomeGalleryIntent.OnClickFilter -> onClickFilter()
 
-            is HomeGalleryIntent.OnClickPost -> onClickPost(intent.post)
+            is HomeGalleryIntent.OnClickPost -> onClickPost(intent)
 
-            is HomeGalleryIntent.OnClickSortFilter -> onClickSortFilter(intent.selectedSortFilter)
+            is HomeGalleryIntent.OnClickSortFilter -> onClickSortFilter(intent)
         }
+    }
+
+    private fun setUpLoading(isInitPage: Boolean, isRefreshing: Boolean) {
+        if (isInitPage) {
+            reduce {
+                copy(
+                    isRefreshing = isRefreshing,
+                    paginationStatus = PaginationStatus.LOADING,
+                    posts = emptyList()
+                )
+            }
+        } else {
+            reduce {
+                copy(
+                    paginationStatus = PaginationStatus.PAGINATING,
+                )
+            }
+        }
+    }
+
+    private suspend fun fetchPostPage(page: Int = 0, isRefreshing: Boolean = false) = launch {
+        if (currentState.paginationStatus in listOf(
+                PaginationStatus.LOADING,
+                PaginationStatus.PAGINATING,
+            )
+        ) return@launch
+
+        setUpLoading(isInitPage = (page == 0), isRefreshing = isRefreshing)
+
+        getGalleryUseCase(
+            params = GetGalleryUseCase.Params(
+                round = null,
+                orderType = currentState.postOrderType.name,
+                page = page,
+                pageSize = PAGE_SIZE,
+            )
+        ).onSuccess { galleryDto ->
+            reduce {
+                copy(
+                    isRefreshing = false,
+                    paginationStatus = when {
+                        !galleryDto.hasNext -> PaginationStatus.EXHAUST
+                        galleryDto.posts.isEmpty() -> PaginationStatus.EMPTY
+                        else -> PaginationStatus.INACTIVE
+                    },
+                    posts = posts + galleryDto.posts,
+                    nextPage = page + 1,
+                    hasNextPage = galleryDto.hasNext
+                )
+            }
+        }.onFailure {
+            reduce {
+                copy(
+                    isRefreshing = false,
+                    paginationStatus = PaginationStatus.ERROR
+
+                )
+            }
+        }
+
+        analyticsHelper.d(
+            logVariable = arrayOf(
+                LogElementArgument("pagingStatus", "${currentState.paginationStatus}"),
+                LogElementArgument("page", "${currentState.nextPage}"),
+                LogElementArgument("haspage", "${currentState.hasNextPage}"),
+            ),
+            message = "fetch post Page"
+        )
     }
 
     private fun onBottomModalDismissRequest() {
@@ -57,27 +135,32 @@ constructor(
         }
     }
 
-    private fun onClickSortFilter(sortType: GalleryPhotoSortFilter) {
+    private suspend fun onClickSortFilter(intent: HomeGalleryIntent.OnClickSortFilter) = launch {
         reduce {
             copy(
-                sortOrder = sortType
+                isShowBottomSheet = false,
+                postOrderType = intent.postOrderType
             )
         }
+
+        fetchPostPage(page = 0)
     }
 
-    private fun onClickPost(post: UserPost.PhotoPost) {
-        postSideEffect(HomeGallerySideEffect.NavigateToHomePost(post))
+    private fun onClickPost(intent: HomeGalleryIntent.OnClickPost) {
+//        postSideEffect(HomeGallerySideEffect.NavigateToHomePost(intent.post))
     }
 
     private fun initMockUpPost() {
         reduce {
             copy(
-                photoList = samplePhotos
+//                galleryInfo = samplePhotos
             )
         }
     }
 
     companion object {
         private const val TAG = "HomeGalleryVM"
+
+        private const val PAGE_SIZE = 10
     }
 }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomeGalleryRoute.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomeGalleryRoute.kt
@@ -1,5 +1,6 @@
 package com.captures2024.soongan.feature.home.route
 
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -9,32 +10,40 @@ import com.captures2024.soongan.core.model.UserPost
 import com.captures2024.soongan.feature.home.HomeGalleryViewModel
 import com.captures2024.soongan.feature.home.state.home_gallery.HomeGalleryIntent
 import com.captures2024.soongan.feature.home.state.home_gallery.HomeGallerySideEffect
+import com.captures2024.soongan.feature.home.ui.gallery.HomeGalleryBottomSheet
 import com.captures2024.soongan.feature.home.ui.gallery.HomeGalleryScreen
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun HomeGalleryRoute(
     navigateToBack: () -> Unit,
     navigateToPost: (UserPost.PhotoPost) -> Unit,
-    homeGalleryViewModel: HomeGalleryViewModel = hiltViewModel()
+    homeGalleryViewModel: HomeGalleryViewModel = hiltViewModel(),
 ) {
     val uiState by homeGalleryViewModel.state.collectAsStateWithLifecycle()
 
     LaunchedEffect(key1 = Unit) {
         homeGalleryViewModel.sideEffect.collect { effect ->
-           when (effect) {
-               is HomeGallerySideEffect.NavigateToHomePost -> navigateToPost(effect.post)
-
-
-           }
+            when (effect) {
+                is HomeGallerySideEffect.NavigateToHomePost -> navigateToPost(effect.post)
+            }
         }
     }
 
     HomeGalleryScreen(
         uiState = uiState,
         onBackPressed = navigateToBack,
+        onRefresh = { homeGalleryViewModel.intent(HomeGalleryIntent.RefreshGallery) },
+        onLoadNextPage = { homeGalleryViewModel.intent(HomeGalleryIntent.LoadNextPage) },
         onClickPost = { homeGalleryViewModel.intent(HomeGalleryIntent.OnClickPost(it)) },
         onClickFilter = { homeGalleryViewModel.intent(HomeGalleryIntent.OnClickFilter) },
-        onClickSortFilter = { homeGalleryViewModel.intent(HomeGalleryIntent.OnClickSortFilter(it)) },
-        onBottomModalDismissRequest = { homeGalleryViewModel.intent(HomeGalleryIntent.OnBottomModalDismissRequest) },
     )
+
+    if (uiState.isShowBottomSheet) {
+        HomeGalleryBottomSheet(
+            uiState = uiState,
+            onDismissRequest = { homeGalleryViewModel.intent(HomeGalleryIntent.OnBottomModalDismissRequest) },
+            onClickItem = { homeGalleryViewModel.intent(HomeGalleryIntent.OnClickSortFilter(it)) },
+        )
+    }
 }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/state/home/HomeUIState.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/state/home/HomeUIState.kt
@@ -2,10 +2,8 @@ package com.captures2024.soongan.feature.home.state.home
 
 import com.captures2024.soongan.core.analytics.utils.LogElementArgument
 import com.captures2024.soongan.core.common.base.UIState
-import com.captures2024.soongan.core.model.UserPost
 import com.captures2024.soongan.core.model.dto.ContestInfoDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
-import com.captures2024.soongan.feature.home.utils.GalleryPhotoSortFilter
 
 internal data class HomeUIState(
     val isLoading: Boolean = false,

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/state/home_gallery/HomeGalleryIntent.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/state/home_gallery/HomeGalleryIntent.kt
@@ -2,18 +2,25 @@ package com.captures2024.soongan.feature.home.state.home_gallery
 
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.model.UserPost
-import com.captures2024.soongan.feature.home.utils.GalleryPhotoSortFilter
+import com.captures2024.soongan.core.model.dto.GalleryPostDto
+import com.captures2024.soongan.feature.home.utils.PostOrderType
 
 internal sealed interface HomeGalleryIntent : UIIntent {
 
+    data object Init: HomeGalleryIntent
+
+    data object RefreshGallery: HomeGalleryIntent
+
+    data object LoadNextPage: HomeGalleryIntent
+
     data class OnClickPost(
-        val post: UserPost.PhotoPost
+        val post: GalleryPostDto
     ) : HomeGalleryIntent
 
     data object OnClickFilter : HomeGalleryIntent
 
     data class OnClickSortFilter(
-        val selectedSortFilter: GalleryPhotoSortFilter
+        val postOrderType: PostOrderType
     ) : HomeGalleryIntent
 
     data object OnBottomModalDismissRequest : HomeGalleryIntent

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/state/home_gallery/HomeGalleryUIState.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/state/home_gallery/HomeGalleryUIState.kt
@@ -2,20 +2,26 @@ package com.captures2024.soongan.feature.home.state.home_gallery
 
 import com.captures2024.soongan.core.analytics.utils.LogElementArgument
 import com.captures2024.soongan.core.common.base.UIState
-import com.captures2024.soongan.core.model.UserPost
-import com.captures2024.soongan.feature.home.utils.GalleryPhotoSortFilter
+import com.captures2024.soongan.core.model.dto.GalleryPostDto
+import com.captures2024.soongan.feature.home.utils.PaginationStatus
+import com.captures2024.soongan.feature.home.utils.PostOrderType
 
 internal data class HomeGalleryUIState(
     val isLoading: Boolean = false,
     val isShowBottomSheet: Boolean = false,
-    val sortOrder: GalleryPhotoSortFilter = GalleryPhotoSortFilter.LIKES,
-    val photoList: List<UserPost> = emptyList(),
+    val isRefreshing: Boolean = false,
+    val postOrderType: PostOrderType = PostOrderType.MOST_LIKED,
+    val paginationStatus: PaginationStatus = PaginationStatus.INACTIVE,
+    val posts: List<GalleryPostDto> = emptyList(),
+    val nextPage: Int = 0,
+    val hasNextPage: Boolean = false,
 ) : UIState {
 
     override fun toLoggingElements(): Array<LogElementArgument> = arrayOf(
         LogElementArgument("isLoading", isLoading.toString()),
         LogElementArgument("isShowBottomSheet", isShowBottomSheet.toString()),
-        LogElementArgument("sortOrder", sortOrder.toString()),
-        LogElementArgument("photoList", photoList.toString()),
+        LogElementArgument("postOrderType", postOrderType.toString()),
+        LogElementArgument("paginationStatus", paginationStatus.toString()),
+        LogElementArgument("posts", posts.toString()),
     )
 }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/gallery/HomeGalleryBottomSheet.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/gallery/HomeGalleryBottomSheet.kt
@@ -3,18 +3,27 @@ package com.captures2024.soongan.feature.home.ui.gallery
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -25,9 +34,46 @@ import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconFilterLike
 import com.captures2024.soongan.core.designsystem.theme.SGColor
 import com.captures2024.soongan.core.designsystem.util.DevicePreviews
 import com.captures2024.soongan.feature.home.R
+import com.captures2024.soongan.feature.home.state.home_gallery.HomeGalleryUIState
+import com.captures2024.soongan.feature.home.utils.PostOrderType
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun HomeGalleryBottomSheet(
+    uiState: HomeGalleryUIState,
+    modifier: Modifier = Modifier,
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    onDismissRequest: () -> Unit = {},
+    onClickItem: (PostOrderType) -> Unit = {},
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        sheetState = sheetState,
+        containerColor = Color.White,
+    ) {
+        Column(
+            modifier = Modifier.padding(
+                horizontal = 20.dp,
+                vertical = 20.dp
+            )
+        ) {
+            PostOrderType.entries.forEachIndexed { idx, postOrderType ->
+                if (idx != 0) HorizontalDivider(color = SGColor.primaryA.copy(alpha = 0.3f))
+
+                HomeGalleryFilterItem(
+                    text = stringResource(id = postOrderType.textId),
+                    icon = postOrderType.icon,
+                    selected = uiState.postOrderType == postOrderType,
+                    onClickItem = { onClickItem(postOrderType) }
+                )
+            }
+        }
+    }
+}
 
 @Composable
-internal fun HomeGalleryFilterItem(
+private fun HomeGalleryFilterItem(
     modifier: Modifier = Modifier,
     text: String,
     icon: ImageVector,
@@ -69,6 +115,23 @@ internal fun HomeGalleryFilterItem(
             )
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@DevicePreviews
+@Composable
+private fun HomeGalleryBottomSheetPreview() {
+    val sheetState = SheetState(
+        skipPartiallyExpanded = true,
+        initialValue = SheetValue.Expanded,
+        density = LocalDensity.current,
+        skipHiddenState = false
+    )
+
+    HomeGalleryBottomSheet(
+        uiState = HomeGalleryUIState(),
+        sheetState = sheetState,
+    )
 }
 
 @DevicePreviews

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/gallery/HomeGalleryScreen.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/gallery/HomeGalleryScreen.kt
@@ -2,9 +2,12 @@ package com.captures2024.soongan.feature.home.ui.gallery
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -13,20 +16,27 @@ import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.paint
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.captures2024.soongan.core.design.R
+import com.captures2024.soongan.core.designsystem.component.NonScaleText
 import com.captures2024.soongan.core.designsystem.component.SoonGanIconButton
 import com.captures2024.soongan.core.designsystem.icon.MyIconPack
 import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillTopArrow
@@ -35,8 +45,11 @@ import com.captures2024.soongan.core.designsystem.util.DevicePreviews
 import com.captures2024.soongan.core.model.dto.GalleryPostDto
 import com.captures2024.soongan.feature.home.state.home_gallery.HomeGalleryUIState
 import com.captures2024.soongan.feature.home.ui.gallery.component.HomeGalleryImageItem
+import com.captures2024.soongan.feature.home.ui.gallery.component.HomeGallerySkeletonItem
 import com.captures2024.soongan.feature.home.ui.gallery.component.HomeGalleryTopBar
 import com.captures2024.soongan.feature.home.utils.PaginationStatus
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -91,6 +104,26 @@ private fun HomeGalleryScreen(
     val lazyStaggeredGridState = rememberLazyStaggeredGridState()
     val coroutineScope = rememberCoroutineScope()
 
+    val shouldLoadMore = remember {
+        derivedStateOf {
+            val totalItemsCount = lazyStaggeredGridState.layoutInfo.totalItemsCount
+            val lastVisibleItemIndex =
+                lazyStaggeredGridState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            lastVisibleItemIndex >= (totalItemsCount - 2)
+        }
+    }
+
+    if (paginationStatus != PaginationStatus.EXHAUST) {
+        LaunchedEffect(lazyStaggeredGridState) {
+            snapshotFlow { shouldLoadMore.value }
+                .distinctUntilChanged()
+                .filter { it }
+                .collect {
+                    onLoadNextPage()
+                }
+        }
+    }
+
     LazyVerticalStaggeredGrid(
         modifier = modifier
             .fillMaxSize()
@@ -112,14 +145,78 @@ private fun HomeGalleryScreen(
                 onClickFilter = onClickFilter,
             )
         }
-        items(
-            items = posts,
-            key = { it.postId }
-        ) {
-            HomeGalleryImageItem(
-                item = it,
-                onClick = onClickPost
-            )
+        when (paginationStatus) {
+            PaginationStatus.LOADING -> {
+                items(listOf(258, 192, 275, 268, 275, 192)) { height ->
+                    HomeGallerySkeletonItem(height = height)
+                }
+            }
+
+            PaginationStatus.EMPTY -> {
+                item(span = StaggeredGridItemSpan.FullLine) {
+                    Box(modifier = Modifier.height(100.dp), contentAlignment = Alignment.Center) {
+                        NonScaleText(
+                            text = "게시글이 없어요.",
+                            fontSize = 20.sp
+                        )
+                    }
+                }
+            }
+
+            else -> {
+                items(
+                    items = posts,
+                    key = { it.postId }
+                ) {
+                    HomeGalleryImageItem(
+                        item = it,
+                        onClick = onClickPost
+                    )
+                }
+            }
+        }
+
+        if (paginationStatus == PaginationStatus.PAGINATING) {
+            item(span = StaggeredGridItemSpan.FullLine) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(100.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(50.dp),
+                        color = SGColor.black
+                    )
+                }
+            }
+        }
+
+        if (paginationStatus == PaginationStatus.ERROR) {
+            item(span = StaggeredGridItemSpan.FullLine) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(100.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    NonScaleText(
+                        "게시글을 불러올 수 없어요.",
+                        fontSize = 20.sp
+                    )
+//                    SoonGanIconButton(onClick = {
+//                        onRefresh() || onLoadNextPage()
+//                    }) {
+//                        Icon(
+//                            imageVector = ,
+//                            contentDescription = "refresh gallery",
+//                            modifier = Modifier.size(50.dp),
+//                            tint = SGColor.black
+//                        )
+//                    }
+
+                }
+            }
         }
     }
 

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/gallery/HomeGalleryScreen.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/gallery/HomeGalleryScreen.kt
@@ -13,7 +13,11 @@ import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -23,25 +27,66 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.captures2024.soongan.core.design.R
+import com.captures2024.soongan.core.designsystem.component.SoonGanIconButton
 import com.captures2024.soongan.core.designsystem.icon.MyIconPack
 import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillTopArrow
-import com.captures2024.soongan.core.designsystem.util.DevicePreviews
-import com.captures2024.soongan.core.model.UserPost
-import com.captures2024.soongan.feature.home.state.home_gallery.HomeGalleryUIState
-import com.captures2024.soongan.core.designsystem.component.SoonGanIconButton
 import com.captures2024.soongan.core.designsystem.theme.SGColor
-import com.captures2024.soongan.feature.home.utils.GalleryPhotoSortFilter
+import com.captures2024.soongan.core.designsystem.util.DevicePreviews
+import com.captures2024.soongan.core.model.dto.GalleryPostDto
+import com.captures2024.soongan.feature.home.state.home_gallery.HomeGalleryUIState
+import com.captures2024.soongan.feature.home.ui.gallery.component.HomeGalleryImageItem
+import com.captures2024.soongan.feature.home.ui.gallery.component.HomeGalleryTopBar
+import com.captures2024.soongan.feature.home.utils.PaginationStatus
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun HomeGalleryScreen(
-    modifier: Modifier = Modifier,
     uiState: HomeGalleryUIState,
+    modifier: Modifier = Modifier,
     onBackPressed: () -> Unit = {},
-    onClickPost: (UserPost.PhotoPost) -> Unit = {},
+    onRefresh: () -> Unit = {},
+    onLoadNextPage: () -> Unit = {},
+    onClickPost: (GalleryPostDto) -> Unit = {},
     onClickFilter: () -> Unit = {},
-    onClickSortFilter: (GalleryPhotoSortFilter) -> Unit = {},
-    onBottomModalDismissRequest: () -> Unit = {}
+) {
+    val pullToRefreshState = rememberPullToRefreshState()
+
+    PullToRefreshBox(
+        isRefreshing = uiState.isRefreshing,
+        onRefresh = onRefresh,
+        modifier = modifier,
+        state = pullToRefreshState,
+        indicator = {
+            Indicator(
+                modifier = Modifier.align(Alignment.TopCenter),
+                isRefreshing = uiState.isRefreshing,
+                containerColor = SGColor.white,
+                color = SGColor.black,
+                state = pullToRefreshState
+            )
+        }
+    ) {
+        HomeGalleryScreen(
+            posts = uiState.posts,
+            paginationStatus = uiState.paginationStatus,
+            onBackPressed = onBackPressed,
+            onLoadNextPage = onLoadNextPage,
+            onClickPost = onClickPost,
+            onClickFilter = onClickFilter,
+        )
+    }
+}
+
+@Composable
+private fun HomeGalleryScreen(
+    posts: List<GalleryPostDto>,
+    paginationStatus: PaginationStatus,
+    onBackPressed: () -> Unit,
+    onLoadNextPage: () -> Unit,
+    onClickPost: (GalleryPostDto) -> Unit,
+    onClickFilter: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val lazyStaggeredGridState = rememberLazyStaggeredGridState()
     val coroutineScope = rememberCoroutineScope()
@@ -63,26 +108,18 @@ internal fun HomeGalleryScreen(
     ) {
         item(span = StaggeredGridItemSpan.FullLine) {
             HomeGalleryTopBar(
-                isShowBottomSheet = uiState.isShowBottomSheet,
-                sortOrder = uiState.sortOrder,
                 onBackPressed = onBackPressed,
                 onClickFilter = onClickFilter,
-                onClickSortFilter = onClickSortFilter,
-                onBottomModalDismissRequest = onBottomModalDismissRequest
             )
         }
         items(
-            items = uiState.photoList,
-            key = { it.id }
+            items = posts,
+            key = { it.postId }
         ) {
-            when (val item = it) {
-                is UserPost.SkeletonPost -> HomeGallerySkeletonItem(item = item)
-
-                is UserPost.PhotoPost -> HomeGalleryImageItem(
-                    item = item,
-                    onClick = onClickPost
-                )
-            }
+            HomeGalleryImageItem(
+                item = it,
+                onClick = onClickPost
+            )
         }
     }
 

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/gallery/component/HomeGalleryItems.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/gallery/component/HomeGalleryItems.kt
@@ -1,4 +1,4 @@
-package com.captures2024.soongan.feature.home.ui.gallery
+package com.captures2024.soongan.feature.home.ui.gallery.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -12,15 +12,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import com.captures2024.soongan.core.designsystem.component.shimmerBrush
 import com.captures2024.soongan.core.designsystem.theme.SGColor
 import com.captures2024.soongan.core.designsystem.theme.dropShadow
 import com.captures2024.soongan.core.designsystem.util.DevicePreviews
 import com.captures2024.soongan.core.model.UserPost
+import com.captures2024.soongan.core.model.dto.GalleryPostDto
 
 @Composable
 internal fun HomeGallerySkeletonItem(
@@ -44,16 +43,14 @@ internal fun HomeGallerySkeletonItem(
 @Composable
 internal fun HomeGalleryImageItem(
     modifier: Modifier = Modifier,
-    item: UserPost.PhotoPost,
-    onClick: (UserPost.PhotoPost) -> Unit = {},
+    item: GalleryPostDto,
+    onClick: (GalleryPostDto) -> Unit = {},
 ) {
     val showShimmer = remember { mutableStateOf(true) }
 
     AsyncImage(
-        model = ImageRequest.Builder(LocalContext.current)
-            .data(item.url)
-            .build(),
-        contentDescription = item.title,
+        model = item.imageUrl,
+        contentDescription = null,
         modifier = modifier
             .background(shimmerBrush(targetValue = 1300f, showShimmer = showShimmer.value))
             .width(190.dp)
@@ -86,10 +83,6 @@ private fun HomeGallerySkeletonItemPreview() {
 @Composable
 private fun HomeGalleryImageItemPreview() {
     HomeGalleryImageItem(
-        item = UserPost.PhotoPost(
-            id = 0,
-            url = "",
-            title = ""
-        )
+        item = GalleryPostDto()
     )
 }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/gallery/component/HomeGalleryItems.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/gallery/component/HomeGalleryItems.kt
@@ -18,17 +18,16 @@ import com.captures2024.soongan.core.designsystem.component.shimmerBrush
 import com.captures2024.soongan.core.designsystem.theme.SGColor
 import com.captures2024.soongan.core.designsystem.theme.dropShadow
 import com.captures2024.soongan.core.designsystem.util.DevicePreviews
-import com.captures2024.soongan.core.model.UserPost
 import com.captures2024.soongan.core.model.dto.GalleryPostDto
 
 @Composable
 internal fun HomeGallerySkeletonItem(
     modifier: Modifier = Modifier,
-    item: UserPost.SkeletonPost
+    height: Int = 200,
 ) = Box(
     modifier = modifier
         .width(190.dp)
-        .height(item.height.dp)
+        .height(height.dp)
         .dropShadow(
             shape = RoundedCornerShape(0.dp),
             color = SGColor.black.copy(alpha = 0.2f),
@@ -38,7 +37,6 @@ internal fun HomeGallerySkeletonItem(
         .background(SGColor.gray400)
         .background(brush = shimmerBrush(targetValue = 1300f))
 )
-
 
 @Composable
 internal fun HomeGalleryImageItem(
@@ -54,7 +52,7 @@ internal fun HomeGalleryImageItem(
         modifier = modifier
             .background(shimmerBrush(targetValue = 1300f, showShimmer = showShimmer.value))
             .width(190.dp)
-            .heightIn(min = 100.dp)
+            .heightIn(min = 100.dp, max = 300.dp)
             .dropShadow(
                 shape = RoundedCornerShape(0.dp),
                 color = SGColor.black.copy(alpha = 0.2f),
@@ -74,9 +72,7 @@ internal fun HomeGalleryImageItem(
 @DevicePreviews
 @Composable
 private fun HomeGallerySkeletonItemPreview() {
-    HomeGallerySkeletonItem(
-        item = UserPost.SkeletonPost(id = 1)
-    )
+    HomeGallerySkeletonItem()
 }
 
 @DevicePreviews

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/gallery/component/HomeGalleryTopBar.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/gallery/component/HomeGalleryTopBar.kt
@@ -1,7 +1,6 @@
-package com.captures2024.soongan.feature.home.ui.gallery
+package com.captures2024.soongan.feature.home.ui.gallery.component
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,10 +10,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,29 +21,20 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.captures2024.soongan.core.designsystem.component.NonScaleText
+import com.captures2024.soongan.core.designsystem.component.SoonGanIconButton
 import com.captures2024.soongan.core.designsystem.icon.MyIconPack
-import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconFilterLike
-import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconFilterNew
-import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconFilterOld
 import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillFillter
 import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillLeftArrow
+import com.captures2024.soongan.core.designsystem.theme.SGColor
 import com.captures2024.soongan.core.designsystem.util.DevicePreviews
 import com.captures2024.soongan.feature.home.R
-import com.captures2024.soongan.core.designsystem.component.SoonGanIconButton
-import com.captures2024.soongan.core.designsystem.theme.SGColor
-import com.captures2024.soongan.feature.home.utils.GalleryPhotoSortFilter
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun HomeGalleryTopBar(
     modifier: Modifier = Modifier,
     lazyStaggeredGridState: LazyStaggeredGridState = rememberLazyStaggeredGridState(),
-    isShowBottomSheet: Boolean,
-    sortOrder: GalleryPhotoSortFilter,
     onBackPressed: () -> Unit = {},
     onClickFilter: () -> Unit = {},
-    onClickSortFilter: (GalleryPhotoSortFilter) -> Unit = {},
-    onBottomModalDismissRequest: () -> Unit = {}
 ) {
     var scrolledY = 0f
     var previousOffset = 0
@@ -110,41 +97,6 @@ internal fun HomeGalleryTopBar(
                 )
             )
         }
-
-        if (isShowBottomSheet) {
-            ModalBottomSheet(
-                onDismissRequest = onBottomModalDismissRequest,
-                containerColor = Color.White,
-            ) {
-                Column(
-                    modifier = Modifier.padding(
-                        horizontal = 20.dp,
-                        vertical = 20.dp
-                    )
-                ) {
-                    HomeGalleryFilterItem(
-                        text = stringResource(id = R.string.filter_likes),
-                        icon = MyIconPack.IconFilterLike,
-                        selected = sortOrder == GalleryPhotoSortFilter.LIKES,
-                        onClickItem = { onClickSortFilter(GalleryPhotoSortFilter.LIKES) }
-                    )
-                    HorizontalDivider(color = SGColor.primaryA.copy(alpha = 0.3f))
-                    HomeGalleryFilterItem(
-                        text = stringResource(id = R.string.filter_oldest),
-                        icon = MyIconPack.IconFilterOld,
-                        selected = sortOrder == GalleryPhotoSortFilter.OLDEST,
-                        onClickItem = { onClickSortFilter(GalleryPhotoSortFilter.OLDEST) }
-                    )
-                    HorizontalDivider(color = SGColor.primaryA.copy(alpha = 0.3f))
-                    HomeGalleryFilterItem(
-                        text = stringResource(id = R.string.filter_newest),
-                        icon = MyIconPack.IconFilterNew,
-                        selected = sortOrder == GalleryPhotoSortFilter.NEWEST,
-                        onClickItem = { onClickSortFilter(GalleryPhotoSortFilter.NEWEST) }
-                    )
-                }
-            }
-        }
     }
 }
 
@@ -152,8 +104,5 @@ internal fun HomeGalleryTopBar(
 @DevicePreviews
 @Composable
 private fun HomeGalleryTopBarPreview() {
-    HomeGalleryTopBar(
-        isShowBottomSheet = false,
-        sortOrder = GalleryPhotoSortFilter.LIKES
-    )
+    HomeGalleryTopBar()
 }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/utils/GalleryPhotoSortFilter.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/utils/GalleryPhotoSortFilter.kt
@@ -1,7 +1,0 @@
-package com.captures2024.soongan.feature.home.utils
-
-internal enum class GalleryPhotoSortFilter {
-    LIKES,
-    OLDEST,
-    NEWEST,
-}

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/utils/PaginationStatus.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/utils/PaginationStatus.kt
@@ -1,0 +1,10 @@
+package com.captures2024.soongan.feature.home.utils
+
+enum class PaginationStatus {
+    LOADING, // loading first page
+    INACTIVE, // no loading
+    PAGINATING, // loading next page
+    EXHAUST, // loaded all pages
+    ERROR, // fail loaded
+    EMPTY, // success loaded - no content
+}

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/utils/PostOrderType.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/utils/PostOrderType.kt
@@ -1,7 +1,18 @@
 package com.captures2024.soongan.feature.home.utils
 
-internal enum class PostOrderType {
-    LATEST,
-    MOST_LIKED,
-    OLDEST,
+import androidx.annotation.StringRes
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconFilterLike
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconFilterNew
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconFilterOld
+import com.captures2024.soongan.feature.home.R as RHome
+
+internal enum class PostOrderType(
+    @StringRes val textId: Int,
+    val icon: ImageVector,
+) {
+    MOST_LIKED(textId = RHome.string.filter_likes, icon = MyIconPack.IconFilterLike),
+    OLDEST(textId = RHome.string.filter_oldest, icon = MyIconPack.IconFilterOld),
+    LATEST(textId = RHome.string.filter_newest, icon = MyIconPack.IconFilterNew),
 }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/utils/PostOrderType.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/utils/PostOrderType.kt
@@ -1,0 +1,7 @@
+package com.captures2024.soongan.feature.home.utils
+
+internal enum class PostOrderType {
+    LATEST,
+    MOST_LIKED,
+    OLDEST,
+}


### PR DESCRIPTION
# [SG-85] 갤러리 게시글 조회

## 작업 사항
- api 관련 로직 작성
- pagination 처리(Paging3 x)
- 상태 별 UI 수정 및 추가

## GIF
![get_posts](https://github.com/user-attachments/assets/e2338717-c784-4bee-8475-f27a3dfa6a9a)

## 추가
- 현재는 api 호출 시간이 짧아 2초 딜레이를 적용시키고 있어요. (로딩 상태 표시, 호출 횟수 감소 등)

## 관련 이슈
- 게시글이 없는 경우, 네트워크 에러 등의 디자인이 없어서 임의로 구성해두어 하드코딩 되어 있어요.
- 특정 pageSize를 기준으로 중복된 post가 내려오는 경우가 있는데 관련하여 문의 남겼어요. 
현재 pr은 테스트 시 이상 없었던 pageSize = 20 을 사용하고 있어요.

[SG-85]: https://captures2024.atlassian.net/browse/SG-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ