### PR TITLE
[feat] firebase crashlytics 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.captures2024.soongan.retrofit)
     alias(libs.plugins.captures2024.soongan.test.junit5)
     alias(libs.plugins.captures2024.soongan.test.kotest)
+    alias(libs.plugins.google.crashlytics)
 }
 
 android {
@@ -87,6 +88,8 @@ dependencies {
     implementation(projects.feature.signUp)
     implementation(projects.feature.termsOfUse)
     implementation(projects.feature.welcome)
+
+    implementation(libs.google.firebase.crashlytics)
 
     implementation(libs.android.startup)
     implementation(libs.kakao.login)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -249,7 +249,6 @@ navigation = [
 firebase = [
     "google-firebase-auth",
     "google-firebase-analytics",
-#    "google-firebase-crashlytics",
     "google-firebase-messaging"
 ]
 


### PR DESCRIPTION
# [feat] firebase crashlytics 연동

## 기능
- 파이어베이스 콘솔 에러 연동

### Commit
- feat: add firebase crashlytics

## 비고
프로가드 설정의 경우 `isMinifyEnabled = true` 하고 좀 찾아보면서 진행을 하고 있는데 오류가 상당해서 시간이 걸리거나
차주까지 연동될 것 같아서 일단 작업량이 적어도 분리해서 전달드립니다