### PR TITLE
[feature] 게스트 모드 블락 로직 구현

### DIFF
--- a/app/src/main/kotlin/com/captures2024/soongan/route/AppRoute.kt
+++ b/app/src/main/kotlin/com/captures2024/soongan/route/AppRoute.kt
@@ -39,6 +39,7 @@ internal fun AppRoute(
 
     SGBackground {
         AppRootScreen(
+            intent = appRootViewModel::intent,
             uiState = uiState,
             appLandingRoute = @Composable { AppLandingRoute() },
             appSignRoute = @Composable {

--- a/app/src/main/kotlin/com/captures2024/soongan/ui/AppRootScreen.kt
+++ b/app/src/main/kotlin/com/captures2024/soongan/ui/AppRootScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.captures2024.soongan.core.designsystem.component.dialog.SGSingleButtonDialog
 import com.captures2024.soongan.core.designsystem.theme.SGTheme
 import com.captures2024.soongan.core.designsystem.util.DevicePreviews
 import com.captures2024.soongan.core.viewmodel.AppRootViewModel
@@ -12,6 +13,7 @@ import com.captures2024.soongan.core.viewmodel.model.AppRootRoute
 
 @Composable
 internal fun AppRootScreen(
+    intent: (AppRootViewModel.Intent) -> Unit,
     uiState: AppRootViewModel.State,
     appLandingRoute: @Composable () -> Unit,
     appSignRoute: @Composable () -> Unit,
@@ -28,6 +30,15 @@ internal fun AppRootScreen(
 
             AppRootRoute.MAIN -> appMainRoute()
         }
+
+        if (uiState.isShowGuestModeDialog) {
+            SGSingleButtonDialog(
+                content = "해당 기능은\n로그인 필요한 기능입니다.",
+                confirmContent = "확인",
+                onClickConfirm = { intent(AppRootViewModel.Intent.OnClickConfirmGuestModeDialog) },
+                onDismissRequest = { intent(AppRootViewModel.Intent.OnClickConfirmGuestModeDialog) }
+            )
+        }
     }
 }
 
@@ -36,6 +47,7 @@ internal fun AppRootScreen(
 private fun PreviewAppRootScreen() {
     SGTheme {
         AppRootScreen(
+            intent = {},
             uiState = AppRootViewModel.State(),
             appLandingRoute = {},
             appSignRoute = {},

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/di/RepositoryModule.kt
@@ -1,6 +1,7 @@
 package com.captures2024.soongan.core.data.di
 
 import com.captures2024.soongan.core.data.repository.AuthRepository
+import com.captures2024.soongan.core.data.repository.DialogRepository
 import com.captures2024.soongan.core.data.repository.FcmRepository
 import com.captures2024.soongan.core.data.repository.HomeRepository
 import com.captures2024.soongan.core.data.repository.LoadingRepository
@@ -9,6 +10,7 @@ import com.captures2024.soongan.core.data.repository.ReportRepository
 import com.captures2024.soongan.core.data.repository.TokenRepository
 import com.captures2024.soongan.core.data.repository.WeeklyContestRepository
 import com.captures2024.soongan.core.data.repository.impl.AuthRepositoryImpl
+import com.captures2024.soongan.core.data.repository.impl.DialogRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.FcmRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.HomeRepositoryImpl
 import com.captures2024.soongan.core.data.repository.impl.LoadingRepositoryImpl
@@ -58,4 +60,7 @@ abstract class RepositoryModule {
     @Singleton
     abstract fun bindReportRepository(reportRepositoryImpl: ReportRepositoryImpl): ReportRepository
 
+    @Binds
+    @Singleton
+    abstract fun bindDialogRepository(dialogRepositoryImpl: DialogRepositoryImpl): DialogRepository
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/DialogRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/DialogRepository.kt
@@ -1,0 +1,10 @@
+package com.captures2024.soongan.core.data.repository
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface DialogRepository {
+
+    val isShowGuestModeDialogFlow: StateFlow<Boolean>
+
+    fun setIsShowGuestModeDialogFlow(condition: Boolean)
+}

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/DialogRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/DialogRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.captures2024.soongan.core.data.repository.impl
+
+import com.captures2024.soongan.core.data.repository.DialogRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+class DialogRepositoryImpl
+@Inject
+constructor() : DialogRepository {
+    private val _isShowGuestModeDialogFlow = MutableStateFlow(false)
+    override val isShowGuestModeDialogFlow: StateFlow<Boolean>
+        get() = _isShowGuestModeDialogFlow.asStateFlow()
+
+    override fun setIsShowGuestModeDialogFlow(condition: Boolean) {
+        _isShowGuestModeDialogFlow.value = condition
+    }
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/dialog/GetIsShowGuestModeDialogFlowUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/dialog/GetIsShowGuestModeDialogFlowUseCase.kt
@@ -1,0 +1,13 @@
+package com.captures2024.soongan.core.domain.usecase.dialog
+
+import com.captures2024.soongan.core.data.repository.DialogRepository
+import javax.inject.Inject
+
+class GetIsShowGuestModeDialogFlowUseCase
+@Inject
+constructor(
+    private val repository: DialogRepository,
+) {
+
+    operator fun invoke() = repository.isShowGuestModeDialogFlow
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/dialog/SetIsShowGuestModeDialogFlowUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/dialog/SetIsShowGuestModeDialogFlowUseCase.kt
@@ -1,0 +1,15 @@
+package com.captures2024.soongan.core.domain.usecase.dialog
+
+import com.captures2024.soongan.core.data.repository.DialogRepository
+import javax.inject.Inject
+
+class SetIsShowGuestModeDialogFlowUseCase
+@Inject
+constructor(
+    private val repository: DialogRepository,
+) {
+
+    operator fun invoke(condition: Boolean) {
+        repository.setIsShowGuestModeDialogFlow(condition)
+    }
+}

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/GetIsCurrentGuestModeUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/GetIsCurrentGuestModeUseCase.kt
@@ -1,0 +1,13 @@
+package com.captures2024.soongan.core.domain.usecase.members
+
+import com.captures2024.soongan.core.data.repository.MembersRepository
+import javax.inject.Inject
+
+class GetIsCurrentGuestModeUseCase
+@Inject
+constructor(
+    private val repository: MembersRepository,
+) {
+
+    operator fun invoke(): Boolean = repository.isGuestMode.value
+}

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/AppRootViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/AppRootViewModel.kt
@@ -6,6 +6,8 @@ import com.captures2024.soongan.core.analytics.utils.LogElementArgument
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.GetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.fcm.InitFcmUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.GetLoadingFlowUseCase
@@ -13,7 +15,9 @@ import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetCurrentMemberFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetGuestModeFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetMemberInfoUseCase
+import com.captures2024.soongan.core.domain.usecase.members.SetGuestModeUseCase
 import com.captures2024.soongan.core.domain.usecase.token.ClearAllTokenUseCase
 import com.captures2024.soongan.core.model.dto.UserInfoDto
 import com.captures2024.soongan.core.viewmodel.model.AppRootRoute
@@ -28,18 +32,24 @@ constructor(
     private val initFcmUseCase: InitFcmUseCase,
     private val getMemberInfoUseCase: GetMemberInfoUseCase,
     private val getGuestModeFlowUseCase: GetGuestModeFlowUseCase,
+    private val setGuestModeUseCase: SetGuestModeUseCase,
     private val clearAllTokenUseCase: ClearAllTokenUseCase,
     private val getLoadingFlowUseCase: GetLoadingFlowUseCase,
+    private val getIsShowGuestModeDialogFlowUseCase: GetIsShowGuestModeDialogFlowUseCase,
     analyticsHelper: AnalyticsHelper,
     showLoadingUseCase: ShowLoadingUseCase,
     hideLoadingUseCase: HideLoadingUseCase,
     clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
 ) : NewBaseViewModel<AppRootViewModel.State, AppRootViewModel.Effect, AppRootViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
     hideLoadingUseCase = hideLoadingUseCase,
     clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
     savedStateHandle = savedStateHandle,
 ) {
 
@@ -48,6 +58,7 @@ constructor(
         val isGuestMode: Boolean = false,
         val currentMember: UserInfoDto? = null,
         val isLoading: Pair<Boolean, Long> = false to System.currentTimeMillis(),
+        val isShowGuestModeDialog: Boolean = false,
     ) : UIState {
 
         val rootRouteState: AppRootRoute
@@ -88,6 +99,8 @@ constructor(
     sealed interface Intent : UIIntent {
 
         data object Init : Intent
+
+        data object OnClickConfirmGuestModeDialog : Intent
     }
 
     init {
@@ -105,6 +118,8 @@ constructor(
     override fun handleIntent(intent: Intent) {
         when (intent) {
             is Intent.Init -> launch { handleInit() }
+
+            is Intent.OnClickConfirmGuestModeDialog -> loadingLaunch { handleOnClickConfirmGuestModeDialog() }
         }
     }
 
@@ -112,6 +127,7 @@ constructor(
         launch { collectCurrentMember() }
         launch { collectGuestMode() }
         launch { collectLoading() }
+        launch { collectGuestModeDialog() }
 
         fetchRemoteFCMToken()
         fetchRemoteMemberInfo()
@@ -121,6 +137,11 @@ constructor(
                 isInitialized = true,
             )
         }
+    }
+
+    private fun handleOnClickConfirmGuestModeDialog() {
+        dismissGuestModeDialog()
+        setGuestModeUseCase(false)
     }
 
     private suspend fun collectCurrentMember() {
@@ -146,6 +167,16 @@ constructor(
     private suspend fun collectLoading() {
         getLoadingFlowUseCase().collect {
             reduce { copy(isLoading = it to System.currentTimeMillis()) }
+        }
+    }
+
+    private suspend fun collectGuestModeDialog() {
+        getIsShowGuestModeDialogFlowUseCase().collect { condition ->
+            reduce {
+                copy(
+                    isShowGuestModeDialog = condition,
+                )
+            }
         }
     }
 

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/NewBaseViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/NewBaseViewModel.kt
@@ -7,9 +7,11 @@ import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -21,7 +23,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
@@ -31,6 +32,8 @@ abstract class NewBaseViewModel<S: UIState, SE: UISideEffect, I: UIIntent>(
     private val showLoadingUseCase: ShowLoadingUseCase,
     private val hideLoadingUseCase: HideLoadingUseCase,
     private val clearLoadingUseCase: ClearLoadingUseCase,
+    private val getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    private val setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     private val simpleName: String?
@@ -69,6 +72,16 @@ abstract class NewBaseViewModel<S: UIState, SE: UISideEffect, I: UIIntent>(
 
     protected fun clearLoading() {
         clearLoadingUseCase(simpleName ?: "")
+    }
+
+    protected fun isGuestMode(): Boolean = getIsCurrentGuestModeUseCase()
+
+    protected fun showGuestModeDialog() {
+        setIsShowGuestModeDialogFlowUseCase(true)
+    }
+
+    protected fun dismissGuestModeDialog() {
+        setIsShowGuestModeDialogFlowUseCase(false)
     }
 
     protected fun launch(

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
@@ -6,9 +6,11 @@ import com.captures2024.soongan.core.analytics.utils.LogElementArgument
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetGalleryUseCase
 import com.captures2024.soongan.core.model.dto.GalleryPostDto
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
@@ -27,12 +29,16 @@ constructor(
     showLoadingUseCase: ShowLoadingUseCase,
     hideLoadingUseCase: HideLoadingUseCase,
     clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
 ) : NewBaseViewModel<HomeGalleryViewModel.State, HomeGalleryViewModel.Effect, HomeGalleryViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
     hideLoadingUseCase = hideLoadingUseCase,
     clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
     savedStateHandle = savedStateHandle,
 ) {
 

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomePostPhotoViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomePostPhotoViewModel.kt
@@ -7,9 +7,11 @@ import com.captures2024.soongan.core.analytics.utils.LogElementArgument
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.navigator.screen.main.home.HomePostPhotoNavigator
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -23,12 +25,16 @@ constructor(
     showLoadingUseCase: ShowLoadingUseCase,
     hideLoadingUseCase: HideLoadingUseCase,
     clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle
 ) : NewBaseViewModel<HomePostPhotoViewModel.State, HomePostPhotoViewModel.Effect, HomePostPhotoViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
     hideLoadingUseCase = hideLoadingUseCase,
     clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
     savedStateHandle = savedStateHandle,
 ) {
 

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomePostViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomePostViewModel.kt
@@ -7,9 +7,11 @@ import com.captures2024.soongan.core.analytics.utils.LogElementArgument
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetPostInfoUseCase
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import com.captures2024.soongan.core.navigator.screen.main.home.HomePostNavigator
@@ -27,12 +29,16 @@ constructor(
     showLoadingUseCase: ShowLoadingUseCase,
     hideLoadingUseCase: HideLoadingUseCase,
     clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
 ) : NewBaseViewModel<HomePostViewModel.State, HomePostViewModel.Effect, HomePostViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
     hideLoadingUseCase = hideLoadingUseCase,
     clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
     savedStateHandle = savedStateHandle,
 ) {
 

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeViewModel.kt
@@ -6,10 +6,12 @@ import com.captures2024.soongan.core.analytics.utils.LogElementArgument
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.home.GetHomeUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.model.dto.ContestInfoDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
@@ -25,12 +27,16 @@ constructor(
     showLoadingUseCase: ShowLoadingUseCase,
     hideLoadingUseCase: HideLoadingUseCase,
     clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle
 ) : NewBaseViewModel<HomeViewModel.State, HomeViewModel.Effect, HomeViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
     hideLoadingUseCase = hideLoadingUseCase,
     clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
     savedStateHandle = savedStateHandle,
 ) {
 
@@ -126,7 +132,11 @@ constructor(
     }
 
     private fun handleOnClickPlus() {
-        postSideEffect(Effect.NavigateToRegistrationPost)
+        when (isGuestMode()) {
+            true -> showGuestModeDialog()
+
+            false -> postSideEffect(Effect.NavigateToRegistrationPost)
+        }
     }
 
     private fun handleOnClickPost(intent: Intent.OnClickPost) {

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/post/RegistrationPostViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/post/RegistrationPostViewModel.kt
@@ -7,9 +7,11 @@ import com.captures2024.soongan.core.analytics.utils.LogElementArgument
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.domain.usecase.weekly.contests.RegisterPostUseCase
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -24,12 +26,16 @@ constructor(
     showLoadingUseCase: ShowLoadingUseCase,
     hideLoadingUseCase: HideLoadingUseCase,
     clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle
 ) : NewBaseViewModel<RegistrationPostViewModel.State, RegistrationPostViewModel.Effect, RegistrationPostViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
     hideLoadingUseCase = hideLoadingUseCase,
     clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
     savedStateHandle = savedStateHandle,
 ) {
     data class State(

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/sign/BirthViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/sign/BirthViewModel.kt
@@ -9,9 +9,11 @@ import com.captures2024.soongan.core.common.Validation.BirthYearValidState
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.domain.usecase.members.PatchBirthYearUseCase
 import com.captures2024.soongan.core.navigator.screen.sign.BirthNavigator
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
@@ -27,12 +29,16 @@ constructor(
     showLoadingUseCase: ShowLoadingUseCase,
     hideLoadingUseCase: HideLoadingUseCase,
     clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
 ) : NewBaseViewModel<BirthViewModel.State, BirthViewModel.Effect, BirthViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
     hideLoadingUseCase = hideLoadingUseCase,
     clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
     savedStateHandle = savedStateHandle,
 ) {
     data class State(

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/sign/NicknameViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/sign/NicknameViewModel.kt
@@ -7,9 +7,11 @@ import com.captures2024.soongan.core.common.Validation
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.domain.usecase.members.IsVerifiedNicknameUseCase
 import com.captures2024.soongan.core.domain.usecase.members.PatchProfileUseCase
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
@@ -26,12 +28,16 @@ constructor(
     showLoadingUseCase: ShowLoadingUseCase,
     hideLoadingUseCase: HideLoadingUseCase,
     clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
 ) : NewBaseViewModel<NicknameViewModel.State, NicknameViewModel.Effect, NicknameViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
     hideLoadingUseCase = hideLoadingUseCase,
     clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
     savedStateHandle = savedStateHandle,
 ) {
 

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/sign/PrivacyPolicyViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/sign/PrivacyPolicyViewModel.kt
@@ -6,11 +6,12 @@ import com.captures2024.soongan.core.analytics.utils.LogElementArgument
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
-import com.captures2024.soongan.core.viewmodel.sign.TermsOfUseViewModel.Intent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import javax.inject.Inject
@@ -23,12 +24,16 @@ constructor(
     showLoadingUseCase: ShowLoadingUseCase,
     hideLoadingUseCase: HideLoadingUseCase,
     clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
 ) : NewBaseViewModel<PrivacyPolicyViewModel.State, PrivacyPolicyViewModel.Effect, PrivacyPolicyViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
     hideLoadingUseCase = hideLoadingUseCase,
     clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
     savedStateHandle = savedStateHandle,
 ) {
 

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/sign/SignViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/sign/SignViewModel.kt
@@ -7,10 +7,12 @@ import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
 import com.captures2024.soongan.core.domain.usecase.auth.SigningKakaoUseCase
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.fcm.GetFcmUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetMemberInfoUseCase
 import com.captures2024.soongan.core.domain.usecase.members.SetGuestModeUseCase
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
@@ -29,12 +31,16 @@ constructor(
     showLoadingUseCase: ShowLoadingUseCase,
     hideLoadingUseCase: HideLoadingUseCase,
     clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
 ) : NewBaseViewModel<SignViewModel.State, SignViewModel.Effect, SignViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
     hideLoadingUseCase = hideLoadingUseCase,
     clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
     savedStateHandle = savedStateHandle,
 ) {
 

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/sign/TermsOfUseViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/sign/TermsOfUseViewModel.kt
@@ -6,9 +6,11 @@ import com.captures2024.soongan.core.analytics.utils.LogElementArgument
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
@@ -22,12 +24,16 @@ constructor(
     showLoadingUseCase: ShowLoadingUseCase,
     hideLoadingUseCase: HideLoadingUseCase,
     clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
 ) : NewBaseViewModel<TermsOfUseViewModel.State, TermsOfUseViewModel.Effect, TermsOfUseViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
     hideLoadingUseCase = hideLoadingUseCase,
     clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
     savedStateHandle = savedStateHandle,
 ) {
 

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/welcome/WelcomeViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/welcome/WelcomeViewModel.kt
@@ -6,10 +6,12 @@ import com.captures2024.soongan.core.analytics.utils.LogElementArgument
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetCurrentMemberFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
@@ -23,6 +25,8 @@ constructor(
     showLoadingUseCase: ShowLoadingUseCase,
     hideLoadingUseCase: HideLoadingUseCase,
     clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
     private val getCurrentMemberFlowUseCase: GetCurrentMemberFlowUseCase,
 ) : NewBaseViewModel<WelcomeViewModel.State, WelcomeViewModel.Effect, WelcomeViewModel.Intent>(
@@ -30,6 +34,8 @@ constructor(
     showLoadingUseCase = showLoadingUseCase,
     hideLoadingUseCase = hideLoadingUseCase,
     clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
     savedStateHandle = savedStateHandle,
 ) {
 


### PR DESCRIPTION
# [feature] 게스트 모드 블락 로직 구현

## 작업 사항
- 게스트 모드 시 진입 불가한 부분에 dialog 이후 로그인으로 이동시키는 로직 구현

## 비고
- NewBaseViewModel에 isGuestMode, showGuestModeDialog, dismissGuestModeDialog를 추가로 구현해놨습니다
- 해당 부분을 이용하면 AppRootScreen.kt에 선언된 dialog를 통해 전역적으로 게스트 모드 상태에서의 진입을 막을 수 있습니다

## GIF
![화면 기록 2025-02-23 오후 6 48 04](https://github.com/user-attachments/assets/7814aaf1-c227-4fb3-96a5-eef7027ad64e)
