### PR TITLE
[SG-103] 신고 후 게시물 hide

### DIFF
--- a/build-logic/src/main/kotlin/RetrofitConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/RetrofitConventionPlugin.kt
@@ -11,6 +11,7 @@ class RetrofitConventionPlugin : BaseConventionPlugin({
     dependencies {
         implementation(libs.retrofit)
         implementation(libs.retrofit.kotlin.serialization.converter)
+        implementation(libs.converter.scalars)
         implementation(libs.kotlin.serialization.json)
     }
 })

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/MembersMapper.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/MembersMapper.kt
@@ -10,7 +10,7 @@ fun PatchProfileResponse.toUserInfoDto(): UserInfoDto = UserInfoDto(
     email = "",
     nickname = this.nickname,
     selfIntroduction = this.selfIntroduction,
-    profileImageUrl = this.profileImage,
+    profileImageUrl = this.profileImageUrl,
 )
 
 fun PatchBirthYearResponse.toUserInfoDto(): UserInfoDto = UserInfoDto(

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/MembersDataSource.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/MembersDataSource.kt
@@ -8,7 +8,8 @@ interface MembersDataSource {
     suspend fun patchProfile(
         nickname: String? = null,
         selfIntroduction: String? = null,
-        profileImage: String? = null
+        profileImageUrl: String? = null,
+        isDefaultProfileImage: Boolean = false,
     ): UserInfoDto?
 
     suspend fun patchBirthYear(

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/WeeklyContestDataSource.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/WeeklyContestDataSource.kt
@@ -14,8 +14,7 @@ interface WeeklyContestDataSource {
     ): GalleryDto?
 
     suspend fun registerPost(
-        weeklyContestRound: Int,
-        subject: String,
+        title: String,
         imageFile: String,
     ): PostInfoDto?
 

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/MembersDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/MembersDataSourceImpl.kt
@@ -6,7 +6,6 @@ import com.captures2024.soongan.core.data.remote.MembersDataSource
 import com.captures2024.soongan.core.data.service.MembersService
 import com.captures2024.soongan.core.data.utils.safeAPICall
 import com.captures2024.soongan.core.data.utils.toImageMultiPart
-import com.captures2024.soongan.core.data.utils.toTextRequestBody
 import com.captures2024.soongan.core.model.dto.ResultConditionDto
 import com.captures2024.soongan.core.model.dto.UserInfoDto
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -22,12 +21,14 @@ constructor(
     override suspend fun patchProfile(
         nickname: String?,
         selfIntroduction: String?,
-        profileImage: String?,
+        profileImageUrl: String?,
+        isDefaultProfileImage: Boolean,
     ): UserInfoDto? = safeAPICall {
         service.patchProfile(
-            nickname = nickname.toTextRequestBody(),
-            selfIntroduction = selfIntroduction.toTextRequestBody(),
-            profileImage = profileImage.toImageMultiPart(context, "profileImage"),
+            nickname = nickname,
+            selfIntroduction = selfIntroduction,
+            profileImageUrl = profileImageUrl.toImageMultiPart(context, "profileImage"),
+            isDefaultProfileImage = isDefaultProfileImage
         )
     }.body?.responseData?.toUserInfoDto()
 

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/WeeklyContestDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/WeeklyContestDataSourceImpl.kt
@@ -8,7 +8,6 @@ import com.captures2024.soongan.core.data.remote.WeeklyContestDataSource
 import com.captures2024.soongan.core.data.service.WeeklyContestService
 import com.captures2024.soongan.core.data.utils.safeAPICall
 import com.captures2024.soongan.core.data.utils.toImageMultiPart
-import com.captures2024.soongan.core.data.utils.toTextRequestBody
 import com.captures2024.soongan.core.model.dto.GalleryDto
 import com.captures2024.soongan.core.model.dto.MyGalleryDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
@@ -36,13 +35,11 @@ constructor(
     }.body?.responseData?.toGalleryDto()
 
     override suspend fun registerPost(
-        weeklyContestRound: Int,
-        subject: String,
+        title: String,
         imageFile: String,
     ): PostInfoDto? = safeAPICall {
         service.registerPost(
-            weeklyContestRound = weeklyContestRound.toString().toTextRequestBody(),
-            subject = subject.toTextRequestBody(),
+            title = title,
             imageFile = imageFile.toImageMultiPart(context, "imageFile"),
         )
     }.body?.responseData?.toPostInfoDto()

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/MembersRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/MembersRepository.kt
@@ -19,7 +19,8 @@ interface MembersRepository {
     suspend fun patchProfile(
         nickname: String?,
         selfIntroduction: String?,
-        profileImage: String?,
+        profileImageUrl: String?,
+        isDefaultProfileImage: Boolean,
     ): UserInfoDto
 
     suspend fun patchBirthYear(birthYear: Int): UserInfoDto

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/WeeklyContestRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/WeeklyContestRepository.kt
@@ -14,8 +14,7 @@ interface WeeklyContestRepository {
     ): GalleryDto
 
     suspend fun registerPost(
-        weeklyContestRound: Int,
-        subject: String,
+        title: String,
         imageFile: String
     ): PostInfoDto
 

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/MembersRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/MembersRepositoryImpl.kt
@@ -32,20 +32,22 @@ constructor(
     override suspend fun patchProfile(
         nickname: String?,
         selfIntroduction: String?,
-        profileImage: String?
+        profileImageUrl: String?,
+        isDefaultProfileImage: Boolean,
     ): UserInfoDto {
         val userInfoDto = membersDataSource.patchProfile(
             nickname = nickname,
             selfIntroduction = selfIntroduction,
-            profileImage = profileImage,
+            profileImageUrl = profileImageUrl,
+            isDefaultProfileImage = isDefaultProfileImage,
         )
 
         _currentMember.emit(
             _currentMember.value?.let { currentMember ->
                 return@let currentMember.copy(
-                    nickname = userInfoDto?.nickname ?: currentMember.nickname,
-                    selfIntroduction = userInfoDto?.selfIntroduction ?: currentMember.selfIntroduction,
-                    profileImageUrl = userInfoDto?.profileImageUrl ?: currentMember.profileImageUrl,
+                    nickname = userInfoDto?.nickname,
+                    selfIntroduction = userInfoDto?.selfIntroduction,
+                    profileImageUrl = userInfoDto?.profileImageUrl,
                 )
             }
         )

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/ReportRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/ReportRepositoryImpl.kt
@@ -34,7 +34,7 @@ constructor(
         if (
             targetId != reportInfo.targetId
             || targetType.name != reportInfo.targetType
-//            || reportType.name != reportInfo.reportType
+            || reportType.name != reportInfo.reportType
             || reason != reportInfo.reason
         ) {
             return ResultConditionDto(result = false)

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/WeeklyContestRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/WeeklyContestRepositoryImpl.kt
@@ -31,13 +31,11 @@ constructor(
     }
 
     override suspend fun registerPost(
-        weeklyContestRound: Int,
-        subject: String,
+        title: String,
         imageFile: String,
     ): PostInfoDto {
         val postInfoDto = weeklyContestDataSource.registerPost(
-            weeklyContestRound = weeklyContestRound,
-            subject = subject,
+            title = title,
             imageFile = imageFile,
         )
 

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/WeeklyContestRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/WeeklyContestRepositoryImpl.kt
@@ -59,8 +59,8 @@ constructor(
         delay(200)
 
         return PostInfoDto(
-            postId = 6,
-            imageUrl = "https://storage.googleapis.com/soongan-dev-bucket/52/weekly/1/soongan_image-1736689106951.jpg",
+            postId = 1,
+            imageUrl = "https://storage.googleapis.com/soongan-dev-bkt/2/weekly/1/soongan_image-1739873705023.jpg",
             subject = "무제",
             registerNickname = "intexy12",
             likeCount = 0,

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/MembersService.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/MembersService.kt
@@ -5,7 +5,6 @@ import com.captures2024.soongan.core.model.network.response.members.GetMemberInf
 import com.captures2024.soongan.core.model.network.response.members.PatchBirthYearResponse
 import com.captures2024.soongan.core.model.network.response.members.PatchProfileResponse
 import okhttp3.MultipartBody
-import okhttp3.RequestBody
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Headers
@@ -20,9 +19,10 @@ interface MembersService {
     @Multipart
     @PATCH("members/profile")
     suspend fun patchProfile(
-        @Part("nickname") nickname: RequestBody?,
-        @Part("selfIntroduction") selfIntroduction: RequestBody?,
-        @Part profileImage: MultipartBody.Part?,
+        @Part("nickname") nickname: String?,
+        @Part("selfIntroduction") selfIntroduction: String?,
+        @Part profileImageUrl: MultipartBody.Part?,
+        @Part("isDefaultProfileImage") isDefaultProfileImage: Boolean,
     ): Response<BaseResponse<PatchProfileResponse>>
 
     @Headers("Authorization: true")

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/WeeklyContestService.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/WeeklyContestService.kt
@@ -5,7 +5,6 @@ import com.captures2024.soongan.core.model.network.response.weekly.contests.GetG
 import com.captures2024.soongan.core.model.network.response.weekly.contests.GetMyGalleryResponse
 import com.captures2024.soongan.core.model.network.response.weekly.contests.RegisterPostResponse
 import okhttp3.MultipartBody
-import okhttp3.RequestBody
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Headers
@@ -29,8 +28,8 @@ interface WeeklyContestService {
     @Multipart
     @POST("weekly/contests/posts")
     suspend fun registerPost(
-        @Part("weeklyContestRound") weeklyContestRound: RequestBody?,
-        @Part("subject") subject: RequestBody?,
+//        @Part("weeklyContestRound") weeklyContestRound: Int?,
+        @Part("title") title: String?,
         @Part imageFile: MultipartBody.Part?,
     ): Response<BaseResponse<RegisterPostResponse>>
 

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/utils/MultiPartExt.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/utils/MultiPartExt.kt
@@ -4,11 +4,9 @@ import android.content.Context
 import android.net.Uri
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
-import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
 
-fun String?.toTextRequestBody(): RequestBody? = this?.toRequestBody("text/plain".toMediaType())
+//fun String?.toTextRequestBody(): RequestBody? = this?.toRequestBody("text/plain".toMediaType())
 
 fun String?.toImageMultiPart(context: Context, name: String): MultipartBody.Part? {
     return this?.let {

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/utils/SafeAPICall.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/utils/SafeAPICall.kt
@@ -1,6 +1,8 @@
 package com.captures2024.soongan.core.data.utils
 
+import com.captures2024.soongan.core.model.exception.ExceptionResponse
 import com.captures2024.soongan.core.model.exception.NetworkExceptionWrapper
+import kotlinx.serialization.json.Json
 import retrofit2.HttpException
 import retrofit2.Response
 import java.net.UnknownHostException
@@ -22,11 +24,13 @@ internal suspend fun <T> safeAPICall(
         false -> {
             // Fail Response
             val errorBody = response.errorBody()?.string() ?: "UNKNOWN_ERROR"
-
             val exception = Exception(errorBody)
 
+            val json = Json { ignoreUnknownKeys = true }
+            val exceptionResponse = json.decodeFromString<ExceptionResponse>(errorBody)
+
             throw NetworkExceptionWrapper(
-                statusCode = response.code(),
+                statusCode = exceptionResponse.statusCode,
                 message = exception.message,
                 cause = exception,
             )

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/PatchProfileUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/members/PatchProfileUseCase.kt
@@ -13,14 +13,16 @@ constructor(
     suspend operator fun invoke(
         nickname: String? = null,
         selfIntroduction: String? = null,
-        profileImage: String? = null,
+        profileImageUrl: String? = null,
+        isDefaultProfileImage: Boolean = false,
     ): Result<Boolean> = runSuspendCatching {
         val userInfoDto = membersRepository.patchProfile(
             nickname = nickname,
             selfIntroduction = selfIntroduction,
-            profileImage = profileImage,
+            profileImageUrl = profileImageUrl,
+            isDefaultProfileImage = isDefaultProfileImage,
         )
 
-        return@runSuspendCatching (nickname == userInfoDto.nickname && selfIntroduction == userInfoDto.selfIntroduction && profileImage == userInfoDto.profileImageUrl)
+        return@runSuspendCatching (nickname == userInfoDto.nickname && selfIntroduction == userInfoDto.selfIntroduction && profileImageUrl == userInfoDto.profileImageUrl)
     }
 }

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/weekly/contests/RegisterPostUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/weekly/contests/RegisterPostUseCase.kt
@@ -12,8 +12,7 @@ constructor(
 
     suspend operator fun invoke(params: Params): Result<Int> = runSuspendCatching {
         val result = weeklyContestRepository.registerPost(
-            weeklyContestRound = params.weeklyContestRound,
-            subject = params.subject,
+            title = params.title,
             imageFile = params.imageFile,
         )
 
@@ -22,8 +21,7 @@ constructor(
 
 
     data class Params(
-        val weeklyContestRound: Int,
-        val subject: String,
+        val title: String,
         val imageFile: String,
     )
 }

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/exception/ExceptionResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/exception/ExceptionResponse.kt
@@ -1,0 +1,10 @@
+package com.captures2024.soongan.core.model.exception
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ExceptionResponse(
+    val statusCode: Int,
+    val message: String?,
+    val detailMessage: String?,
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/members/PatchProfileResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/members/PatchProfileResponse.kt
@@ -9,6 +9,6 @@ data class PatchProfileResponse(
     val nickname: String? = null,
     @SerialName("selfIntroduction")
     val selfIntroduction: String? = null,
-    @SerialName("profileImage")
-    val profileImage: String? = null
+    @SerialName("profileImageUrl")
+    val profileImageUrl: String? = null,
 )

--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/home/HomeGalleryNavigator.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/home/HomeGalleryNavigator.kt
@@ -13,3 +13,15 @@ fun NavController.navigateToHomeGallery(navOptions: NavOptions?) = navigate(
     route = HomeGalleryNavigator,
     navOptions = navOptions,
 )
+
+fun NavController.setReportedPostId(postId: Int) {
+    this.previousBackStackEntry?.savedStateHandle?.set(savedStateHandleKey, postId)
+
+    popBackStack<HomeGalleryNavigator>(inclusive = false)
+}
+
+fun NavController.getReportedPostId(): Int =
+    this.currentBackStackEntry?.savedStateHandle?.get(savedStateHandleKey) ?: -1
+
+
+private const val savedStateHandleKey = "reported_post_id"

--- a/core/network/src/main/kotlin/com/captures2024/soongan/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/captures2024/soongan/core/network/di/NetworkModule.kt
@@ -17,6 +17,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
+import retrofit2.converter.scalars.ScalarsConverterFactory
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
@@ -87,6 +88,7 @@ internal object NetworkModule {
     fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit = Retrofit.Builder()
         .baseUrl(BuildConfig.CAPTURES_BASE_URL)
         .client(okHttpClient)
+        .addConverterFactory(ScalarsConverterFactory.create())
         .addConverterFactory(jsonConverterFactory)
         .build()
 }

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
@@ -85,8 +85,11 @@ constructor(
         data object OnBottomModalDismissRequest : Intent
 
         data object OnClickRegistrationText : Intent
-    }
 
+        data class HidePost(
+            val postId: Int,
+        ) : Intent
+    }
 
     init {
         intent(Intent.Init)
@@ -117,6 +120,8 @@ constructor(
             is Intent.OnClickSortFilter -> loadingLaunch { handleOnClickSortFilter(intent) }
 
             is Intent.OnClickRegistrationText -> handleOnClickRegistrationText()
+
+            is Intent.HidePost -> handleHidePost(intent)
         }
     }
 
@@ -193,7 +198,8 @@ constructor(
     ) {
         when (currentState.paginationStatus) {
             PaginationStatus.LOADING,
-            PaginationStatus.PAGINATING -> return
+            PaginationStatus.PAGINATING,
+            -> return
 
             else -> Unit
         }
@@ -248,6 +254,18 @@ constructor(
 
     private fun handleOnClickRegistrationText() {
         postSideEffect(Effect.NavigateToRegistrationPost)
+    }
+
+    private fun handleHidePost(intent: Intent.HidePost) {
+        val tempPosts = currentState.posts.toMutableList()
+
+        tempPosts.removeAll { it.postId == intent.postId }
+
+        reduce {
+            copy(posts = tempPosts.toList())
+        }
+
+        analyticsHelper.d(message = "reported post, postId : ${intent.postId}")
     }
 
     companion object {

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomePostViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomePostViewModel.kt
@@ -58,11 +58,15 @@ constructor(
         data class NavigateToHomePostPhoto(
             val url: String,
         ) : Effect
+
+        data class HidePostAfterReport(
+            val postId: Int,
+        ) : Effect
     }
 
     sealed interface Intent : UIIntent {
 
-        data object Init: Intent
+        data object Init : Intent
 
         data object OnClickBack : Intent
 
@@ -85,6 +89,10 @@ constructor(
         data object OnClickDeletePost : Intent
 
         data object OnClickReportPost : Intent
+
+        data class OnReportPost(
+            val postId: Int,
+        ) : Intent
     }
 
     init {
@@ -98,7 +106,7 @@ constructor(
     }
 
     override fun handleClientException(throwable: Throwable) {
-//        Timber.tag(TAG).e(throwable)
+        analyticsHelper.e(throwable = throwable)
     }
 
     override fun handleIntent(intent: Intent) {
@@ -124,23 +132,27 @@ constructor(
             is Intent.OnClickEditPost -> handleOnClickEditPost()
 
             is Intent.OnClickReportPost -> handleOnClickReportPost()
+
+            is Intent.OnReportPost ->
+                postSideEffect(Effect.HidePostAfterReport(intent.postId))
         }
     }
 
     private suspend fun handleInit() {
-        val postInfo = getPostInfoUseCase(currentState.postId).getOrNull()
-
-        if (postInfo == null) {
-            postSideEffect(Effect.NavigateToBack)
-            return
-        }
-
-        reduce {
-            copy(
-                postId = postInfo.postId,
-                post = postInfo,
-            )
-        }
+        return
+//        val postInfo = getPostInfoUseCase(currentState.postId).getOrNull()
+//
+//        if (postInfo == null) {
+//            postSideEffect(Effect.NavigateToBack)
+//            return
+//        }
+//
+//        reduce {
+//            copy(
+//                postId = postInfo.postId,
+//                post = postInfo,
+//            )
+//        }
     }
 
     private fun handleOnClickBack() {
@@ -201,9 +213,5 @@ constructor(
                 isOpenModal = HomePostBottomModalState.OPEN_REPORT,
             )
         }
-    }
-
-    companion object {
-        private const val TAG = "HomePostVM"
     }
 }

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/post/RegistrationPostViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/post/RegistrationPostViewModel.kt
@@ -207,8 +207,7 @@ constructor(
 
         val result = registerPostUseCase(
             params = RegisterPostUseCase.Params(
-                weeklyContestRound = 1,
-                subject = submitData.title,
+                title = submitData.title,
                 imageFile = submitData.currentMedia.toString(),
             )
         ).getOrNull() ?: -1

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/profile/ProfileEditViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/profile/ProfileEditViewModel.kt
@@ -8,8 +8,8 @@ import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
 import com.captures2024.soongan.core.domain.usecase.members.GetCurrentMemberFlowUseCase
-import com.captures2024.soongan.core.domain.usecase.members.IsVerifiedNicknameUseCase
 import com.captures2024.soongan.core.domain.usecase.members.PatchProfileUseCase
+import com.captures2024.soongan.core.model.exception.NetworkExceptionWrapper
 import com.captures2024.soongan.core.viewmodel.model.profile.EditingProfileState
 import com.captures2024.soongan.core.viewmodel.model.profile.UserProfile
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -22,7 +22,6 @@ constructor(
     private val analyticsHelper: AnalyticsHelper,
     private val getCurrentMemberFlowUseCase: GetCurrentMemberFlowUseCase,
     private val patchProfileUseCase: PatchProfileUseCase,
-    private val isVerifiedNicknameUseCase: IsVerifiedNicknameUseCase,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<ProfileEditViewModel.State, ProfileEditViewModel.Effect, ProfileEditViewModel.Intent>(
     savedStateHandle = savedStateHandle
@@ -122,6 +121,9 @@ constructor(
 
     private suspend fun initSet() {
         getCurrentMemberFlowUseCase().collect { currentMember ->
+
+            analyticsHelper.d(message = "currentMember Update? - currentMember: $currentMember")
+
             val userProfile = UserProfile(
                 nickname = currentMember?.nickname ?: "user1",
                 selfIntroduction = currentMember?.selfIntroduction ?: "본인을 소개해주세요",
@@ -219,53 +221,40 @@ constructor(
         }
     }
 
-    private fun onClickEditButton() = launch {
+    private suspend fun onClickEditButton() {
         val editedProfile = currentState.editingState.editingProfile
-        val isAllowNickname = isVerifiedNicknameUseCase(editedProfile.nickname).getOrNull()
 
-        analyticsHelper.d(message = "isAllowNickname : $isAllowNickname")
+        try {
+            val isPatchedProfile = patchProfileUseCase(
+                nickname = editedProfile.nickname,
+                selfIntroduction = editedProfile.selfIntroduction,
+                profileImageUrl = editedProfile.profileImageUrl,
+                isDefaultProfileImage = (editedProfile.profileImageUrl == null),
+            ).getOrThrow()
 
-        when (isAllowNickname) {
-            true -> {
-                val isPatchedProfile = patchProfileUseCase(
-                    nickname = editedProfile.nickname,
-                    selfIntroduction = editedProfile.selfIntroduction,
-                    profileImage = editedProfile.profileImageUrl,
-                ).onSuccess {
-                    reduce {
-                        copy(
-                            userProfile = editedProfile,
-                            isOpenBottomSheet = false
-                        )
-                    }
-                }
+            analyticsHelper.d(message = "Patch Profile result : $isPatchedProfile")
 
-                analyticsHelper.d(message = "Patch Profile result : $isPatchedProfile")
+            reduce { copy(isOpenBottomSheet = false) }
 
-                postSideEffect(Effect.NavigateToBack)
+            postSideEffect(Effect.NavigateToBack)
+
+        } catch (e: NetworkExceptionWrapper) {
+            reduce {
+                copy(
+                    editingState = editingState.copy(
+                        isEditable = false
+                    )
+                )
             }
 
-            false -> {
+            if (e.statusCode == 704) {
                 reduce {
                     copy(
                         editingState = editingState.copy(
-                            isEditable = false,
                             isDuplicatedNickname = true
                         )
                     )
                 }
-            }
-
-            null -> {
-                reduce {
-                    copy(
-                        editingState = editingState.copy(
-                            isEditable = false
-                        )
-                    )
-                }
-
-//                Toast.makeText(context, "not statusCode 200", Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/navigation/HomeNavigation.kt
@@ -20,6 +20,8 @@ fun NavGraphBuilder.home(
     navigateToGallery: () -> Unit,
     navigateToPost: (Int, NavOptions?) -> Unit,
     navigateToPostPhoto: (String) -> Unit,
+    setReportedPostId: (postId: Int) -> Unit,
+    getReportedPostId: () -> Int,
 ) {
     composable<HomeNavigator> {
         HomeRoute(
@@ -39,12 +41,14 @@ fun NavGraphBuilder.home(
             navigateToBack = navigateToBack,
             navigateToPost = navigateToPost,
             navigateToRegistrationPost = navigateToRegistrationPost,
+            getReportedPostId = getReportedPostId,
         )
     }
     composable<HomePostNavigator> {
         HomePostRoute(
             navigateToBack = navigateToBack,
-            navigateToHomePostPhoto = navigateToPostPhoto
+            navigateToHomePostPhoto = navigateToPostPhoto,
+            setReportedPostId = setReportedPostId,
         )
     }
     composable<HomePostPhotoNavigator> {

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/navigation/ReportRouteNavHost.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/navigation/ReportRouteNavHost.kt
@@ -19,7 +19,7 @@ import com.captures2024.soongan.feature.home.ui.post.report.ReportIdleScreen
 internal fun ReportRouteNavHost(
     reportRouteState: ReportRouteState,
     modifier: Modifier = Modifier,
-    closeSheet: () -> Unit,
+    reportPost: () -> Unit,
 ) {
     NavHost(
         modifier = modifier,
@@ -55,7 +55,7 @@ internal fun ReportRouteNavHost(
             ReportDoneScreen(
                 targetType = reportRouteState.targetType,
                 hasExtraMessage = hasExtraMessage,
-                onClickConfirm = closeSheet
+                onClickConfirm = reportPost
             )
         }
     }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomeGalleryRoute.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomeGalleryRoute.kt
@@ -5,9 +5,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavOptions
 import com.captures2024.soongan.core.viewmodel.home.HomeGalleryViewModel
+import com.captures2024.soongan.core.viewmodel.home.HomeGalleryViewModel.Effect
+import com.captures2024.soongan.core.viewmodel.home.HomeGalleryViewModel.Intent
 import com.captures2024.soongan.feature.home.ui.gallery.HomeGalleryBottomSheet
 import com.captures2024.soongan.feature.home.ui.gallery.HomeGalleryScreen
 
@@ -17,6 +21,7 @@ internal fun HomeGalleryRoute(
     navigateToBack: () -> Unit,
     navigateToPost: (Int, NavOptions?) -> Unit,
     navigateToRegistrationPost: () -> Unit,
+    getReportedPostId: () -> Int,
     homeGalleryViewModel: HomeGalleryViewModel = hiltViewModel(),
 ) {
     val uiState by homeGalleryViewModel.state.collectAsStateWithLifecycle()
@@ -24,28 +29,36 @@ internal fun HomeGalleryRoute(
     LaunchedEffect(key1 = Unit) {
         homeGalleryViewModel.sideEffect.collect { effect ->
             when (effect) {
-                is HomeGalleryViewModel.Effect.NavigateToHomePost -> navigateToPost(effect.postId, null)
+                is Effect.NavigateToHomePost -> navigateToPost(effect.postId, null)
 
-                is HomeGalleryViewModel.Effect.NavigateToRegistrationPost -> navigateToRegistrationPost()
+                is Effect.NavigateToRegistrationPost -> navigateToRegistrationPost()
             }
+        }
+    }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        val postId = getReportedPostId()
+
+        if (postId != -1) {
+            homeGalleryViewModel.intent(Intent.HidePost(postId))
         }
     }
 
     HomeGalleryScreen(
         uiState = uiState,
         onBackPressed = navigateToBack,
-        onRefresh = { homeGalleryViewModel.intent(HomeGalleryViewModel.Intent.RefreshGallery) },
-        onLoadNextPage = { homeGalleryViewModel.intent(HomeGalleryViewModel.Intent.LoadNextPage) },
-        onClickPost = { homeGalleryViewModel.intent(HomeGalleryViewModel.Intent.OnClickPost(it)) },
-        onClickFilter = { homeGalleryViewModel.intent(HomeGalleryViewModel.Intent.OnClickFilter) },
-        onClickRegistrationText = { homeGalleryViewModel.intent(HomeGalleryViewModel.Intent.OnClickRegistrationText) }
+        onRefresh = { homeGalleryViewModel.intent(Intent.RefreshGallery) },
+        onLoadNextPage = { homeGalleryViewModel.intent(Intent.LoadNextPage) },
+        onClickPost = { homeGalleryViewModel.intent(Intent.OnClickPost(it)) },
+        onClickFilter = { homeGalleryViewModel.intent(Intent.OnClickFilter) },
+        onClickRegistrationText = { homeGalleryViewModel.intent(Intent.OnClickRegistrationText) }
     )
 
     if (uiState.isShowBottomSheet) {
         HomeGalleryBottomSheet(
             uiState = uiState,
-            onDismissRequest = { homeGalleryViewModel.intent(HomeGalleryViewModel.Intent.OnBottomModalDismissRequest) },
-            onClickItem = { homeGalleryViewModel.intent(HomeGalleryViewModel.Intent.OnClickSortFilter(it)) },
+            onDismissRequest = { homeGalleryViewModel.intent(Intent.OnBottomModalDismissRequest) },
+            onClickItem = { homeGalleryViewModel.intent(Intent.OnClickSortFilter(it)) },
         )
     }
 }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomePostRoute.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomePostRoute.kt
@@ -1,6 +1,5 @@
 package com.captures2024.soongan.feature.home.route
 
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -11,11 +10,11 @@ import com.captures2024.soongan.core.viewmodel.home.HomePostViewModel
 import com.captures2024.soongan.core.viewmodel.home.HomePostViewModel.Effect
 import com.captures2024.soongan.core.viewmodel.home.HomePostViewModel.Intent
 import com.captures2024.soongan.core.viewmodel.model.HomePostBottomModalState
+import com.captures2024.soongan.feature.home.state.rememberReportRouteState
 import com.captures2024.soongan.feature.home.ui.post.HomePostMenuBottomSheetDialog
 import com.captures2024.soongan.feature.home.ui.post.HomePostScreen
 import com.captures2024.soongan.feature.home.ui.post.comment.HomePostCommentBottomSheetDialog
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun HomePostRoute(
     navigateToBack: () -> Unit,
@@ -24,6 +23,11 @@ internal fun HomePostRoute(
     homePostViewModel: HomePostViewModel = hiltViewModel(),
 ) {
     val uiState by homePostViewModel.state.collectAsStateWithLifecycle()
+
+    val reportRouteState = rememberReportRouteState(
+        targetId = uiState.postId.toLong(),
+        targetType = ReportTargetType.WEEKLY_POST
+    )
 
     LaunchedEffect(key1 = Unit) {
         homePostViewModel.sideEffect.collect { effect ->
@@ -57,8 +61,7 @@ internal fun HomePostRoute(
         )
 
         HomePostBottomModalState.OPEN_REPORT -> ReportRoute(
-            targetId = uiState.postId.toLong(),
-            targetType = ReportTargetType.WEEKLY_POST,
+            reportRouteState = reportRouteState,
             closeSheet = { homePostViewModel.intent(Intent.OnClosedModal) },
             reportPost = { homePostViewModel.intent(Intent.OnReportPost(uiState.postId)) }
         )

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomePostRoute.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomePostRoute.kt
@@ -8,6 +8,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.captures2024.soongan.core.model.utils.ReportTargetType
 import com.captures2024.soongan.core.viewmodel.home.HomePostViewModel
+import com.captures2024.soongan.core.viewmodel.home.HomePostViewModel.Effect
+import com.captures2024.soongan.core.viewmodel.home.HomePostViewModel.Intent
 import com.captures2024.soongan.core.viewmodel.model.HomePostBottomModalState
 import com.captures2024.soongan.feature.home.ui.post.HomePostMenuBottomSheetDialog
 import com.captures2024.soongan.feature.home.ui.post.HomePostScreen
@@ -18,6 +20,7 @@ import com.captures2024.soongan.feature.home.ui.post.comment.HomePostCommentBott
 internal fun HomePostRoute(
     navigateToBack: () -> Unit,
     navigateToHomePostPhoto: (String) -> Unit,
+    setReportedPostId: (postId: Int) -> Unit,
     homePostViewModel: HomePostViewModel = hiltViewModel(),
 ) {
     val uiState by homePostViewModel.state.collectAsStateWithLifecycle()
@@ -25,9 +28,11 @@ internal fun HomePostRoute(
     LaunchedEffect(key1 = Unit) {
         homePostViewModel.sideEffect.collect { effect ->
             when (effect) {
-                is HomePostViewModel.Effect.NavigateToBack -> navigateToBack()
+                is Effect.NavigateToBack -> navigateToBack()
 
-                is HomePostViewModel.Effect.NavigateToHomePostPhoto -> navigateToHomePostPhoto(effect.url)
+                is Effect.NavigateToHomePostPhoto -> navigateToHomePostPhoto(effect.url)
+
+                is Effect.HidePostAfterReport -> setReportedPostId(effect.postId)
             }
         }
     }
@@ -40,21 +45,22 @@ internal fun HomePostRoute(
     when (uiState.isOpenModal) {
         HomePostBottomModalState.OPEN_COMMENT -> HomePostCommentBottomSheetDialog(
             comment = uiState.inWritingComment,
-            closeSheet = { homePostViewModel.intent(HomePostViewModel.Intent.OnClosedModal) },
-            onCommentValueChanged = { homePostViewModel.intent(HomePostViewModel.Intent.OnCommentValueChanged(it)) }
+            closeSheet = { homePostViewModel.intent(Intent.OnClosedModal) },
+            onCommentValueChanged = { homePostViewModel.intent(Intent.OnCommentValueChanged(it)) }
         )
 
         HomePostBottomModalState.OPEN_MENU -> HomePostMenuBottomSheetDialog(
-            closeSheet = { homePostViewModel.intent(HomePostViewModel.Intent.OnClosedModal) },
-            onClickEdit = { homePostViewModel.intent(HomePostViewModel.Intent.OnClickEditPost) },
-            onClickDelete = { homePostViewModel.intent(HomePostViewModel.Intent.OnClickDeletePost) },
-            onClickReport = { homePostViewModel.intent(HomePostViewModel.Intent.OnClickReportPost) },
+            closeSheet = { homePostViewModel.intent(Intent.OnClosedModal) },
+            onClickEdit = { homePostViewModel.intent(Intent.OnClickEditPost) },
+            onClickDelete = { homePostViewModel.intent(Intent.OnClickDeletePost) },
+            onClickReport = { homePostViewModel.intent(Intent.OnClickReportPost) },
         )
 
         HomePostBottomModalState.OPEN_REPORT -> ReportRoute(
             targetId = uiState.postId.toLong(),
             targetType = ReportTargetType.WEEKLY_POST,
-            closeSheet = { homePostViewModel.intent(HomePostViewModel.Intent.OnClosedModal) },
+            closeSheet = { homePostViewModel.intent(Intent.OnClosedModal) },
+            reportPost = { homePostViewModel.intent(Intent.OnReportPost(uiState.postId)) }
         )
 
         HomePostBottomModalState.CLOSED -> Unit

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/ReportRoute.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/ReportRoute.kt
@@ -24,6 +24,7 @@ internal fun ReportRoute(
     targetId: Long,
     targetType: ReportTargetType,
     closeSheet: () -> Unit,
+    reportPost: () -> Unit,
     modifier: Modifier = Modifier,
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
 ) {
@@ -45,7 +46,7 @@ internal fun ReportRoute(
             ReportRouteNavHost(
                 reportRouteState = reportRouteState,
                 modifier = Modifier.fillMaxWidth(),
-                closeSheet = closeSheet
+                reportPost = reportPost
             )
         }
     }
@@ -66,6 +67,7 @@ private fun PostReportBottomSheetDialogPreview() {
         sheetState = sheetState,
         targetId = 0,
         targetType = ReportTargetType.WEEKLY_POST,
-        closeSheet = {}
+        closeSheet = {},
+        reportPost = {}
     )
 }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/ReportRoute.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/ReportRoute.kt
@@ -14,6 +14,7 @@ import com.captures2024.soongan.core.designsystem.theme.SGColor
 import com.captures2024.soongan.core.designsystem.util.DevicePreviews
 import com.captures2024.soongan.core.model.utils.ReportTargetType
 import com.captures2024.soongan.feature.home.navigation.ReportRouteNavHost
+import com.captures2024.soongan.feature.home.state.ReportRouteState
 import com.captures2024.soongan.feature.home.state.rememberReportRouteState
 import com.captures2024.soongan.feature.home.ui.post.report.component.CustomDragHandle
 import com.captures2024.soongan.feature.home.ui.post.report.component.ReportTopBar
@@ -21,18 +22,20 @@ import com.captures2024.soongan.feature.home.ui.post.report.component.ReportTopB
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun ReportRoute(
-    targetId: Long,
-    targetType: ReportTargetType,
+    reportRouteState: ReportRouteState,
     closeSheet: () -> Unit,
     reportPost: () -> Unit,
     modifier: Modifier = Modifier,
-    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
 ) {
-    val reportRouteState = rememberReportRouteState(targetId = targetId, targetType = targetType)
+    reportRouteState.ManageDisableDismissState()
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true,
+        confirmValueChange = { !reportRouteState.disableDismissState.value }
+    )
 
     ModalBottomSheet(
         modifier = modifier,
-        onDismissRequest = closeSheet,
+        onDismissRequest = { closeSheet() },
         sheetState = sheetState,
         containerColor = SGColor.white,
         dragHandle = @Composable { CustomDragHandle() }
@@ -64,9 +67,7 @@ private fun PostReportBottomSheetDialogPreview() {
     )
 
     ReportRoute(
-        sheetState = sheetState,
-        targetId = 0,
-        targetType = ReportTargetType.WEEKLY_POST,
+        reportRouteState = rememberReportRouteState(0, ReportTargetType.WEEKLY_POST),
         closeSheet = {},
         reportPost = {}
     )

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/state/ReportRouteState.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/state/ReportRouteState.kt
@@ -1,7 +1,9 @@
 package com.captures2024.soongan.feature.home.state
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
@@ -15,11 +17,13 @@ import com.captures2024.soongan.core.navigator.screen.main.report.ReportNavigato
 internal fun rememberReportRouteState(
     targetId: Long,
     targetType: ReportTargetType,
+    disableDismissState: MutableState<Boolean> = mutableStateOf(false),
     navController: NavHostController = rememberNavController(),
 ): ReportRouteState = remember(Unit) {
     ReportRouteState(
         targetId = targetId,
         targetType = targetType,
+        disableDismissState = disableDismissState,
         navController = navController,
     )
 }
@@ -29,6 +33,7 @@ internal fun rememberReportRouteState(
 internal class ReportRouteState(
     val targetId: Long,
     val targetType: ReportTargetType,
+    val disableDismissState: MutableState<Boolean>,
     val navController: NavHostController,
 ) {
     val isCheckRoute: Boolean
@@ -36,6 +41,14 @@ internal class ReportRouteState(
         get() = navController.currentBackStackEntryAsState().value?.destination?.hasRoute(
             ReportNavigator.Check::class
         ) ?: false
+
+    @Composable
+    fun ManageDisableDismissState() {
+        navController.currentBackStackEntryAsState().value?.destination?.run {
+            disableDismissState.value =
+                hasRoute(ReportNavigator.Check::class) || hasRoute(ReportNavigator.Done::class)
+        }
+    }
 
     fun popBackStack() = navController.popBackStack()
 

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/report/ReportDoneScreen.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/report/ReportDoneScreen.kt
@@ -1,5 +1,6 @@
 package com.captures2024.soongan.feature.home.ui.post.report
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -34,6 +35,8 @@ internal fun ReportDoneScreen(
     }
     val doneMessage =
         "${stringResource(id = R.string.report_done_text1)}$targetTypeText${stringResource(R.string.report_done_text2)}".trimIndent()
+
+    BackHandler(enabled = true, onBack = {})
 
     Column(
         modifier = modifier

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/report/component/ReportTopBar.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/post/report/component/ReportTopBar.kt
@@ -3,6 +3,7 @@ package com.captures2024.soongan.feature.home.ui.post.report.component
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
@@ -10,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.captures2024.soongan.core.designsystem.component.button.SGIconButton
@@ -32,6 +34,7 @@ internal fun ReportTopBar(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(horizontal = 16.dp)
                 .minimumInteractiveComponentSize(),
             contentAlignment = Alignment.Center
         ) {

--- a/feature/main/src/main/kotlin/com/captures2024/soongan/feature/main/navigation/MainRouteNavHost.kt
+++ b/feature/main/src/main/kotlin/com/captures2024/soongan/feature/main/navigation/MainRouteNavHost.kt
@@ -11,11 +11,13 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.navOptions
 import com.captures2024.soongan.core.navigator.screen.main.home.HomeNavigator
+import com.captures2024.soongan.core.navigator.screen.main.home.getReportedPostId
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHome
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHomeGallery
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHomePost
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHomePostPhoto
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToRegistrationPost
+import com.captures2024.soongan.core.navigator.screen.main.home.setReportedPostId
 import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToEditProfile
 import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToFAQ
 import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToNotification
@@ -62,7 +64,10 @@ internal fun MainRouteNavHost(
             navigateToRegistrationPost = navController::navigateToRegistrationPost,
             navigateToGallery = navController::navigateToHomeGallery,
             navigateToPost = navController::navigateToHomePost,
-            navigateToPostPhoto = navController::navigateToHomePostPhoto
+            navigateToPostPhoto = navController::navigateToHomePostPhoto,
+            setReportedPostId = navController::setReportedPostId,
+            getReportedPostId = navController::getReportedPostId,
+
         )
         feed()
         awards()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -192,6 +192,7 @@ okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-intercepto
 
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-kotlin-serialization-converter = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "kotlin-serialization-converter" }
+converter-scalars = { group = "com.squareup.retrofit2", name = "converter-scalars", version.ref = "retrofit" }
 
 kakao-login = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakao" }
 javax-inject = { group = "javax.inject", name = "javax.inject", version.ref = "javax-inject" }
@@ -273,7 +274,8 @@ compose = [
 
 retrofit = [
     "retrofit",
-    "retrofit-kotlin-serialization-converter"
+    "retrofit-kotlin-serialization-converter",
+    "converter-scalars"
 ]
 
 junit5 = [


### PR DESCRIPTION
# [SG-103] 신고 후 게시물 hide 및 수정된 api 동기화

## 작업 사항
- list 내 신고된 post element 삭제 처리
- 신고 도중 바텀시트 닫히지 않도록 UI 작업
- 수정된 api 동기화 
  - report api - reportType 요청/응답 일치
  - registerPost api - param 변경(subject -> title)
  - patchProfile api - 기본 프로필 param, 중복 닉네임 체크 추가

## GIF
|신고 처리|프로필 변경|
|---|---|
|![report_api](https://github.com/user-attachments/assets/3992ff59-1115-4fbe-9acb-91f2ef677fbc)|![patch_profile_api](https://github.com/user-attachments/assets/cb6e64a1-faec-4d26-b449-88fca332fe30)|

## 추가
MultiPart form-data 형식에서 File을 제외한 Type은 그대로 보낼 수 있도록 scalar-converter를 추가했어요.
```kotlin
// before
@Part("selfIntroduction") selfIntroduction: RequestBody?
// after
@Part("selfIntroduction") selfIntroduction: String?
```


[SG-103]: https://captures2024.atlassian.net/browse/SG-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ