### PR TITLE
[Modify] 화면 일부 flow 수정

### DIFF
--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomePostViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomePostViewModel.kt
@@ -239,6 +239,12 @@ constructor(
                 )
             }
         }
+
+        reduce {
+            copy(
+                isLikedChanged = false,
+            )
+        }
     }
 
     private fun handleOnClickMenu() {

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/RegistrationPostRoute.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/RegistrationPostRoute.kt
@@ -13,6 +13,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.navOptions
 import com.captures2024.soongan.core.android.utils.LocalAnalyticsHelper
 import com.captures2024.soongan.core.designsystem.ui.component.dialog.SGDoubleButtonDialog
+import com.captures2024.soongan.core.navigator.screen.main.home.RegistrationPostNavigator
 import com.captures2024.soongan.core.viewmodel.post.RegistrationPostViewModel
 import com.captures2024.soongan.feature.home.ui.registration_post.RegistrationPostScreen
 import com.captures2024.soongan.feature.home.ui.registration_post.SubmitBottomSheetDialog
@@ -46,7 +47,9 @@ internal fun RegistrationPostRoute(
                 is RegistrationPostViewModel.Effect.NavigateToPost -> navigateToPost(
                     sideEffect.postId,
                     navOptions {
-                        popUpTo(0)
+                        popUpTo(RegistrationPostNavigator) {
+                            inclusive = true
+                        }
                     },
                 )
             }

--- a/feature/main/src/main/kotlin/com/captures2024/soongan/feature/main/navigation/MainRouteNavHost.kt
+++ b/feature/main/src/main/kotlin/com/captures2024/soongan/feature/main/navigation/MainRouteNavHost.kt
@@ -52,7 +52,9 @@ internal fun MainRouteNavHost(
         welcome(
             navigateToHome = {
                 val navOptions = navOptions {
-                    popUpTo(navController.graph.findStartDestination().id)
+                    popUpTo(navController.graph.findStartDestination().id) {
+                        inclusive = true
+                    }
                     launchSingleTop = true
                     restoreState = true
                 }


### PR DESCRIPTION
## 작업 사항
- (게시글 등록 -> 게시글 -> 뒤로가기 -> 앱 종료) flow에서 
   ( ... 뒤로가기 -> 홈) 수정

- 게시글 -> 좋아요 취소 -> 수정 -> 게시글 -> 뒤로가기 시, likecount -2 되는 현상
   게시글 화면 전환 시, isLikedChanged false 변경
   
- 홈에서 뒤로가기 시 welcome 화면 제거

## 비고
기본 프로필 변경 시, null을 필드에서 제거해야 한다는 조건이 백엔드에서 수정되어 정상 작동합니다.