### PR TITLE
[SG-93] Base VM 리펙터 && 전역 loading 관리 구현

### DIFF
--- a/app/src/main/kotlin/com/captures2024/soongan/SoonGanActivity.kt
+++ b/app/src/main/kotlin/com/captures2024/soongan/SoonGanActivity.kt
@@ -117,8 +117,6 @@ class SoonGanActivity : ComponentActivity(), KakaoLoginCallback {
             throwable = error,
             message = "onFailureKakaoLogin",
         )
-
-        signViewModel.intent(SignViewModel.Intent.FailedSignKakao)
     }
 
     private fun signInKakao() {

--- a/app/src/main/kotlin/com/captures2024/soongan/SoonGanActivity.kt
+++ b/app/src/main/kotlin/com/captures2024/soongan/SoonGanActivity.kt
@@ -5,23 +5,16 @@ import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
-import androidx.activity.compose.ManagedActivityResultLauncher
-import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.result.ActivityResult
-import androidx.activity.result.IntentSenderRequest
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.lifecycle.lifecycleScope
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.analytics.utils.LogElementArgument
 import com.captures2024.soongan.core.android.utils.LocalAnalyticsHelper
-import com.captures2024.soongan.core.auth.GoogleAuthUiClient
 import com.captures2024.soongan.core.auth.kakao.KakaoAuthHelper
 import com.captures2024.soongan.core.auth.kakao.KakaoAuthHelperImpl
 import com.captures2024.soongan.core.auth.kakao.KakaoLoginCallback
@@ -29,10 +22,7 @@ import com.captures2024.soongan.core.designsystem.theme.SoonGanTheme
 import com.captures2024.soongan.core.viewmodel.AppRootViewModel
 import com.captures2024.soongan.core.viewmodel.sign.SignViewModel
 import com.captures2024.soongan.route.AppRoute
-import com.google.android.gms.auth.api.identity.BeginSignInRequest
-import com.google.android.gms.auth.api.identity.Identity
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -41,20 +31,10 @@ class SoonGanActivity : ComponentActivity(), KakaoLoginCallback {
     //region di property
     @Inject
     lateinit var analyticsHelper: AnalyticsHelper
-
-    @Inject
-    lateinit var beginSignInRequest: BeginSignInRequest
     //endregion
 
     private val appRootViewModel: AppRootViewModel by viewModels()
     private val signViewModel: SignViewModel by viewModels()
-
-    private val googleAuthUiClient by lazy {
-        GoogleAuthUiClient(
-            oneTapClient = Identity.getSignInClient(this),
-            signInRequest = beginSignInRequest
-        )
-    }
 
     private val kakaoAuthHelper: KakaoAuthHelper by lazy { KakaoAuthHelperImpl() }
 
@@ -66,16 +46,9 @@ class SoonGanActivity : ComponentActivity(), KakaoLoginCallback {
         setContent {
             val darkTheme = isSystemInDarkTheme()
 
-            val launcher = rememberLauncherForActivityResult(
-                contract = ActivityResultContracts.StartIntentSenderForResult(),
-                onResult = this::onResult
-            )
-
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 requestPermissions(arrayOf(android.Manifest.permission.POST_NOTIFICATIONS), 1)
             }
-
-            initFcmToken()
 
             DisposableEffect(darkTheme) {
                 enableEdgeToEdge(
@@ -99,34 +72,11 @@ class SoonGanActivity : ComponentActivity(), KakaoLoginCallback {
                     )
 
                     when (sideEffect) {
-                        is SignViewModel.Effect.GoogleSignIn -> signInGoogle(launcher)
-
                         is SignViewModel.Effect.KakaoSignIn -> signInKakao()
-
-                        is SignViewModel.Effect.SuccessSocialSign -> successSocialSign()
-
-                        is SignViewModel.Effect.NavigateToMain -> navigateToMain()
-
-                        is SignViewModel.Effect.PatchInfo -> patchInfo(sideEffect)
 
                         is SignViewModel.Effect.NavigateToSignUp,
                         is SignViewModel.Effect.NavigateToPrivacyPolicy,
                         is SignViewModel.Effect.NavigateToTermsOfUse -> Unit
-                    }
-                }
-            }
-
-            LaunchedEffect(Unit) {
-                appRootViewModel.sideEffect.collect { sideEffect ->
-                    analyticsHelper.d(
-                        LogElementArgument("appRootVm.sideEffect", "appRootVm.sideEffect = $sideEffect"),
-                        message = "Collected sideEffect"
-                    )
-
-                    when (sideEffect) {
-                        is AppRootViewModel.Effect.FailedRemoteSyncData -> failedSyncData()
-
-                        is AppRootViewModel.Effect.SuccessRemoteSyncData -> successSyncData(sideEffect)
                     }
                 }
             }
@@ -138,36 +88,6 @@ class SoonGanActivity : ComponentActivity(), KakaoLoginCallback {
                         signViewModel = signViewModel,
                     )
                 }
-            }
-        }
-    }
-
-    private fun initFcmToken() {
-        appRootViewModel.intent(AppRootViewModel.Intent.FetchFCMToken)
-    }
-
-    private fun onResult(result: ActivityResult) {
-        when (result.resultCode) {
-            RESULT_OK -> {
-                val resultIntent = result.data
-
-                if (resultIntent == null) {
-                    signViewModel.intent(SignViewModel.Intent.FailedSignGoogle)
-                    return
-                }
-
-                val token = googleAuthUiClient.signInWithIntent(resultIntent)
-
-                if (token == null) {
-                    signViewModel.intent(SignViewModel.Intent.FailedSignGoogle)
-                    return
-                }
-
-                signViewModel.intent(SignViewModel.Intent.CompleteSignGoogle(token = token))
-            }
-
-            RESULT_CANCELED -> {
-                signViewModel.intent(SignViewModel.Intent.CanceledSignGoogle)
             }
         }
     }
@@ -201,46 +121,10 @@ class SoonGanActivity : ComponentActivity(), KakaoLoginCallback {
         signViewModel.intent(SignViewModel.Intent.FailedSignKakao)
     }
 
-    private fun signInGoogle(launcher: ManagedActivityResultLauncher<IntentSenderRequest, ActivityResult>) = lifecycleScope.launch {
-        val signInIntentSender = googleAuthUiClient.signIn() ?: return@launch
-
-        launcher.launch(IntentSenderRequest.Builder(signInIntentSender).build())
-    }
-
     private fun signInKakao() {
         kakaoAuthHelper.kakaoLogin(
             context = this,
             callback = this,
-        )
-    }
-
-    private fun successSocialSign() {
-        appRootViewModel.intent(AppRootViewModel.Intent.SuccessSign)
-    }
-
-    private fun failedSyncData() {
-        signViewModel.intent(SignViewModel.Intent.FailedSyncData)
-    }
-
-    private fun successSyncData(sideEffect: AppRootViewModel.Effect.SuccessRemoteSyncData) {
-        signViewModel.intent(
-            SignViewModel.Intent.SuccessSyncData(
-                nickname = sideEffect.nickname,
-                birthYear = sideEffect.birthYear,
-            )
-        )
-    }
-
-    private fun navigateToMain() {
-        appRootViewModel.intent(AppRootViewModel.Intent.NavigateToMain)
-    }
-
-    private fun patchInfo(sideEffect: SignViewModel.Effect.PatchInfo) {
-        appRootViewModel.intent(
-            AppRootViewModel.Intent.PatchMemberInfo(
-                nickname = sideEffect.nickname,
-                birthYear = sideEffect.birthYear,
-            )
         )
     }
 }

--- a/app/src/main/kotlin/com/captures2024/soongan/route/AppRoute.kt
+++ b/app/src/main/kotlin/com/captures2024/soongan/route/AppRoute.kt
@@ -28,10 +28,10 @@ internal fun AppRoute(
                 )
             },
             appMainRoute = @Composable {
-                AppMainRoute(
-                    isGuestMode = uiState.isGuestMode(),
-                    nickname = uiState.getNickname()
-                )
+//                AppMainRoute(
+//                    isGuestMode = uiState.isGuestMode(),
+//                    nickname = uiState.getNickname()
+//                )
             },
         )
     }

--- a/app/src/main/kotlin/com/captures2024/soongan/route/AppRoute.kt
+++ b/app/src/main/kotlin/com/captures2024/soongan/route/AppRoute.kt
@@ -1,15 +1,31 @@
 package com.captures2024.soongan.route
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.captures2024.soongan.core.designsystem.component.SoonGanBackground
+import com.captures2024.soongan.core.designsystem.theme.SGColor
 import com.captures2024.soongan.core.viewmodel.AppRootViewModel
 import com.captures2024.soongan.core.viewmodel.sign.SignViewModel
 import com.captures2024.soongan.feature.intro.route.IntroRoute
 import com.captures2024.soongan.feature.main.route.MainRoute
 import com.captures2024.soongan.feature.sign.route.SignRoute
 import com.captures2024.soongan.ui.AppRootScreen
+import kotlinx.coroutines.delay
 
 @Composable
 internal fun AppRoute(
@@ -34,9 +50,42 @@ internal fun AppRoute(
                 )
             },
         )
+
+        AppLoading(uiState.isLoading)
     }
 }
 
+@Composable
+private fun AppLoading(visible: Pair<Boolean, Long>) {
+    val animationVisible = remember(visible) { mutableStateOf(visible.first) }
+    LaunchedEffect(visible) {
+        if (visible.first) {
+            delay(20000)
+            animationVisible.value = false
+        }
+    }
+
+    AnimatedVisibility(
+        visible = animationVisible.value,
+        modifier = Modifier.fillMaxSize(),
+        enter = fadeIn(animationSpec = tween(delayMillis = 100)),
+        exit = fadeOut(animationSpec = tween(delayMillis = 100)),
+    ) {
+        Box(
+            Modifier
+                .fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator(
+                color = SGColor.primaryA,
+                modifier = Modifier,
+                strokeWidth = 4.dp,
+                trackColor = SGColor.transparent,
+                strokeCap = StrokeCap.Round,
+            )
+        }
+    }
+}
 
 @Composable
 private fun AppLandingRoute() {

--- a/app/src/main/kotlin/com/captures2024/soongan/route/AppRoute.kt
+++ b/app/src/main/kotlin/com/captures2024/soongan/route/AppRoute.kt
@@ -28,10 +28,10 @@ internal fun AppRoute(
                 )
             },
             appMainRoute = @Composable {
-//                AppMainRoute(
-//                    isGuestMode = uiState.isGuestMode(),
-//                    nickname = uiState.getNickname()
-//                )
+                AppMainRoute(
+                    isGuestMode = uiState.isGuestMode,
+                    nickname = uiState.currentMember?.nickname ?: "Guest"
+                )
             },
         )
     }

--- a/app/src/main/kotlin/com/captures2024/soongan/route/AppRoute.kt
+++ b/app/src/main/kotlin/com/captures2024/soongan/route/AppRoute.kt
@@ -4,6 +4,9 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
@@ -73,7 +76,13 @@ private fun AppLoading(visible: Pair<Boolean, Long>) {
     ) {
         Box(
             Modifier
-                .fillMaxSize(),
+                .fillMaxSize()
+                .background(SGColor.transparent)
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                    onClick = {},
+                ),
             contentAlignment = Alignment.Center
         ) {
             CircularProgressIndicator(

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -13,4 +13,5 @@ dependencies {
     implementation(projects.core.analytics)
 
     implementation(libs.android.compose.runtime)
+    implementation(libs.javax.inject)
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/RepositoryModule.kt
@@ -3,12 +3,14 @@ package com.captures2024.soongan.core.data.di
 import com.captures2024.soongan.core.data.repository.AuthRepository
 import com.captures2024.soongan.core.data.repository.FcmRepository
 import com.captures2024.soongan.core.data.repository.HomeRepository
+import com.captures2024.soongan.core.data.repository.LoadingRepository
 import com.captures2024.soongan.core.data.repository.MembersRepository
 import com.captures2024.soongan.core.data.repository.TokenRepository
 import com.captures2024.soongan.core.data.repository.WeeklyContestRepository
 import com.captures2024.soongan.core.data.repository.impl.AuthRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.FcmRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.HomeRepositoryImpl
+import com.captures2024.soongan.core.data.repository.impl.LoadingRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.MembersRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.TokenRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.WeeklyContestRepositoryImpl
@@ -45,4 +47,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindWeeklyContestRepository(weeklyContestRepositoryImpl: WeeklyContestRepositoryImpl): WeeklyContestRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindLoadingRepository(loadingRepositoryImpl: LoadingRepositoryImpl): LoadingRepository
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/LoadingRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/LoadingRepository.kt
@@ -1,0 +1,15 @@
+package com.captures2024.soongan.core.data.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface LoadingRepository {
+    val loadingFlow: Flow<Boolean>
+
+    fun showLoading(tag: String)
+
+    fun hideLoading(tag: String)
+
+    fun clearLoading(tag: String)
+
+    fun isLoading(tag: String): Boolean
+}

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/MembersRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/MembersRepository.kt
@@ -2,8 +2,15 @@ package com.captures2024.soongan.core.data.repository
 
 import com.captures2024.soongan.core.model.dto.ResultConditionDto
 import com.captures2024.soongan.core.model.dto.UserInfoDto
+import kotlinx.coroutines.flow.StateFlow
 
 interface MembersRepository {
+
+    val currentMember: StateFlow<UserInfoDto?>
+
+    val isGuestMode: StateFlow<Boolean>
+
+    suspend fun setGuestMode(isGuestMode: Boolean)
 
     /**
      * Update user profile info

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/LoadingRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/LoadingRepositoryImpl.kt
@@ -1,0 +1,48 @@
+package com.captures2024.soongan.core.data.repository.impl
+
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.data.repository.LoadingRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class LoadingRepositoryImpl
+@Inject
+constructor(
+    private val analyticsHelper: AnalyticsHelper,
+) : LoadingRepository {
+    private val _isLoading: MutableStateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
+    override val loadingFlow: Flow<Boolean> =  _isLoading.map { it.isNotEmpty() }
+
+    override fun showLoading(tag: String) {
+        val currentMap = _isLoading.value.toMutableMap()
+        val currentCount = currentMap[tag] ?: 0
+        currentMap[tag] = currentCount + 1
+        _isLoading.value = currentMap.toMap()
+
+        analyticsHelper.v(message = "showLoading - $tag, ${_isLoading.value}")
+    }
+
+    override fun hideLoading(tag: String) {
+        val currentMap = _isLoading.value.toMutableMap()
+        val currentCount = currentMap[tag] ?: 0
+
+        if (currentCount > 1) {
+            currentMap[tag] = currentCount - 1
+        } else {
+            currentMap.remove(tag)
+        }
+        _isLoading.value = currentMap.toMap()
+
+        analyticsHelper.v(message = "hideLoading - $tag, ${_isLoading.value}")
+    }
+
+    override fun clearLoading(tag: String) {
+        _isLoading.value -= tag
+
+        analyticsHelper.v(message = "clearLoading - $tag, ${_isLoading.value}")
+    }
+
+    override fun isLoading(tag: String): Boolean = _isLoading.value.contains(tag)
+}

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/MembersRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/MembersRepositoryImpl.kt
@@ -1,16 +1,33 @@
 package com.captures2024.soongan.core.data.repository.impl
 
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.data.remote.MembersDataSource
 import com.captures2024.soongan.core.data.repository.MembersRepository
 import com.captures2024.soongan.core.model.dto.ResultConditionDto
 import com.captures2024.soongan.core.model.dto.UserInfoDto
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 class MembersRepositoryImpl
 @Inject
 constructor(
     private val membersDataSource: MembersDataSource,
+    private val analyticsHelper: AnalyticsHelper,
 ) : MembersRepository {
+
+    private val _currentMember: MutableStateFlow<UserInfoDto?> = MutableStateFlow(null)
+    override val currentMember: StateFlow<UserInfoDto?>
+        get() = _currentMember.asStateFlow()
+
+    private val _isGuestMode: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    override val isGuestMode: StateFlow<Boolean>
+        get() = _isGuestMode.asStateFlow()
+
+    override suspend fun setGuestMode(isGuestMode: Boolean) {
+        _isGuestMode.emit(isGuestMode)
+    }
 
     override suspend fun patchProfile(
         nickname: String?,
@@ -23,7 +40,19 @@ constructor(
             profileImage = profileImage,
         )
 
-        return userInfoDto ?: throw NullPointerException("userInfoDto is null")
+        _currentMember.emit(
+            _currentMember.value?.let { currentMember ->
+                return@let currentMember.copy(
+                    nickname = userInfoDto?.nickname ?: currentMember.nickname,
+                    selfIntroduction = userInfoDto?.selfIntroduction ?: currentMember.selfIntroduction,
+                    profileImageUrl = userInfoDto?.profileImageUrl ?: currentMember.profileImageUrl,
+                )
+            }
+        )
+
+        return userInfoDto?.also {
+            analyticsHelper.d(message = "patchProfile - userInfoDto: $userInfoDto")
+        } ?: throw NullPointerException("userInfoDto is null")
     }
 
     override suspend fun patchBirthYear(birthYear: Int): UserInfoDto {
@@ -31,13 +60,27 @@ constructor(
             birthYear = birthYear,
         )
 
-        return userInfoDto ?: throw NullPointerException("userInfoDto is null")
+        _currentMember.emit(
+            _currentMember.value?.let { currentMember ->
+                return@let currentMember.copy(
+                    birthYear = userInfoDto?.birthYear ?: currentMember.birthYear,
+                )
+            }
+        )
+
+        return userInfoDto?.also {
+            analyticsHelper.d(message = "patchBirthYear - userInfoDto: $userInfoDto")
+        } ?: throw NullPointerException("userInfoDto is null")
     }
 
     override suspend fun getMemberInfo(): UserInfoDto {
         val userInfoDto = membersDataSource.getMemberInfo()
 
-        return userInfoDto ?: throw NullPointerException("MemberInfo is null")
+        _currentMember.emit(userInfoDto)
+
+        return userInfoDto.also {
+            analyticsHelper.d(message = "getMemberInfo - userInfoDto: $userInfoDto")
+        } ?: throw NullPointerException("MemberInfo is null")
     }
 
     override suspend fun isVerifiedNickname(nickname: String): ResultConditionDto {
@@ -45,6 +88,8 @@ constructor(
             nickname = nickname,
         )
 
-        return resultConditionDto ?: throw NullPointerException("resultConditionDto is null")
+        return resultConditionDto.also {
+            analyticsHelper.d(message = "isVerifiedNickname - resultConditionDto: $resultConditionDto")
+        } ?: throw NullPointerException("resultConditionDto is null")
     }
 }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -13,5 +13,7 @@ dependencies {
     implementation(projects.core.data)
     implementation(projects.core.model)
 
+    implementation(libs.kotlin.coroutines)
+    implementation(libs.kotlin.datetime)
     implementation(libs.javax.inject)
 }

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/loading/ClearLoadingUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/loading/ClearLoadingUseCase.kt
@@ -1,0 +1,13 @@
+package com.captures2024.soongan.core.domain.usecase.loading
+
+import com.captures2024.soongan.core.data.repository.LoadingRepository
+import javax.inject.Inject
+
+class ClearLoadingUseCase
+@Inject
+constructor(
+    private val repository: LoadingRepository,
+) {
+
+    operator fun invoke(tag: String) = repository.clearLoading(tag)
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/loading/GetLoadingFlowUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/loading/GetLoadingFlowUseCase.kt
@@ -1,0 +1,14 @@
+package com.captures2024.soongan.core.domain.usecase.loading
+
+import com.captures2024.soongan.core.data.repository.LoadingRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetLoadingFlowUseCase
+@Inject
+constructor(
+    private val repository: LoadingRepository,
+) {
+
+    operator fun invoke(): Flow<Boolean> = repository.loadingFlow
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/loading/HideLoadingUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/loading/HideLoadingUseCase.kt
@@ -1,0 +1,13 @@
+package com.captures2024.soongan.core.domain.usecase.loading
+
+import com.captures2024.soongan.core.data.repository.LoadingRepository
+import javax.inject.Inject
+
+class HideLoadingUseCase
+@Inject
+constructor(
+    private val repository: LoadingRepository,
+) {
+
+    operator fun invoke(tag: String) = repository.hideLoading(tag)
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/loading/IsLoadingUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/loading/IsLoadingUseCase.kt
@@ -1,0 +1,13 @@
+package com.captures2024.soongan.core.domain.usecase.loading
+
+import com.captures2024.soongan.core.data.repository.LoadingRepository
+import javax.inject.Inject
+
+class IsLoadingUseCase
+@Inject
+constructor(
+    private val repository: LoadingRepository,
+) {
+
+    operator fun invoke(tag: String) = repository.isLoading(tag)
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/loading/ShowLoadingUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/loading/ShowLoadingUseCase.kt
@@ -1,0 +1,13 @@
+package com.captures2024.soongan.core.domain.usecase.loading
+
+import com.captures2024.soongan.core.data.repository.LoadingRepository
+import javax.inject.Inject
+
+class ShowLoadingUseCase
+@Inject
+constructor(
+    private val repository: LoadingRepository,
+) {
+
+    operator fun invoke(tag: String) = repository.showLoading(tag)
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/GetCurrentMemberFlow.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/GetCurrentMemberFlow.kt
@@ -1,0 +1,15 @@
+package com.captures2024.soongan.core.domain.usecase.members
+
+import com.captures2024.soongan.core.data.repository.MembersRepository
+import com.captures2024.soongan.core.model.dto.UserInfoDto
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+class GetCurrentMemberFlow
+@Inject
+constructor(
+    private val repository: MembersRepository,
+) {
+
+    operator fun invoke(): StateFlow<UserInfoDto?> = repository.currentMember
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/GetGuestModeFlowUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/GetGuestModeFlowUseCase.kt
@@ -1,0 +1,14 @@
+package com.captures2024.soongan.core.domain.usecase.members
+
+import com.captures2024.soongan.core.data.repository.MembersRepository
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+class GetGuestModeFlowUseCase
+@Inject
+constructor(
+    private val repository: MembersRepository,
+) {
+
+    operator fun invoke(): StateFlow<Boolean> = repository.isGuestMode
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/SetGuestModeUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/SetGuestModeUseCase.kt
@@ -1,0 +1,16 @@
+package com.captures2024.soongan.core.domain.usecase.members
+
+import com.captures2024.soongan.core.data.repository.MembersRepository
+import com.captures2024.soongan.core.domain.runSuspendCatching
+import javax.inject.Inject
+
+class SetGuestModeUseCase
+@Inject
+constructor(
+    private val repository: MembersRepository,
+) {
+
+    suspend operator fun invoke(isGuestMode: Boolean) = runSuspendCatching {
+        repository.setGuestMode(isGuestMode)
+    }
+}

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/AppRootViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/AppRootViewModel.kt
@@ -8,12 +8,13 @@ import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
 import com.captures2024.soongan.core.domain.usecase.fcm.InitFcmUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetCurrentMemberFlow
+import com.captures2024.soongan.core.domain.usecase.members.GetGuestModeFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetMemberInfoUseCase
-import com.captures2024.soongan.core.domain.usecase.token.GetAllTokenUseCase
+import com.captures2024.soongan.core.domain.usecase.token.ClearAllTokenUseCase
 import com.captures2024.soongan.core.model.dto.UserInfoDto
 import com.captures2024.soongan.core.viewmodel.model.AppRootRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import javax.inject.Inject
 
 @HiltViewModel
@@ -21,59 +22,64 @@ class AppRootViewModel
 @Inject
 constructor(
     private val analyticsHelper: AnalyticsHelper,
+    private val getCurrentMemberFlow: GetCurrentMemberFlow,
     private val initFcmUseCase: InitFcmUseCase,
-    private val getAllTokenUseCase: GetAllTokenUseCase,
     private val getMemberInfoUseCase: GetMemberInfoUseCase,
+    private val getGuestModeFlowUseCase: GetGuestModeFlowUseCase,
+    private val clearAllTokenUseCase: ClearAllTokenUseCase,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<AppRootViewModel.State, AppRootViewModel.Effect, AppRootViewModel.Intent>(savedStateHandle) {
 
     data class State(
-        val isLoading: Boolean = false,
-        val rootRouteState: AppRootRoute = AppRootRoute.LANDING,
-        private val memberInfo: UserInfoDto = UserInfoDto.defaultBuilder(),
+        val isInitialized: Boolean = false,
+        val isGuestMode: Boolean = false,
+        private val currentMember: UserInfoDto? = null
     ) : UIState {
 
+        val rootRouteState: AppRootRoute
+            get() = when (isInitialized) {
+                // 앱 진입 성공
+                true -> when (isGuestMode) {
+                    // 게스트 모드 진입
+                    true -> AppRootRoute.MAIN
+
+                    // 게스트 모드 미진입
+                    false -> when (currentMember) {
+                        // 유저 데이터 미존재
+                        null -> AppRootRoute.SIGN
+
+                        // 유저 데이터 존재
+                        else -> when {
+                            // 유저 데이터 닉네임 && 생년 미존재
+                            currentMember.nickname != null && currentMember.birthYear != null -> AppRootRoute.MAIN
+
+                            // 유저 데이터 닉네임 && 생년 존재
+                            else -> AppRootRoute.SIGN
+                        }
+                    }
+                }
+
+                // 앱 진입 실패
+                false -> AppRootRoute.LANDING
+            }
+
         override fun toLoggingElements(): Array<LogElementArgument> = arrayOf(
-            LogElementArgument("isLoading", isLoading.toString()),
-            LogElementArgument("rootRouteState", rootRouteState.toString()),
-            LogElementArgument("memberInfo", memberInfo.toString()),
-        )
-
-        fun isGuestMode(): Boolean = memberInfo.email.isEmpty()
-
-        fun getNickname(): String = memberInfo.nickname ?: ""
-
-        fun patchMemberInfo(
-            nickname: String,
-            birthYear: Int,
-        ): UserInfoDto = memberInfo.copy(
-            nickname = nickname,
-            birthYear = birthYear,
+            LogElementArgument("isInitialized", isInitialized.toString()),
+            LogElementArgument("currentMember", currentMember.toString()),
         )
     }
 
     sealed interface Effect : UISideEffect {
 
-        data object FailedRemoteSyncData : Effect
-
-        data class SuccessRemoteSyncData(
-            val nickname: String?,
-            val birthYear: Int?,
-        ) : Effect
     }
 
     sealed interface Intent : UIIntent {
 
-        data object FetchFCMToken : Intent
+        data object Init : Intent
+    }
 
-        data object SuccessSign : Intent
-
-        data object NavigateToMain : Intent
-
-        data class PatchMemberInfo(
-            val nickname: String,
-            val birthYear: Int,
-        ) : Intent
+    init {
+        intent(Intent.Init)
     }
 
     override fun createInitialState(savedStateHandle: SavedStateHandle): State {
@@ -86,100 +92,45 @@ constructor(
 
     override suspend fun handleIntent(intent: Intent) {
         when (intent) {
-            is Intent.FetchFCMToken -> handleFetchFCMToken()
-
-            is Intent.SuccessSign -> handleSuccessSign()
-
-            is Intent.NavigateToMain -> handleNavigateToMain()
-
-            is Intent.PatchMemberInfo -> handlePatchMemberInfo(intent)
+            is Intent.Init -> handleInit()
         }
     }
 
-    private suspend fun handleFetchFCMToken() {
-        fetchRemoteFcmToken()
-    }
+    private suspend fun handleInit() {
+        launch { collectCurrentMember() }
+        launch { collectGuestMode() }
 
-    private suspend fun handleSuccessSign() {
-        syncAllData()
-    }
+        fetchRemoteFCMToken()
+        fetchRemoteMemberInfo()
 
-    private fun handleNavigateToMain() {
         reduce {
             copy(
-                rootRouteState = AppRootRoute.MAIN,
+                isInitialized = true,
             )
         }
     }
 
-    private fun handlePatchMemberInfo(intent: Intent.PatchMemberInfo) {
-        reduce {
-            copy(
-                memberInfo = currentState.patchMemberInfo(
-                    nickname = intent.nickname,
-                    birthYear = intent.birthYear,
+    private suspend fun collectCurrentMember() {
+        getCurrentMemberFlow().collect { info ->
+            reduce {
+                copy(
+                    currentMember = info,
                 )
-            )
-        }
-
-        handleNavigateToMain()
-    }
-
-    private suspend fun syncAllData() = launch(Dispatchers.IO) {
-        val tokenResult = getAllTokenUseCase().getOrNull()
-
-        if (tokenResult == null || tokenResult.first.isEmpty() || tokenResult.second.isEmpty()) {
-            // 저장된 토큰 불러오기 실패, 토큰이 빈 경우
-            postSideEffect(Effect.FailedRemoteSyncData)
-
-            return@launch
-        }
-
-        val memberInfo = getMemberInfoUseCase().getOrNull()
-
-        if (memberInfo == null) {
-            // 토큰으로 조회되는 멤버가 없는 경우
-            postSideEffect(Effect.FailedRemoteSyncData)
-            return@launch
-        }
-
-        reduce {
-            copy(
-                memberInfo = memberInfo,
-            )
-        }
-
-        val isNeedRegisterNickname = memberInfo.nickname == null
-        val isNeedRegisterBirth = memberInfo.birthYear == null
-
-        postSideEffect(
-            Effect.SuccessRemoteSyncData(
-                nickname = memberInfo.nickname,
-                birthYear = memberInfo.birthYear,
-            )
-        )
-
-        if (!isNeedRegisterNickname && !isNeedRegisterBirth) {
-            fetchRootRoute(routeState = AppRootRoute.MAIN)
-        } else {
-            fetchRootRoute(routeState = AppRootRoute.SIGN)
+            }
         }
     }
 
-    private fun fetchRootRoute(routeState: AppRootRoute) {
-        reduce {
-            copy(
-                rootRouteState = routeState,
-            )
+    private suspend fun collectGuestMode() {
+        getGuestModeFlowUseCase().collect { isGuestMode ->
+            reduce {
+                copy(
+                    isGuestMode = isGuestMode,
+                )
+            }
         }
-
-        analyticsHelper.d(
-            LogElementArgument("routeState", "routeState = $routeState"),
-            message = "fin fetchRootRoute",
-        )
     }
 
-    private suspend fun fetchRemoteFcmToken() = launch(Dispatchers.IO) {
+    private suspend fun fetchRemoteFCMToken() {
         val result = initFcmUseCase().getOrNull()
 
         val logMessage = when (result) {
@@ -192,7 +143,13 @@ constructor(
             LogElementArgument("result about init fcm", "result = $result"),
             message = logMessage,
         )
+    }
 
-        fetchRootRoute(AppRootRoute.SIGN)
+    private suspend fun fetchRemoteMemberInfo() {
+        val result = getMemberInfoUseCase().getOrNull()
+
+        if (result == null) {
+            clearAllTokenUseCase()
+        }
     }
 }

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/AppRootViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/AppRootViewModel.kt
@@ -3,11 +3,14 @@ package com.captures2024.soongan.core.viewmodel
 import androidx.lifecycle.SavedStateHandle
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.analytics.utils.LogElementArgument
-import com.captures2024.soongan.core.common.base.BaseViewModel
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
 import com.captures2024.soongan.core.domain.usecase.fcm.InitFcmUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.GetLoadingFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetCurrentMemberFlow
 import com.captures2024.soongan.core.domain.usecase.members.GetGuestModeFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetMemberInfoUseCase
@@ -21,19 +24,30 @@ import javax.inject.Inject
 class AppRootViewModel
 @Inject
 constructor(
-    private val analyticsHelper: AnalyticsHelper,
     private val getCurrentMemberFlow: GetCurrentMemberFlow,
     private val initFcmUseCase: InitFcmUseCase,
     private val getMemberInfoUseCase: GetMemberInfoUseCase,
     private val getGuestModeFlowUseCase: GetGuestModeFlowUseCase,
     private val clearAllTokenUseCase: ClearAllTokenUseCase,
+    private val getLoadingFlowUseCase: GetLoadingFlowUseCase,
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<AppRootViewModel.State, AppRootViewModel.Effect, AppRootViewModel.Intent>(savedStateHandle) {
+) : NewBaseViewModel<AppRootViewModel.State, AppRootViewModel.Effect, AppRootViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    savedStateHandle = savedStateHandle,
+) {
 
     data class State(
         val isInitialized: Boolean = false,
         val isGuestMode: Boolean = false,
-        val currentMember: UserInfoDto? = null
+        val currentMember: UserInfoDto? = null,
+        val isLoading: Pair<Boolean, Long> = false to System.currentTimeMillis(),
     ) : UIState {
 
         val rootRouteState: AppRootRoute
@@ -69,9 +83,7 @@ constructor(
         )
     }
 
-    sealed interface Effect : UISideEffect {
-
-    }
+    sealed interface Effect : UISideEffect
 
     sealed interface Intent : UIIntent {
 
@@ -90,15 +102,16 @@ constructor(
         analyticsHelper.e(throwable = throwable)
     }
 
-    override suspend fun handleIntent(intent: Intent) {
+    override fun handleIntent(intent: Intent) {
         when (intent) {
-            is Intent.Init -> handleInit()
+            is Intent.Init -> launch { handleInit() }
         }
     }
 
     private suspend fun handleInit() {
         launch { collectCurrentMember() }
         launch { collectGuestMode() }
+        launch { collectLoading() }
 
         fetchRemoteFCMToken()
         fetchRemoteMemberInfo()
@@ -127,6 +140,12 @@ constructor(
                     isGuestMode = isGuestMode,
                 )
             }
+        }
+    }
+
+    private suspend fun collectLoading() {
+        getLoadingFlowUseCase().collect {
+            reduce { copy(isLoading = it to System.currentTimeMillis()) }
         }
     }
 

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/AppRootViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/AppRootViewModel.kt
@@ -33,7 +33,7 @@ constructor(
     data class State(
         val isInitialized: Boolean = false,
         val isGuestMode: Boolean = false,
-        private val currentMember: UserInfoDto? = null
+        val currentMember: UserInfoDto? = null
     ) : UIState {
 
         val rootRouteState: AppRootRoute

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/NewBaseViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/NewBaseViewModel.kt
@@ -1,0 +1,115 @@
+package com.captures2024.soongan.core.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import dagger.hilt.android.scopes.ViewModelScoped
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+@ViewModelScoped
+abstract class NewBaseViewModel<S: UIState, SE: UISideEffect, I: UIIntent>(
+    protected val analyticsHelper: AnalyticsHelper,
+    private val showLoadingUseCase: ShowLoadingUseCase,
+    private val hideLoadingUseCase: HideLoadingUseCase,
+    private val clearLoadingUseCase: ClearLoadingUseCase,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    private val simpleName: String?
+        get() = this::class.simpleName
+
+    private val initialState: S by lazy { createInitialState(savedStateHandle = savedStateHandle) }
+
+    protected abstract fun createInitialState(savedStateHandle: SavedStateHandle): S
+
+    protected abstract fun handleIntent(intent: I)
+
+    private val _state: MutableStateFlow<S> = MutableStateFlow(initialState)
+    val state: StateFlow<S>
+        get() = _state.asStateFlow()
+
+    private val _sideEffect: MutableSharedFlow<SE> = MutableSharedFlow()
+    val sideEffect
+        get() = _sideEffect.asSharedFlow()
+
+    protected val currentState: S
+        get() = _state.value
+
+    protected val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        handleClientException(throwable)
+    }
+
+    protected abstract fun handleClientException(throwable: Throwable)
+
+    protected fun showLoading() {
+        showLoadingUseCase(simpleName ?: "")
+    }
+
+    protected fun hideLoading() {
+        hideLoadingUseCase(simpleName ?: "")
+    }
+
+    protected fun clearLoading() {
+        clearLoadingUseCase(simpleName ?: "")
+    }
+
+    protected fun launch(
+        context: CoroutineContext = EmptyCoroutineContext,
+        start: CoroutineStart = CoroutineStart.DEFAULT,
+        block: suspend CoroutineScope.() -> Unit
+    ): Job = viewModelScope.launch(
+        context = context + coroutineExceptionHandler,
+        start = start,
+        block = block
+    )
+
+    protected fun loadingLaunch(
+        context: CoroutineContext = EmptyCoroutineContext,
+        block: suspend CoroutineScope.() -> Unit
+    ) {
+        showLoading()
+        launch(context) {
+            try {
+                block()
+            } finally {
+                hideLoading()
+            }
+        }
+    }
+
+    fun intent(intent: I) {
+        analyticsHelper.i(message = "[$simpleName] intent: $intent")
+        handleIntent(intent)
+    }
+
+    protected fun reduce(reduce: S.() -> S) {
+        val state = currentState.reduce()
+        if (_state.value != state) {
+            analyticsHelper.i(message = "[$simpleName] reduce: $state")
+            _state.value = state
+        }
+    }
+
+    protected fun postSideEffect(sideEffect: SE) {
+        analyticsHelper.i(message = "[$simpleName] postSideEffect: $sideEffect")
+        launch { _sideEffect.emit(sideEffect) }
+    }
+}

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
@@ -3,12 +3,15 @@ package com.captures2024.soongan.core.viewmodel.home
 import androidx.lifecycle.SavedStateHandle
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.analytics.utils.LogElementArgument
-import com.captures2024.soongan.core.common.base.BaseViewModel
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetGalleryUseCase
 import com.captures2024.soongan.core.model.dto.GalleryPostDto
+import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
 import com.captures2024.soongan.core.viewmodel.model.PaginationStatus
 import com.captures2024.soongan.core.viewmodel.model.PostOrderType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,11 +22,18 @@ import javax.inject.Inject
 class HomeGalleryViewModel
 @Inject
 constructor(
-    private val analyticsHelper: AnalyticsHelper,
     private val getGalleryUseCase: GetGalleryUseCase,
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<HomeGalleryViewModel.State, HomeGalleryViewModel.Effect, HomeGalleryViewModel.Intent>(
-    savedStateHandle
+) : NewBaseViewModel<HomeGalleryViewModel.State, HomeGalleryViewModel.Effect, HomeGalleryViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    savedStateHandle = savedStateHandle,
 ) {
 
     data class State(
@@ -90,24 +100,70 @@ constructor(
         analyticsHelper.e(throwable = throwable)
     }
 
-    override suspend fun handleIntent(intent: Intent) {
+    override fun handleIntent(intent: Intent) {
         when (intent) {
-            is Intent.Init -> fetchPostPage(page = 0)
+            is Intent.Init -> loadingLaunch { handleInit() }
 
-            is Intent.RefreshGallery -> fetchPostPage(page = 0, isRefreshing = true)
+            is Intent.RefreshGallery -> launch { handleRefreshGallery() }
 
-            is Intent.LoadNextPage -> fetchPostPage(page = currentState.nextPage)
+            is Intent.LoadNextPage -> launch { handleLoadNextPage() }
 
-            is Intent.OnBottomModalDismissRequest -> onBottomModalDismissRequest()
+            is Intent.OnBottomModalDismissRequest -> handleOnBottomModalDismissRequest()
 
-            is Intent.OnClickFilter -> onClickFilter()
+            is Intent.OnClickFilter -> handleOnClickFilter()
 
-            is Intent.OnClickPost -> onClickPost(intent)
+            is Intent.OnClickPost -> handleOnClickPost(intent)
 
-            is Intent.OnClickSortFilter -> onClickSortFilter(intent)
+            is Intent.OnClickSortFilter -> loadingLaunch { handleOnClickSortFilter(intent) }
 
-            is Intent.OnClickRegistrationText -> postSideEffect(Effect.NavigateToRegistrationPost)
+            is Intent.OnClickRegistrationText -> handleOnClickRegistrationText()
         }
+    }
+
+    private suspend fun handleInit() {
+        fetchPostPage(page = 0)
+    }
+
+    private suspend fun handleRefreshGallery() {
+        fetchPostPage(
+            page = 0,
+            isRefreshing = true,
+        )
+    }
+
+    private suspend fun handleLoadNextPage() {
+        fetchPostPage(page = currentState.nextPage)
+    }
+
+    private fun handleOnBottomModalDismissRequest() {
+        reduce {
+            copy(
+                isShowBottomSheet = false
+            )
+        }
+    }
+
+    private fun handleOnClickFilter() {
+        reduce {
+            copy(
+                isShowBottomSheet = true
+            )
+        }
+    }
+
+    private fun handleOnClickPost(intent: Intent.OnClickPost) {
+        postSideEffect(Effect.NavigateToHomePost(intent.postId))
+    }
+
+    private suspend fun handleOnClickSortFilter(intent: Intent.OnClickSortFilter) {
+        reduce {
+            copy(
+                isShowBottomSheet = false,
+                postOrderType = intent.postOrderType
+            )
+        }
+
+        fetchPostPage(page = 0)
     }
 
     private fun setUpLoading(
@@ -131,9 +187,13 @@ constructor(
         }
     }
 
-    private fun fetchPostPage(page: Int = 0, isRefreshing: Boolean = false) {
+    private suspend fun fetchPostPage(
+        page: Int = 0,
+        isRefreshing: Boolean = false,
+    ) {
         when (currentState.paginationStatus) {
-            PaginationStatus.LOADING, PaginationStatus.PAGINATING -> return
+            PaginationStatus.LOADING,
+            PaginationStatus.PAGINATING -> return
 
             else -> Unit
         }
@@ -142,86 +202,55 @@ constructor(
 
         setUpLoading(isInitPage = isInitPage, isRefreshing = isRefreshing)
 
-        launch {
-            delay(2_000)
+        delay(2_000)
 
-            val galleryDto = getGalleryUseCase(
-                params = GetGalleryUseCase.Params(
-                    round = null,
-                    orderType = currentState.postOrderType.name,
-                    page = page,
-                    pageSize = PAGE_SIZE,
-                )
-            ).getOrNull()
+        val galleryDto = getGalleryUseCase(
+            params = GetGalleryUseCase.Params(
+                round = null,
+                orderType = currentState.postOrderType.name,
+                page = page,
+                pageSize = PAGE_SIZE,
+            )
+        ).getOrNull()
 
 
-            if (galleryDto == null) {
-                analyticsHelper.d(message = "galleryDto is null")
-
-                reduce {
-                    copy(
-                        isRefreshing = false,
-                        paginationStatus = PaginationStatus.ERROR
-                    )
-                }
-
-                return@launch
-            }
-
-            analyticsHelper.d(message = "galleryDto is ${galleryDto.posts}")
+        if (galleryDto == null) {
+            analyticsHelper.d(message = "galleryDto is null")
 
             reduce {
                 copy(
                     isRefreshing = false,
-                    paginationStatus = when {
-                        !galleryDto.hasNext -> PaginationStatus.EXHAUST
-                        galleryDto.posts.isEmpty() -> PaginationStatus.EMPTY
-                        else -> PaginationStatus.INACTIVE
-                    },
-                    posts = posts + galleryDto.posts,
-                    nextPage = page + 1,
-                    hasNextPage = galleryDto.hasNext
+                    paginationStatus = PaginationStatus.ERROR
                 )
             }
 
+            return
         }
-    }
 
+        analyticsHelper.d(message = "galleryDto is ${galleryDto.posts}")
 
-    private fun onBottomModalDismissRequest() {
         reduce {
             copy(
-                isShowBottomSheet = false
+                isRefreshing = false,
+                paginationStatus = when {
+                    !galleryDto.hasNext -> PaginationStatus.EXHAUST
+
+                    galleryDto.posts.isEmpty() -> PaginationStatus.EMPTY
+
+                    else -> PaginationStatus.INACTIVE
+                },
+                posts = posts + galleryDto.posts,
+                nextPage = page + 1,
+                hasNextPage = galleryDto.hasNext
             )
         }
     }
 
-    private fun onClickFilter() {
-        reduce {
-            copy(
-                isShowBottomSheet = true
-            )
-        }
-    }
-
-    private fun onClickSortFilter(intent: Intent.OnClickSortFilter) = launch {
-        reduce {
-            copy(
-                isShowBottomSheet = false,
-                postOrderType = intent.postOrderType
-            )
-        }
-
-        fetchPostPage(page = 0)
-    }
-
-    private fun onClickPost(intent: Intent.OnClickPost) {
-        postSideEffect(HomeGalleryViewModel.Effect.NavigateToHomePost(intent.postId))
+    private fun handleOnClickRegistrationText() {
+        postSideEffect(Effect.NavigateToRegistrationPost)
     }
 
     companion object {
-        private const val TAG = "HomeGalleryVM"
-
         private const val PAGE_SIZE = 20
     }
 }

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomePostPhotoViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomePostPhotoViewModel.kt
@@ -2,12 +2,16 @@ package com.captures2024.soongan.core.viewmodel.home
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.analytics.utils.LogElementArgument
-import com.captures2024.soongan.core.common.base.BaseViewModel
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
 import com.captures2024.soongan.core.navigator.screen.main.home.HomePostPhotoNavigator
+import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -15,8 +19,18 @@ import javax.inject.Inject
 class HomePostPhotoViewModel
 @Inject
 constructor(
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
     savedStateHandle: SavedStateHandle
-) : BaseViewModel<HomePostPhotoViewModel.State, HomePostPhotoViewModel.Effect, HomePostPhotoViewModel.Intent>(savedStateHandle) {
+) : NewBaseViewModel<HomePostPhotoViewModel.State, HomePostPhotoViewModel.Effect, HomePostPhotoViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    savedStateHandle = savedStateHandle,
+) {
 
     data class State(
         val url: String,
@@ -31,13 +45,9 @@ constructor(
         )
     }
 
-    sealed interface Effect : UISideEffect {
+    sealed interface Effect : UISideEffect
 
-    }
-
-    sealed interface Intent : UIIntent {
-
-    }
+    sealed interface Intent : UIIntent
 
     override fun createInitialState(savedStateHandle: SavedStateHandle): State {
         val info = savedStateHandle.toRoute<HomePostPhotoNavigator>()
@@ -49,11 +59,7 @@ constructor(
         TODO("Not yet implemented")
     }
 
-    override suspend fun handleIntent(intent: Intent) {
+    override fun handleIntent(intent: Intent) {
         TODO("Not yet implemented")
-    }
-
-    companion object {
-        private const val TAG = "HomePostVM"
     }
 }

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomePostViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomePostViewModel.kt
@@ -2,17 +2,20 @@ package com.captures2024.soongan.core.viewmodel.home
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.analytics.utils.LogElementArgument
-import com.captures2024.soongan.core.common.base.BaseViewModel
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetPostInfoUseCase
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import com.captures2024.soongan.core.navigator.screen.main.home.HomePostNavigator
+import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
 import com.captures2024.soongan.core.viewmodel.model.HomePostBottomModalState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import javax.inject.Inject
 
 @HiltViewModel
@@ -20,19 +23,27 @@ class HomePostViewModel
 @Inject
 constructor(
     private val getPostInfoUseCase: GetPostInfoUseCase,
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<HomePostViewModel.State, HomePostViewModel.Effect, HomePostViewModel.Intent>(savedStateHandle) {
+) : NewBaseViewModel<HomePostViewModel.State, HomePostViewModel.Effect, HomePostViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    savedStateHandle = savedStateHandle,
+) {
 
     data class State(
         val postId: Int,
         val post: PostInfoDto = PostInfoDto(),
-        val isLoading: Boolean = false,
         val isOpenModal: HomePostBottomModalState = HomePostBottomModalState.CLOSED,
         val inWritingComment: String = "",
     ) : UIState {
 
         override fun toLoggingElements(): Array<LogElementArgument> = arrayOf(
-            LogElementArgument("isLoading", isLoading.toString()),
             LogElementArgument("postId", postId.toString()),
             LogElementArgument("post", post.toString()),
             LogElementArgument("isOpenModal", isOpenModal.toString()),
@@ -83,19 +94,16 @@ constructor(
     override fun createInitialState(savedStateHandle: SavedStateHandle): State {
         val info = savedStateHandle.toRoute<HomePostNavigator>()
 
-        return State(
-            postId = info.id,
-            isLoading = true,
-        )
+        return State(postId = info.id)
     }
 
     override fun handleClientException(throwable: Throwable) {
 //        Timber.tag(TAG).e(throwable)
     }
 
-    override suspend fun handleIntent(intent: Intent) {
+    override fun handleIntent(intent: Intent) {
         when (intent) {
-            is Intent.Init -> handleInit()
+            is Intent.Init -> loadingLaunch { handleInit() }
 
             is Intent.OnClickBack -> handleOnClickBack()
 
@@ -109,7 +117,7 @@ constructor(
 
             is Intent.OnClosedModal -> handleOnClosedModal()
 
-            is Intent.OnCommentValueChanged -> handleOnCommentValueChanged(intent.inWritingComment)
+            is Intent.OnCommentValueChanged -> handleOnCommentValueChanged(intent)
 
             is Intent.OnClickDeletePost -> handleOnClickDeletePost()
 
@@ -131,7 +139,6 @@ constructor(
             copy(
                 postId = postInfo.postId,
                 post = postInfo,
-                isLoading = false,
             )
         }
     }
@@ -161,8 +168,7 @@ constructor(
     }
 
     private fun handleOnClickPhoto() {
-        // TODO 1차 MVP 스펙아웃
-//        postSideEffect(Effect.NavigateToHomePostPhoto(currentState.post.url))
+        postSideEffect(Effect.NavigateToHomePostPhoto(currentState.post.imageUrl))
     }
 
     private fun handleOnClosedModal() {
@@ -173,10 +179,10 @@ constructor(
         }
     }
 
-    private fun handleOnCommentValueChanged(inWritingComment: String) {
+    private fun handleOnCommentValueChanged(intent: Intent.OnCommentValueChanged) {
         reduce {
             copy(
-                inWritingComment = inWritingComment,
+                inWritingComment = intent.inWritingComment,
             )
         }
     }

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeViewModel.kt
@@ -3,13 +3,16 @@ package com.captures2024.soongan.core.viewmodel.home
 import androidx.lifecycle.SavedStateHandle
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.analytics.utils.LogElementArgument
-import com.captures2024.soongan.core.common.base.BaseViewModel
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
 import com.captures2024.soongan.core.domain.usecase.home.GetHomeUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
 import com.captures2024.soongan.core.model.dto.ContestInfoDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
+import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -17,10 +20,19 @@ import javax.inject.Inject
 class HomeViewModel
 @Inject
 constructor(
-    private val analyticsHelper: AnalyticsHelper,
     private val getHomeUseCase: GetHomeUseCase,
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
     savedStateHandle: SavedStateHandle
-) : BaseViewModel<HomeViewModel.State, HomeViewModel.Effect, HomeViewModel.Intent>(savedStateHandle) {
+) : NewBaseViewModel<HomeViewModel.State, HomeViewModel.Effect, HomeViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    savedStateHandle = savedStateHandle,
+) {
 
     data class State(
         val isLoading: Boolean = false,
@@ -81,21 +93,21 @@ constructor(
         analyticsHelper.e(throwable = throwable)
     }
 
-    override suspend fun handleIntent(intent: Intent) {
+    override fun handleIntent(intent: Intent) {
         when (intent) {
-            is Intent.Init -> handleInit()
+            is Intent.Init -> loadingLaunch { handleInit() }
 
-            is Intent.OnClickPlus -> onClickPlus()
+            is Intent.OnClickPlus -> handleOnClickPlus()
 
             is Intent.OnClickPost -> handleOnClickPost(intent)
 
-            is Intent.OnToggleWeeklyDaily -> onToggleWeeklyDaily()
+            is Intent.OnToggleWeeklyDaily -> handleOnToggleWeeklyDaily()
 
-            is Intent.OnClickInfo -> onClickInfo()
+            is Intent.OnClickInfo -> handleOnClickInfo()
 
-            is Intent.OnClickRightArrow -> onClickRightArrow()
+            is Intent.OnClickRightArrow -> handleOnClickRightArrow()
 
-            is Intent.OnCloseBottomSheet -> onCloseBottomSheet()
+            is Intent.OnCloseBottomSheet -> handleOnCloseBottomSheet()
         }
     }
 
@@ -117,7 +129,7 @@ constructor(
         }
     }
 
-    private fun onClickPlus() {
+    private fun handleOnClickPlus() {
         postSideEffect(Effect.NavigateToRegistrationPost)
     }
 
@@ -125,7 +137,7 @@ constructor(
         postSideEffect(Effect.NavigateToHomePost(intent.postInfo))
     }
 
-    private fun onToggleWeeklyDaily() {
+    private fun handleOnToggleWeeklyDaily() {
         reduce {
             copy(
                 isWeeklySelected = !isWeeklySelected
@@ -133,7 +145,7 @@ constructor(
         }
     }
 
-    private fun onClickInfo() {
+    private fun handleOnClickInfo() {
         reduce {
             copy(
                 isOpenBottomSheet = true
@@ -141,11 +153,11 @@ constructor(
         }
     }
 
-    private fun onClickRightArrow() {
+    private fun handleOnClickRightArrow() {
         postSideEffect(Effect.NavigateToHomeGallery)
     }
 
-    private fun onCloseBottomSheet() {
+    private fun handleOnCloseBottomSheet() {
         reduce {
             copy(
                 isOpenBottomSheet = false

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/sign/SignViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/sign/SignViewModel.kt
@@ -7,12 +7,11 @@ import com.captures2024.soongan.core.common.base.BaseViewModel
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
-import com.captures2024.soongan.core.domain.usecase.auth.SigningGoogleUseCase
 import com.captures2024.soongan.core.domain.usecase.auth.SigningKakaoUseCase
 import com.captures2024.soongan.core.domain.usecase.fcm.GetFcmUseCase
-import com.captures2024.soongan.core.domain.usecase.token.ClearAllTokenUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetMemberInfoUseCase
+import com.captures2024.soongan.core.domain.usecase.members.SetGuestModeUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import javax.inject.Inject
 
 @HiltViewModel
@@ -21,9 +20,9 @@ class SignViewModel
 constructor(
     private val analyticsHelper: AnalyticsHelper,
     private val getFcmUseCase: GetFcmUseCase,
-    private val signingGoogleUseCase: SigningGoogleUseCase,
     private val signingKakaoUseCase: SigningKakaoUseCase,
-    private val clearAllTokenUseCase: ClearAllTokenUseCase,
+    private val setGuestModeUseCase: SetGuestModeUseCase,
+    private val getMemberInfoUseCase: GetMemberInfoUseCase,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<SignViewModel.State, SignViewModel.Effect, SignViewModel.Intent>(savedStateHandle) {
 
@@ -38,12 +37,7 @@ constructor(
 
     sealed interface Effect : UISideEffect {
 
-
-        data object GoogleSignIn : Effect
-
         data object KakaoSignIn : Effect
-
-        data object SuccessSocialSign : Effect
 
         data object NavigateToTermsOfUse : Effect
 
@@ -51,13 +45,6 @@ constructor(
 
         data class NavigateToSignUp(
             val nickname: String?,
-        ) : Effect
-
-        data object NavigateToMain : Effect
-
-        data class PatchInfo(
-            val nickname: String,
-            val birthYear: Int,
         ) : Effect
     }
 
@@ -67,8 +54,6 @@ constructor(
          * 사용자가 게스트 모드로 진입하려고 할 때 발생하는 인텐트
          */
         data object OnClickGuestMode : Intent
-
-        data object OnClickSignGoogle : Intent
 
         /**
          * 사용자가 카카오 로그인을 시도할 때 발생하는 인텐트
@@ -86,23 +71,9 @@ constructor(
         data object OnClickPrivacyPolicy : Intent
 
         /**
-         * 사용자가 구글 로그인 과정을 취소했을 때 발생하는 인텐트
-         */
-        data object CanceledSignGoogle : Intent
-
-        /**
          * 사용자가 카카오 로그인 과정을 취소했을 때 발생하는 인텐트
          */
         data object CanceledSignKakao : Intent
-
-        /**
-         * 구글 로그인이 성공적으로 완료되었을 때 발생하는 인텐트
-         *
-         * @property token 구글로부터 받은 인증 토큰
-         */
-        data class CompleteSignGoogle(
-            val token: String,
-        ) : Intent
 
         /**
          * 카카오 로그인이 성공적으로 완료되었을 때 발생하는 인텐트
@@ -116,41 +87,9 @@ constructor(
         ) : Intent
 
         /**
-         * 구글 로그인 시도가 실패했을 때 발생하는 인텐트
-         */
-        data object FailedSignGoogle : Intent
-
-        /**
          * 카카오 로그인 시도가 실패했을 때 발생하는 인텐트
          */
         data object FailedSignKakao : Intent
-
-        /**
-         * 사용자 데이터 동기화가 실패했을 때 발생하는 인텐트
-         */
-        data object FailedSyncData : Intent
-
-        /**
-         * 사용자 데이터 동기화가 성공적으로 완료되었을 때 발생하는 인텐트
-         *
-         * @property nickname 사용자의 닉네임 (nullable)
-         * @property birthYear 사용자의 출생연도 (nullable)
-         */
-        data class SuccessSyncData(
-            val nickname: String?,
-            val birthYear: Int?,
-        ) : Intent
-
-        /**
-         * 사용자의 닉네임과 출생연도 입력이 모두 완료되었을 때 발생하는 인텐트
-         *
-         * @property nickname 사용자의 닉네임
-         * @property birthYear 사용자의 출생연도
-         */
-        data class SuccessPathBirth(
-            val nickname: String,
-            val birthYear: Int,
-        ) : Intent
     }
 
     override fun createInitialState(savedStateHandle: SavedStateHandle): State = State()
@@ -164,9 +103,7 @@ constructor(
 
     override suspend fun handleIntent(intent: Intent) {
         when (intent) {
-            is Intent.OnClickGuestMode -> handleOnClickGuestMode()
-
-            is Intent.OnClickSignGoogle -> handleOnClickSignGoogle()
+            is Intent.OnClickGuestMode -> launch { handleOnClickGuestMode() }
 
             is Intent.OnClickSignKakao -> handleOnClickSignKakao()
 
@@ -174,36 +111,16 @@ constructor(
 
             is Intent.OnClickTermsOfUse -> handleOnClickTermsOfUse()
 
-            is Intent.CanceledSignGoogle -> handleCanceledSignGoogle()
-
             is Intent.CanceledSignKakao -> handleCanceledSignKakao()
-
-            is Intent.FailedSignGoogle -> handleFailedSignGoogle()
 
             is Intent.FailedSignKakao -> handleFailedSignKakao()
 
-            is Intent.CompleteSignGoogle -> handleCompleteSignGoogle(intent)
-
-            is Intent.CompleteSignKakao -> handleCompleteSignKakao(intent)
-
-            is Intent.FailedSyncData -> handleFailedSyncData()
-
-            is Intent.SuccessSyncData -> handleSuccessSyncData(intent)
-
-            is Intent.SuccessPathBirth -> handleSuccessPathBirth(intent)
+            is Intent.CompleteSignKakao -> launch { handleCompleteSignKakao(intent) }
         }
     }
 
-    private fun handleOnClickGuestMode() {
-        postSideEffect(Effect.NavigateToMain)
-    }
-
-    private fun handleOnClickSignGoogle() {
-        reduce {
-            copy(isLoading = true)
-        }
-
-        postSideEffect(Effect.GoogleSignIn)
+    private suspend fun handleOnClickGuestMode() {
+        setGuestModeUseCase(isGuestMode = true)
     }
 
     private fun handleOnClickSignKakao() {
@@ -222,56 +139,16 @@ constructor(
         postSideEffect(Effect.NavigateToTermsOfUse)
     }
 
-    private fun handleCanceledSignGoogle() {
-        canceledSignIn()
-    }
-
     private fun handleCanceledSignKakao() {
         canceledSignIn()
-    }
-
-    private fun handleFailedSignGoogle() {
-        failedSignIn()
     }
 
     private fun handleFailedSignKakao() {
         failedSignIn()
     }
 
-    private suspend fun handleCompleteSignGoogle(intent: Intent.CompleteSignGoogle) {
-        googleSignIn(token = intent.token)
-    }
-
     private suspend fun handleCompleteSignKakao(intent: Intent.CompleteSignKakao) {
         kakaoSignIn(token = intent.accessToken)
-    }
-
-    private suspend fun handleFailedSyncData() {
-        clearAllTokenUseCase()
-        failedSignIn()
-    }
-
-    private suspend fun handleSuccessSyncData(intent: Intent.SuccessSyncData) {
-        reduce {
-            copy(
-                isLoading = false,
-            )
-        }
-
-        postSideEffect(
-            Effect.NavigateToSignUp(
-                nickname = intent.nickname,
-            ),
-        )
-    }
-
-    private suspend fun handleSuccessPathBirth(intent: Intent.SuccessPathBirth) {
-        postSideEffect(
-            Effect.PatchInfo(
-                nickname = intent.nickname,
-                birthYear = intent.birthYear,
-            )
-        )
     }
 
     private fun canceledSignIn() {
@@ -286,40 +163,12 @@ constructor(
         }
     }
 
-    private suspend fun googleSignIn(token: String) = launch(Dispatchers.IO) {
+    private suspend fun kakaoSignIn(token: String) {
         val fcmToken = getFcmUseCase().getOrNull()
 
-        if(fcmToken == null) {
+        if (fcmToken == null) {
             analyticsHelper.d(message = "fcm token is null")
-            return@launch
-        }
-
-        val result = signingGoogleUseCase(
-            token = token,
-            fcmToken = fcmToken,
-        ).getOrNull()
-
-        if (result == null) {
-            analyticsHelper.d(message = "result is null")
-            failedSignIn()
-            return@launch
-        }
-
-        if (result == false) {
-            analyticsHelper.d(message = "result: false")
-            failedSignIn()
-            return@launch
-        }
-
-        successSign()
-    }
-
-    private suspend fun kakaoSignIn(token: String) = launch {
-        val fcmToken = getFcmUseCase().getOrNull()
-
-        if(fcmToken == null) {
-            analyticsHelper.d(message = "fcm token is null")
-            return@launch
+            return
         }
 
         val result = signingKakaoUseCase(
@@ -327,22 +176,20 @@ constructor(
             fcmToken = fcmToken,
         ).getOrNull()
 
-        if (result == null) {
-            analyticsHelper.d(message = "result is null")
-            failedSignIn()
-            return@launch
+        when (result) {
+            true -> {
+                val infoDto = getMemberInfoUseCase().getOrNull()
+
+                if (infoDto == null) {
+                    analyticsHelper.d(message = "kakaoSignIn - infoDto is null")
+                    failedSignIn()
+                }
+            }
+
+            else -> {
+                analyticsHelper.d(message = "kakaoSignIn - result: $result")
+                failedSignIn()
+            }
         }
-
-        if (result == false) {
-            analyticsHelper.d(message = "result: false")
-            failedSignIn()
-            return@launch
-        }
-
-        successSign()
-    }
-
-    private fun successSign() {
-        postSideEffect(Effect.SuccessSocialSign)
     }
 }

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/sign/SignViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/sign/SignViewModel.kt
@@ -3,14 +3,17 @@ package com.captures2024.soongan.core.viewmodel.sign
 import androidx.lifecycle.SavedStateHandle
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.analytics.utils.LogElementArgument
-import com.captures2024.soongan.core.common.base.BaseViewModel
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
 import com.captures2024.soongan.core.domain.usecase.auth.SigningKakaoUseCase
 import com.captures2024.soongan.core.domain.usecase.fcm.GetFcmUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetMemberInfoUseCase
 import com.captures2024.soongan.core.domain.usecase.members.SetGuestModeUseCase
+import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -18,13 +21,22 @@ import javax.inject.Inject
 class SignViewModel
 @Inject
 constructor(
-    private val analyticsHelper: AnalyticsHelper,
     private val getFcmUseCase: GetFcmUseCase,
     private val signingKakaoUseCase: SigningKakaoUseCase,
     private val setGuestModeUseCase: SetGuestModeUseCase,
     private val getMemberInfoUseCase: GetMemberInfoUseCase,
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<SignViewModel.State, SignViewModel.Effect, SignViewModel.Intent>(savedStateHandle) {
+) : NewBaseViewModel<SignViewModel.State, SignViewModel.Effect, SignViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    savedStateHandle = savedStateHandle,
+) {
 
     data class State(
         val isLoading: Boolean = false,
@@ -71,11 +83,6 @@ constructor(
         data object OnClickPrivacyPolicy : Intent
 
         /**
-         * 사용자가 카카오 로그인 과정을 취소했을 때 발생하는 인텐트
-         */
-        data object CanceledSignKakao : Intent
-
-        /**
          * 카카오 로그인이 성공적으로 완료되었을 때 발생하는 인텐트
          *
          * @property accessToken 카카오로부터 받은 access 토큰
@@ -85,11 +92,6 @@ constructor(
             val accessToken: String,
             val refreshToken: String,
         ) : Intent
-
-        /**
-         * 카카오 로그인 시도가 실패했을 때 발생하는 인텐트
-         */
-        data object FailedSignKakao : Intent
     }
 
     override fun createInitialState(savedStateHandle: SavedStateHandle): State = State()
@@ -101,19 +103,15 @@ constructor(
         )
     }
 
-    override suspend fun handleIntent(intent: Intent) {
+    override fun handleIntent(intent: Intent) {
         when (intent) {
             is Intent.OnClickGuestMode -> launch { handleOnClickGuestMode() }
 
-            is Intent.OnClickSignKakao -> handleOnClickSignKakao()
+            is Intent.OnClickSignKakao -> loadingLaunch { handleOnClickSignKakao() }
 
             is Intent.OnClickPrivacyPolicy -> handleOnClickPrivacyPolicy()
 
             is Intent.OnClickTermsOfUse -> handleOnClickTermsOfUse()
-
-            is Intent.CanceledSignKakao -> handleCanceledSignKakao()
-
-            is Intent.FailedSignKakao -> handleFailedSignKakao()
 
             is Intent.CompleteSignKakao -> launch { handleCompleteSignKakao(intent) }
         }
@@ -124,10 +122,6 @@ constructor(
     }
 
     private fun handleOnClickSignKakao() {
-        reduce {
-            copy(isLoading = true)
-        }
-
         postSideEffect(Effect.KakaoSignIn)
     }
 
@@ -139,28 +133,8 @@ constructor(
         postSideEffect(Effect.NavigateToTermsOfUse)
     }
 
-    private fun handleCanceledSignKakao() {
-        canceledSignIn()
-    }
-
-    private fun handleFailedSignKakao() {
-        failedSignIn()
-    }
-
     private suspend fun handleCompleteSignKakao(intent: Intent.CompleteSignKakao) {
         kakaoSignIn(token = intent.accessToken)
-    }
-
-    private fun canceledSignIn() {
-        reduce {
-            copy(isLoading = false)
-        }
-    }
-
-    private fun failedSignIn() {
-        reduce {
-            copy(isLoading = false)
-        }
     }
 
     private suspend fun kakaoSignIn(token: String) {
@@ -182,13 +156,11 @@ constructor(
 
                 if (infoDto == null) {
                     analyticsHelper.d(message = "kakaoSignIn - infoDto is null")
-                    failedSignIn()
                 }
             }
 
             else -> {
                 analyticsHelper.d(message = "kakaoSignIn - result: $result")
-                failedSignIn()
             }
         }
     }

--- a/feature/sign/src/main/kotlin/com/captures2024/soongan/feature/sign/navigation/SignRouteNavhost.kt
+++ b/feature/sign/src/main/kotlin/com/captures2024/soongan/feature/sign/navigation/SignRouteNavhost.kt
@@ -45,7 +45,6 @@ internal fun SignRouteNavHost(
         signUp(
             navigateToBack = navController::popBackStack,
             navigateToBirth = navController::navigateToBirth,
-            signViewModel = signViewModel,
         )
     }
 }

--- a/feature/signIn/src/main/kotlin/com/captures2024/soongan/feature/signIn/route/SignInRoute.kt
+++ b/feature/signIn/src/main/kotlin/com/captures2024/soongan/feature/signIn/route/SignInRoute.kt
@@ -43,11 +43,7 @@ internal fun SignInRoute(
                     }
                 }
 
-                is SignViewModel.Effect.PatchInfo,
-                is SignViewModel.Effect.NavigateToMain,
-                is SignViewModel.Effect.GoogleSignIn,
-                is SignViewModel.Effect.KakaoSignIn,
-                is SignViewModel.Effect.SuccessSocialSign -> Unit
+                is SignViewModel.Effect.KakaoSignIn -> Unit
             }
         }
     }
@@ -56,7 +52,7 @@ internal fun SignInRoute(
         true -> SignInLoadingScreen()
 
         false -> SignInDefaultScreen(
-            onClickGoogleSignIn = { signViewModel.intent(SignViewModel.Intent.OnClickSignGoogle) },
+            onClickGoogleSignIn = { TODO("onClickGoogleSignIn Not impl yet") },
             onClickKakaoSignIn = { signViewModel.intent(SignViewModel.Intent.OnClickSignKakao) },
             onClickTermsOfUse = { signViewModel.intent(SignViewModel.Intent.OnClickTermsOfUse) },
             onClickGuestMode = { signViewModel.intent(SignViewModel.Intent.OnClickGuestMode) },

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/BirthViewModel.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/BirthViewModel.kt
@@ -80,44 +80,12 @@ constructor(
         val birthYear = currentState.birthYear.toInt()
 
         launch {
-            val isPatched = patchBirthYearUseCase(birthYear = birthYear).getOrNull()
+            patchBirthYearUseCase(birthYear = birthYear).getOrNull()
 
-            if (isPatched == null) {
-                reduce {
-                    copy(
-                        isLoading = false,
-                    )
-                }
-
-                return@launch
-            }
-
-            when (isPatched) {
-                true -> {
-                    reduce {
-                        copy(
-                            isLoading = false,
-                        )
-                    }
-
-                    postSideEffect(
-                        sideEffect = BirthSideEffect.NavigateToMain(
-                            nickname = currentState.nickname,
-                            birthYear = birthYear,
-                        )
-                    )
-                    return@launch
-                }
-
-                false -> {
-                    reduce {
-                        copy(
-                            isLoading = false,
-                        )
-                    }
-
-                    return@launch
-                }
+            reduce {
+                copy(
+                    isLoading = false,
+                )
             }
         }
     }

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/navigation/SignUpNavigation.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/navigation/SignUpNavigation.kt
@@ -11,7 +11,6 @@ import com.captures2024.soongan.feature.signUp.route.InputNicknameRoute
 fun NavGraphBuilder.signUp(
     navigateToBack: () -> Unit,
     navigateToBirth: (String) -> Unit,
-    signViewModel: SignViewModel,
 ) {
     composable<NicknameNavigator> {
         InputNicknameRoute(
@@ -22,7 +21,6 @@ fun NavGraphBuilder.signUp(
     composable<BirthNavigator> {
         InputBirthRoute(
             navigateToBack = navigateToBack,
-            signViewModel = signViewModel,
         )
     }
 }

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/route/InputBirthRoute.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/route/InputBirthRoute.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.captures2024.soongan.core.viewmodel.sign.SignViewModel
 import com.captures2024.soongan.feature.signUp.BirthViewModel
 import com.captures2024.soongan.feature.signUp.state.birth.BirthIntent
 import com.captures2024.soongan.feature.signUp.state.birth.BirthSideEffect
@@ -13,7 +12,6 @@ import com.captures2024.soongan.feature.signUp.ui.InputBirthScreen
 @Composable
 internal fun InputBirthRoute(
     navigateToBack: () -> Unit,
-    signViewModel: SignViewModel,
     birthViewModel: BirthViewModel = hiltViewModel(),
 ) {
     val uiState = birthViewModel.state.collectAsStateWithLifecycle()
@@ -22,14 +20,6 @@ internal fun InputBirthRoute(
         birthViewModel.sideEffect.collect {
             when (it) {
                 is BirthSideEffect.NavigateToBack -> navigateToBack()
-
-                is BirthSideEffect.NavigateToMain ->
-                    signViewModel.intent(
-                        SignViewModel.Intent.SuccessPathBirth(
-                            nickname = it.nickname,
-                            birthYear = it.birthYear,
-                        )
-                    )
             }
         }
     }

--- a/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/state/birth/BirthSideEffect.kt
+++ b/feature/signUp/src/main/kotlin/com/captures2024/soongan/feature/signUp/state/birth/BirthSideEffect.kt
@@ -5,9 +5,4 @@ import com.captures2024.soongan.core.common.base.UISideEffect
 internal sealed interface BirthSideEffect : UISideEffect {
 
     data object NavigateToBack : BirthSideEffect
-
-    data class NavigateToMain(
-        val nickname: String,
-        val birthYear: Int,
-    ) : BirthSideEffect
 }


### PR DESCRIPTION
# [SG-93] Base VM 리펙터 && 전역 loading 관리 구현

## 변경 사항
- NewBaseViewModel.kt 생성
    - 해당 VM은 Loading을 관리할 수 있게 loadingLaunch 항목이 추가됨
    - 해당 VM은 savedStateHandle 처럼 하기 Usecase를 주입해야함
        - analyticsHelper
        - showLoadingUseCase
        - hideLoadingUseCase
        - clearLoadingUseCase
        - savedStateHandle
    - 해당 VM은 intent가 suspend가 아니기때문에 handleIntent 구문에서 launch 여부를 작성해야함
 - AppViewModel 및 Sign VM 코드 리펙터
    - 기존 두가지 VM이 서로 intent와 effect를 오가는 구조를 축약하여 user data를 repository에서 flow로 관리
 
## 비고
- 해당 수정사항이 다른 작업사항 진행중이신 상태에서 충돌이 클까봐 기존 BaseViewModel을 살려놨습니다
- 따라서 NewBaseViewModel에 대한 분석 소요가 크다고 생각되시면 기존 BaseViewModel을 사용하셔도 무방합니다

[SG-93]: https://captures2024.atlassian.net/browse/SG-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ