### PR TITLE
[SG-113] 신고 관련 api 변경 사항 적용

### DIFF
--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/MembersMapper.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/MembersMapper.kt
@@ -23,4 +23,5 @@ fun GetMemberInfoResponse.toUserInfoDto(): UserInfoDto = UserInfoDto(
     birthYear = this.birthYear,
     profileImageUrl = this.profileImageUrl,
     selfIntroduction = this.selfIntroduction,
+    reportHistories = this.reportHistories.map { it.toReportHistoryDto() },
 )

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/NotificationsMapper.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/NotificationsMapper.kt
@@ -1,9 +1,9 @@
 package com.captures2024.soongan.core.data.mapper
 
-import com.captures2024.soongan.core.model.Notification
-import com.captures2024.soongan.core.model.NotificationCountItem
-import com.captures2024.soongan.core.model.dto.NotificationsCountDto
-import com.captures2024.soongan.core.model.dto.NotificationsDto
+import com.captures2024.soongan.core.model.dto.NotificationDto
+import com.captures2024.soongan.core.model.dto.NotificationCountDto
+import com.captures2024.soongan.core.model.dto.NotificationsCountInfoDto
+import com.captures2024.soongan.core.model.dto.NotificationsInfoDto
 import com.captures2024.soongan.core.model.network.response.notifications.GetNotificationsCountResponse
 import com.captures2024.soongan.core.model.network.response.notifications.GetNotificationsResponse
 import com.captures2024.soongan.core.model.network.response.notifications.NotificationCountResponse
@@ -11,19 +11,19 @@ import com.captures2024.soongan.core.model.network.response.notifications.Notifi
 import com.captures2024.soongan.core.model.utils.NotificationSubType
 import com.captures2024.soongan.core.model.utils.NotificationType
 
-fun GetNotificationsResponse.toNotificationsDto(): NotificationsDto =
-    NotificationsDto(
+fun GetNotificationsResponse.toNotificationsDto(): NotificationsInfoDto =
+    NotificationsInfoDto(
         type = NotificationType.valueOf(type),
         notifications = notificationResponses.map { it.toNotification() },
     )
 
-fun GetNotificationsCountResponse.toNotificationsCountDto(): NotificationsCountDto =
-    NotificationsCountDto(
+fun GetNotificationsCountResponse.toNotificationsCountDto(): NotificationsCountInfoDto =
+    NotificationsCountInfoDto(
         notificationCountItems = this.map { it.toNotificationCountItem() },
     )
 
-private fun NotificationResponse.toNotification(): Notification =
-    Notification(
+private fun NotificationResponse.toNotification(): NotificationDto =
+    NotificationDto(
         id = id,
         title = title,
         body = body,
@@ -33,8 +33,8 @@ private fun NotificationResponse.toNotification(): Notification =
         createdAt = createdAt,
     )
 
-private fun NotificationCountResponse.toNotificationCountItem(): NotificationCountItem =
-    NotificationCountItem(
+private fun NotificationCountResponse.toNotificationCountItem(): NotificationCountDto =
+    NotificationCountDto(
         count = count,
         type = NotificationType.valueOf(type),
     )

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/ReportMapper.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/ReportMapper.kt
@@ -13,7 +13,7 @@ fun PostReportResponse.toReportInfoDto(): ReportInfoDto = ReportInfoDto(
     targetType = targetType,
     reportType = reportType,
     reason = reason,
-    reportHistories = reportHistories.map { it.toReportHistoryDto() }
+    reportHistories = reportHistories.map { it.toReportHistoryDto() },
 )
 
 fun ReportHistoryResponse.toReportHistoryDto(): ReportHistoryDto = ReportHistoryDto(

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/ReportMapper.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/ReportMapper.kt
@@ -1,7 +1,9 @@
 package com.captures2024.soongan.core.data.mapper
 
+import com.captures2024.soongan.core.model.dto.ReportHistoryDto
 import com.captures2024.soongan.core.model.dto.ReportInfoDto
 import com.captures2024.soongan.core.model.network.response.report.PostReportResponse
+import com.captures2024.soongan.core.model.network.response.report.ReportHistoryResponse
 
 fun PostReportResponse.toReportInfoDto(): ReportInfoDto = ReportInfoDto(
     id = id,
@@ -11,4 +13,11 @@ fun PostReportResponse.toReportInfoDto(): ReportInfoDto = ReportInfoDto(
     targetType = targetType,
     reportType = reportType,
     reason = reason,
+    reportHistories = reportHistories.map { it.toReportHistoryDto() }
+)
+
+fun ReportHistoryResponse.toReportHistoryDto(): ReportHistoryDto = ReportHistoryDto(
+    id = id,
+    targetId = targetId,
+    targetType = targetType,
 )

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/NotificationsDataSource.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/NotificationsDataSource.kt
@@ -1,16 +1,16 @@
 package com.captures2024.soongan.core.data.remote
 
-import com.captures2024.soongan.core.model.dto.NotificationsCountDto
-import com.captures2024.soongan.core.model.dto.NotificationsDto
+import com.captures2024.soongan.core.model.dto.NotificationsCountInfoDto
+import com.captures2024.soongan.core.model.dto.NotificationsInfoDto
 import com.captures2024.soongan.core.model.utils.NotificationType
 
 interface NotificationsDataSource {
 
     suspend fun getNotifications(
         type: NotificationType,
-    ): NotificationsDto?
+    ): NotificationsInfoDto?
 
-    suspend fun getNotificationsCount(): NotificationsCountDto?
+    suspend fun getNotificationsCount(): NotificationsCountInfoDto?
 
     suspend fun postNotificationRead(
         notificationId: Long,

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/NotificationsDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/remote/impl/NotificationsDataSourceImpl.kt
@@ -5,8 +5,8 @@ import com.captures2024.soongan.core.data.mapper.toNotificationsDto
 import com.captures2024.soongan.core.data.remote.NotificationsDataSource
 import com.captures2024.soongan.core.data.service.NotificationsService
 import com.captures2024.soongan.core.data.utils.safeAPICall
-import com.captures2024.soongan.core.model.dto.NotificationsCountDto
-import com.captures2024.soongan.core.model.dto.NotificationsDto
+import com.captures2024.soongan.core.model.dto.NotificationsCountInfoDto
+import com.captures2024.soongan.core.model.dto.NotificationsInfoDto
 import com.captures2024.soongan.core.model.utils.NotificationType
 import javax.inject.Inject
 
@@ -16,11 +16,11 @@ constructor(
     private val service: NotificationsService,
 ) : NotificationsDataSource {
 
-    override suspend fun getNotifications(type: NotificationType): NotificationsDto? = safeAPICall {
+    override suspend fun getNotifications(type: NotificationType): NotificationsInfoDto? = safeAPICall {
         service.getNotifications(type = type.name)
     }.body?.responseData?.toNotificationsDto()
 
-    override suspend fun getNotificationsCount(): NotificationsCountDto? = safeAPICall {
+    override suspend fun getNotificationsCount(): NotificationsCountInfoDto? = safeAPICall {
         service.getNotificationsCount()
     }.body?.responseData?.toNotificationsCountDto()
 

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/MembersRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/MembersRepository.kt
@@ -1,5 +1,6 @@
 package com.captures2024.soongan.core.data.repository
 
+import com.captures2024.soongan.core.model.dto.ReportHistoryDto
 import com.captures2024.soongan.core.model.dto.ResultConditionDto
 import com.captures2024.soongan.core.model.dto.UserInfoDto
 import kotlinx.coroutines.flow.StateFlow
@@ -28,6 +29,8 @@ interface MembersRepository {
     suspend fun getMemberInfo(): UserInfoDto
 
     suspend fun isVerifiedNickname(nickname: String): ResultConditionDto
+
+    suspend fun updateReportHistories(histories: List<ReportHistoryDto>)
 
     suspend fun clearCurrentMember()
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/NotificationsRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/NotificationsRepository.kt
@@ -1,16 +1,16 @@
 package com.captures2024.soongan.core.data.repository
 
-import com.captures2024.soongan.core.model.dto.NotificationsCountDto
-import com.captures2024.soongan.core.model.dto.NotificationsDto
+import com.captures2024.soongan.core.model.dto.NotificationsCountInfoDto
+import com.captures2024.soongan.core.model.dto.NotificationsInfoDto
 import com.captures2024.soongan.core.model.utils.NotificationType
 
 interface NotificationsRepository {
 
     suspend fun getNotifications(
         type: NotificationType,
-    ): NotificationsDto
+    ): NotificationsInfoDto
 
-    suspend fun getNotificationsCount(): NotificationsCountDto
+    suspend fun getNotificationsCount(): NotificationsCountInfoDto
 
     suspend fun postNotificationRead(
         notificationId: Long,

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/ReportRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/ReportRepository.kt
@@ -1,6 +1,6 @@
 package com.captures2024.soongan.core.data.repository
 
-import com.captures2024.soongan.core.model.dto.ResultConditionDto
+import com.captures2024.soongan.core.model.dto.ReportInfoDto
 import com.captures2024.soongan.core.model.utils.ReportTargetType
 import com.captures2024.soongan.core.model.utils.ReportType
 
@@ -11,5 +11,5 @@ interface ReportRepository {
         targetType: ReportTargetType,
         reportType: ReportType,
         reason: String?,
-    ): ResultConditionDto
+    ): ReportInfoDto
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/MembersRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/MembersRepositoryImpl.kt
@@ -3,11 +3,13 @@ package com.captures2024.soongan.core.data.repository.impl
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.data.remote.MembersDataSource
 import com.captures2024.soongan.core.data.repository.MembersRepository
+import com.captures2024.soongan.core.model.dto.ReportHistoryDto
 import com.captures2024.soongan.core.model.dto.ResultConditionDto
 import com.captures2024.soongan.core.model.dto.UserInfoDto
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 class MembersRepositoryImpl
@@ -98,6 +100,12 @@ constructor(
         return resultConditionDto
             ?.also { analyticsHelper.d { "isVerifiedNickname - resultConditionDto: $resultConditionDto" } }
             ?: throw NullPointerException("resultConditionDto is null")
+    }
+
+    override suspend fun updateReportHistories(histories: List<ReportHistoryDto>) {
+        _currentMember.update { currentMember ->
+            currentMember?.copy(reportHistories = histories)
+        }
     }
 
     override suspend fun clearCurrentMember() = _currentMember.emit(null)

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/NotificationsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/NotificationsRepositoryImpl.kt
@@ -3,8 +3,8 @@ package com.captures2024.soongan.core.data.repository.impl
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.data.remote.impl.NotificationsDataSourceImpl
 import com.captures2024.soongan.core.data.repository.NotificationsRepository
-import com.captures2024.soongan.core.model.dto.NotificationsCountDto
-import com.captures2024.soongan.core.model.dto.NotificationsDto
+import com.captures2024.soongan.core.model.dto.NotificationsCountInfoDto
+import com.captures2024.soongan.core.model.dto.NotificationsInfoDto
 import com.captures2024.soongan.core.model.utils.NotificationType
 import javax.inject.Inject
 
@@ -19,13 +19,13 @@ constructor(
         analyticsHelper.d { "NotificationsRepository:init" }
     }
 
-    override suspend fun getNotifications(type: NotificationType): NotificationsDto {
+    override suspend fun getNotifications(type: NotificationType): NotificationsInfoDto {
         val notifications = dataSourceImpl.getNotifications(type = type)
 
         return notifications ?: throw NullPointerException("notificationsDto is null")
     }
 
-    override suspend fun getNotificationsCount(): NotificationsCountDto {
+    override suspend fun getNotificationsCount(): NotificationsCountInfoDto {
         val notificationsCount = dataSourceImpl.getNotificationsCount()
 
         return notificationsCount

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/ReportRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/ReportRepositoryImpl.kt
@@ -3,7 +3,7 @@ package com.captures2024.soongan.core.data.repository.impl
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.data.remote.ReportDataSource
 import com.captures2024.soongan.core.data.repository.ReportRepository
-import com.captures2024.soongan.core.model.dto.ResultConditionDto
+import com.captures2024.soongan.core.model.dto.ReportInfoDto
 import com.captures2024.soongan.core.model.utils.ReportTargetType
 import com.captures2024.soongan.core.model.utils.ReportType
 import javax.inject.Inject
@@ -24,7 +24,7 @@ constructor(
         targetType: ReportTargetType,
         reportType: ReportType,
         reason: String?,
-    ): ResultConditionDto {
+    ): ReportInfoDto {
         val reportInfo = dataSource.postReport(
             targetId = targetId,
             targetType = targetType,
@@ -40,9 +40,9 @@ constructor(
             targetType.name != reportInfo.targetType ||
             reportType.name != reportInfo.reportType ||
             reason != reportInfo.reason) {
-            return ResultConditionDto(result = false)
+            error("mismatch between request and response data")
         }
 
-        return ResultConditionDto(result = true)
+        return reportInfo
     }
 }

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/notifications/GetNotificationsCountUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/notifications/GetNotificationsCountUseCase.kt
@@ -2,7 +2,7 @@ package com.captures2024.soongan.core.domain.usecase.notifications
 
 import com.captures2024.soongan.core.data.repository.NotificationsRepository
 import com.captures2024.soongan.core.domain.runSuspendCatching
-import com.captures2024.soongan.core.model.dto.NotificationsCountDto
+import com.captures2024.soongan.core.model.dto.NotificationsCountInfoDto
 import javax.inject.Inject
 
 class GetNotificationsCountUseCase
@@ -11,7 +11,7 @@ constructor(
     private val repository: NotificationsRepository,
 ) {
 
-    suspend operator fun invoke(): Result<NotificationsCountDto> = runSuspendCatching {
+    suspend operator fun invoke(): Result<NotificationsCountInfoDto> = runSuspendCatching {
         val notificationsCountDto = repository.getNotificationsCount()
 
         return@runSuspendCatching notificationsCountDto

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/notifications/GetNotificationsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/notifications/GetNotificationsUseCase.kt
@@ -2,7 +2,7 @@ package com.captures2024.soongan.core.domain.usecase.notifications
 
 import com.captures2024.soongan.core.data.repository.NotificationsRepository
 import com.captures2024.soongan.core.domain.runSuspendCatching
-import com.captures2024.soongan.core.model.dto.NotificationsDto
+import com.captures2024.soongan.core.model.dto.NotificationsInfoDto
 import com.captures2024.soongan.core.model.utils.NotificationType
 import javax.inject.Inject
 
@@ -12,7 +12,7 @@ constructor(
     private val repository: NotificationsRepository,
 ) {
 
-    suspend operator fun invoke(type: NotificationType): Result<NotificationsDto> = runSuspendCatching {
+    suspend operator fun invoke(type: NotificationType): Result<NotificationsInfoDto> = runSuspendCatching {
         val notificationsDto = repository.getNotifications(type = type)
 
         return@runSuspendCatching notificationsDto.copy(

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/report/PostReportUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/report/PostReportUseCase.kt
@@ -1,5 +1,7 @@
 package com.captures2024.soongan.core.domain.usecase.report
 
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.data.repository.MembersRepository
 import com.captures2024.soongan.core.data.repository.ReportRepository
 import com.captures2024.soongan.core.domain.runSuspendCatching
 import com.captures2024.soongan.core.model.utils.ReportTargetType
@@ -9,18 +11,24 @@ import javax.inject.Inject
 class PostReportUseCase
 @Inject
 constructor(
-    private val repository: ReportRepository,
+    private val analyticsHelper: AnalyticsHelper,
+    private val reportRepository: ReportRepository,
+    private val membersRepository: MembersRepository,
 ) {
 
     suspend operator fun invoke(params: Params): Result<Boolean> = runSuspendCatching {
-        val resultConditionDto = repository.postReport(
+        val reportInfoDto = reportRepository.postReport(
             targetId = params.targetId,
             targetType = params.targetType,
             reportType = params.reportType,
             reason = params.reason,
         )
 
-        return@runSuspendCatching resultConditionDto.result
+        membersRepository.updateReportHistories(reportInfoDto.reportHistories)
+
+        analyticsHelper.d { "currentMember reportHistories : ${membersRepository.currentMember.value?.reportHistories}" }
+
+        return@runSuspendCatching true
     }
 
     data class Params(

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/NotificationCountDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/NotificationCountDto.kt
@@ -1,8 +1,8 @@
-package com.captures2024.soongan.core.model
+package com.captures2024.soongan.core.model.dto
 
 import com.captures2024.soongan.core.model.utils.NotificationType
 
-data class NotificationCountItem(
+data class NotificationCountDto(
     val count: Int = 0,
     val type: NotificationType = NotificationType.CONTEST,
 )

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/NotificationDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/NotificationDto.kt
@@ -1,8 +1,8 @@
-package com.captures2024.soongan.core.model
+package com.captures2024.soongan.core.model.dto
 
 import com.captures2024.soongan.core.model.utils.NotificationSubType
 
-data class Notification(
+data class NotificationDto(
     val id: Long = -1,
     val title: String = "",
     val body: String = "",
@@ -10,9 +10,9 @@ data class Notification(
     val isRead: Boolean = false,
     val redirectUrl: String? = null,
     val createdAt: String = "",
-) : Comparable<Notification> {
+) : Comparable<NotificationDto> {
 
-    override fun compareTo(other: Notification): Int {
+    override fun compareTo(other: NotificationDto): Int {
         // 1. 소명 알림 순
         val thisAppeal = (this.subType == NotificationSubType.APPEAL)
         val otherAppeal = (other.subType == NotificationSubType.APPEAL)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/NotificationsCountDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/NotificationsCountDto.kt
@@ -1,7 +1,0 @@
-package com.captures2024.soongan.core.model.dto
-
-import com.captures2024.soongan.core.model.NotificationCountItem
-
-data class NotificationsCountDto(
-    val notificationCountItems: List<NotificationCountItem> = emptyList(),
-)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/NotificationsCountInfoDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/NotificationsCountInfoDto.kt
@@ -1,0 +1,5 @@
+package com.captures2024.soongan.core.model.dto
+
+data class NotificationsCountInfoDto(
+    val notificationCountItems: List<NotificationCountDto> = emptyList(),
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/NotificationsInfoDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/NotificationsInfoDto.kt
@@ -1,9 +1,8 @@
 package com.captures2024.soongan.core.model.dto
 
-import com.captures2024.soongan.core.model.Notification
 import com.captures2024.soongan.core.model.utils.NotificationType
 
-data class NotificationsDto(
+data class NotificationsInfoDto(
     val type: NotificationType = NotificationType.CONTEST,
-    val notifications: List<Notification> = emptyList(),
+    val notifications: List<NotificationDto> = emptyList(),
 )

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/ReportHistoryDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/ReportHistoryDto.kt
@@ -1,0 +1,7 @@
+package com.captures2024.soongan.core.model.dto
+
+data class ReportHistoryDto(
+    val id: Long,
+    val targetId: Long,
+    val targetType: String,
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/ReportInfoDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/ReportInfoDto.kt
@@ -8,4 +8,5 @@ data class ReportInfoDto(
     val targetType: String,
     val reportType: String,
     val reason: String? = null,
+    val reportHistories: List<ReportHistoryDto>,
 )

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/UserInfoDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/UserInfoDto.kt
@@ -6,6 +6,7 @@ data class UserInfoDto(
     val birthYear: Int? = null,
     val selfIntroduction: String? = null,
     val profileImageUrl: String? = null,
+    val reportHistories: List<ReportHistoryDto> = emptyList(),
 ) {
 
     companion object {

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/mock/MockUpData.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/mock/MockUpData.kt
@@ -1,6 +1,6 @@
 package com.captures2024.soongan.core.model.mock
 
-import com.captures2024.soongan.core.model.Notification
+import com.captures2024.soongan.core.model.dto.NotificationDto
 import com.captures2024.soongan.core.model.UserPost
 import com.captures2024.soongan.core.model.utils.NotificationSubType
 import com.captures2024.soongan.core.model.utils.NotificationType
@@ -148,23 +148,23 @@ val mockNotificationsTable: NotificationsTable by lazy {
         index to notification
     }.toMap()
 
-    EnumMap<NotificationType, Map<Int, Notification>>(NotificationType::class.java).apply {
+    EnumMap<NotificationType, Map<Int, NotificationDto>>(NotificationType::class.java).apply {
         put(NotificationType.CONTEST, tempContestNotifications)
         put(NotificationType.ACTIVITY, tempActivityNotifications)
         put(NotificationType.NOTICE, tempNoticeNotifications)
     }
 }
 
-val mockContestNotifications: List<Notification> by lazy {
+val mockContestNotifications: List<NotificationDto> by lazy {
     listOf(
-        Notification(
+        NotificationDto(
             id = 1,
             title = "CONTEST_START",
             body = "CONTEST_START",
             subType = NotificationSubType.CONTEST_START,
             createdAt = "1",
         ),
-        Notification(
+        NotificationDto(
             id = 2,
             title = "CONTEST_END",
             body = "CONTEST_END",
@@ -174,23 +174,23 @@ val mockContestNotifications: List<Notification> by lazy {
     )
 }
 
-private val mockActivityNotifications: List<Notification> by lazy {
+private val mockActivityNotifications: List<NotificationDto> by lazy {
     listOf(
-        Notification(
+        NotificationDto(
             id = 3,
             title = "LIKE",
             body = "LIKE",
             subType = NotificationSubType.LIKE,
             createdAt = "1",
         ),
-        Notification(
+        NotificationDto(
             id = 4,
             title = "COMMENT",
             body = "COMMENT",
             subType = NotificationSubType.COMMENT,
             createdAt = "2",
         ),
-        Notification(
+        NotificationDto(
             id = 5,
             title = "APPEAL",
             body = "APPEAL",
@@ -200,16 +200,16 @@ private val mockActivityNotifications: List<Notification> by lazy {
     )
 }
 
-private val mockNoticeNotifications: List<Notification> by lazy {
+private val mockNoticeNotifications: List<NotificationDto> by lazy {
     listOf(
-        Notification(
+        NotificationDto(
             id = 6,
             title = "NOTICE",
             body = "NOTICE",
             subType = NotificationSubType.NOTICE,
             createdAt = "1",
         ),
-        Notification(
+        NotificationDto(
             id = 7,
             title = "NOTICE",
             body = "NOTICE",

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/members/GetMemberInfoResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/members/GetMemberInfoResponse.kt
@@ -1,5 +1,6 @@
 package com.captures2024.soongan.core.model.network.response.members
 
+import com.captures2024.soongan.core.model.network.response.report.ReportHistoryResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -15,4 +16,6 @@ data class GetMemberInfoResponse(
     val profileImageUrl: String? = null,
     @SerialName("selfIntroduction")
     val selfIntroduction: String? = null,
+    @SerialName("reportHistories")
+    val reportHistories: List<ReportHistoryResponse> = emptyList(),
 )

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/report/PostReportResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/report/PostReportResponse.kt
@@ -19,4 +19,6 @@ data class PostReportResponse(
     val reportType: String,
     @SerialName("reason")
     val reason: String? = null,
+    @SerialName("reportHistories")
+    val reportHistories: List<ReportHistoryResponse>,
 )

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/report/ReportHistoryResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/report/ReportHistoryResponse.kt
@@ -1,0 +1,14 @@
+package com.captures2024.soongan.core.model.network.response.report
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReportHistoryResponse(
+    @SerialName("id")
+    val id: Long,
+    @SerialName("targetId")
+    val targetId: Long,
+    @SerialName("targetType")
+    val targetType: String,
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/utils/TypeAlias.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/utils/TypeAlias.kt
@@ -1,7 +1,7 @@
 package com.captures2024.soongan.core.model.utils
 
-import com.captures2024.soongan.core.model.Notification
+import com.captures2024.soongan.core.model.dto.NotificationDto
 
-typealias NotificationsTable = Map<NotificationType, Map<Int, Notification>>
+typealias NotificationsTable = Map<NotificationType, Map<Int, NotificationDto>>
 
 typealias NotificationsCountTable = Map<NotificationType, Int>

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
@@ -134,7 +134,7 @@ constructor(
     }
 
     private suspend fun handleInit() {
-        launch { fetchReportHistories() }
+        launch { handleReportHistoriesFlow() }
         fetchPostPage(page = 0)
     }
 
@@ -201,7 +201,7 @@ constructor(
         }
     }
 
-    private suspend fun fetchReportHistories() {
+    private suspend fun handleReportHistoriesFlow() {
         getCurrentMemberFlowUseCase()
             .map { it?.reportHistories ?: emptyList() }
             .distinctUntilChanged()
@@ -257,13 +257,8 @@ constructor(
             return
         }
 
-        val galleryPosts = when (isInitPage) {
-            false -> galleryDto.posts
-            true -> {
-                val reportHistories = getCurrentMemberFlowUseCase().first()?.reportHistories
-                filterReportedPosts(posts = galleryDto.posts, reportHistories = reportHistories)
-            }
-        }
+        val reportHistories = getCurrentMemberFlowUseCase().first()?.reportHistories
+        val galleryPosts = filterReportedPosts(posts = galleryDto.posts, reportHistories = reportHistories)
 
         analyticsHelper.d { "galleryDto posts are $galleryPosts" }
 

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
@@ -9,20 +9,26 @@ import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDia
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetCurrentMemberFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetGalleryUseCase
 import com.captures2024.soongan.core.model.dto.GalleryPostDto
+import com.captures2024.soongan.core.model.dto.ReportHistoryDto
+import com.captures2024.soongan.core.model.utils.ReportTargetType
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
 import com.captures2024.soongan.core.viewmodel.model.PaginationStatus
 import com.captures2024.soongan.core.viewmodel.model.PostOrderType
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeGalleryViewModel
 @Inject
 constructor(
+    private val getCurrentMemberFlowUseCase: GetCurrentMemberFlowUseCase,
     private val getGalleryUseCase: GetGalleryUseCase,
     analyticsHelper: AnalyticsHelper,
     showLoadingUseCase: ShowLoadingUseCase,
@@ -128,6 +134,7 @@ constructor(
     }
 
     private suspend fun handleInit() {
+        launch { fetchReportHistories() }
         fetchPostPage(page = 0)
     }
 
@@ -194,6 +201,24 @@ constructor(
         }
     }
 
+    private suspend fun fetchReportHistories() {
+        getCurrentMemberFlowUseCase()
+            .map { it?.reportHistories ?: emptyList() }
+            .distinctUntilChanged()
+            .collect { currentReportHistories ->
+                val filteredPost = filterReportedPosts(
+                    posts = currentState.posts,
+                    reportHistories = currentReportHistories
+                )
+
+                reduce {
+                    copy(
+                        posts = filteredPost
+                    )
+                }
+            }
+    }
+
     private suspend fun fetchPostPage(
         page: Int = 0,
         isRefreshing: Boolean = false,
@@ -209,8 +234,6 @@ constructor(
         val isInitPage = (page == 0)
 
         setUpLoading(isInitPage = isInitPage, isRefreshing = isRefreshing)
-
-        delay(2_000)
 
         val galleryDto = getGalleryUseCase(
             params = GetGalleryUseCase.Params(
@@ -234,7 +257,15 @@ constructor(
             return
         }
 
-        analyticsHelper.d { "galleryDto is ${galleryDto.posts}" }
+        val galleryPosts = when (isInitPage) {
+            false -> galleryDto.posts
+            true -> {
+                val reportHistories = getCurrentMemberFlowUseCase().first()?.reportHistories
+                filterReportedPosts(posts = galleryDto.posts, reportHistories = reportHistories)
+            }
+        }
+
+        analyticsHelper.d { "galleryDto posts are $galleryPosts" }
 
         reduce {
             copy(
@@ -246,11 +277,24 @@ constructor(
 
                     else -> PaginationStatus.INACTIVE
                 },
-                posts = posts + galleryDto.posts,
+                posts = posts + galleryPosts,
                 nextPage = page + 1,
                 hasNextPage = galleryDto.hasNext,
             )
         }
+    }
+
+    private fun filterReportedPosts(
+        posts: List<GalleryPostDto>,
+        reportHistories: List<ReportHistoryDto>?,
+    ): List<GalleryPostDto> {
+        val reportTargetIds = reportHistories
+            ?.filter { it.targetType == ReportTargetType.WEEKLY_POST.name }
+            ?.map { it.targetId }
+            ?.toSet()
+            ?: emptySet()
+
+        return posts.filter { it.postId !in reportTargetIds }
     }
 
     private fun handleOnClickRegistrationText() {

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
@@ -208,12 +208,12 @@ constructor(
             .collect { currentReportHistories ->
                 val filteredPost = filterReportedPosts(
                     posts = currentState.posts,
-                    reportHistories = currentReportHistories
+                    reportHistories = currentReportHistories,
                 )
 
                 reduce {
                     copy(
-                        posts = filteredPost
+                        posts = filteredPost,
                     )
                 }
             }

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/profile/ProfileNotificationViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/profile/ProfileNotificationViewModel.kt
@@ -14,7 +14,7 @@ import com.captures2024.soongan.core.domain.usecase.notifications.DeleteNotifica
 import com.captures2024.soongan.core.domain.usecase.notifications.GetNotificationsCountUseCase
 import com.captures2024.soongan.core.domain.usecase.notifications.GetNotificationsUseCase
 import com.captures2024.soongan.core.domain.usecase.notifications.PostNotificationReadUseCase
-import com.captures2024.soongan.core.model.Notification
+import com.captures2024.soongan.core.model.dto.NotificationDto
 import com.captures2024.soongan.core.model.utils.NotificationSubType
 import com.captures2024.soongan.core.model.utils.NotificationType
 import com.captures2024.soongan.core.model.utils.NotificationsCountTable
@@ -143,7 +143,7 @@ constructor(
 
     private suspend fun initSetNotifications() {
         val tempNotificationsTable =
-            EnumMap<NotificationType, Map<Int, Notification>>(NotificationType::class.java)
+            EnumMap<NotificationType, Map<Int, NotificationDto>>(NotificationType::class.java)
 
         NotificationType.entries.forEach { type ->
             val notificationsDto = getNotificationsUseCase(type = type).getOrNull()
@@ -156,7 +156,7 @@ constructor(
 
             analyticsHelper.d { "Init Set NotificationsDto: $notificationsDto" }
 
-            val tempNotificationMap: Map<Int, Notification> =
+            val tempNotificationMap: Map<Int, NotificationDto> =
                 notificationsDto.notifications.mapIndexed { index, notification ->
                     index to notification
                 }.toMap()

--- a/feature/profile/src/main/kotlin/com/captures2024/soongan/feature/profile/ui/notification/NotificationBody.kt
+++ b/feature/profile/src/main/kotlin/com/captures2024/soongan/feature/profile/ui/notification/NotificationBody.kt
@@ -26,7 +26,7 @@ import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScal
 import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
 import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
 import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
-import com.captures2024.soongan.core.model.Notification
+import com.captures2024.soongan.core.model.dto.NotificationDto
 import com.captures2024.soongan.core.model.mock.mockNotificationsTable
 import com.captures2024.soongan.core.model.utils.NotificationSubType
 import com.captures2024.soongan.core.model.utils.NotificationType
@@ -37,7 +37,7 @@ import com.captures2024.soongan.feature.profile.ui.notification.component.Notifi
 
 @Composable
 internal fun NotificationBody(
-    notifications: Map<Int, Notification>,
+    notifications: Map<Int, NotificationDto>,
     modifier: Modifier = Modifier,
     onClickNotification: (Int) -> Unit = {},
     onDeleteNotification: (Int) -> Unit = {},
@@ -79,7 +79,7 @@ private fun EmptyNotificationHistory(modifier: Modifier = Modifier) {
 
 @Composable
 private fun NotificationHistory(
-    notifications: Map<Int, Notification>,
+    notifications: Map<Int, NotificationDto>,
     modifier: Modifier = Modifier,
     onClickNotification: (Int) -> Unit = {},
     onDeleteNotification: (Int) -> Unit = {},
@@ -118,7 +118,7 @@ private fun NotificationHistory(
 
 @Composable
 private fun NotificationHistoryContent(
-    notification: Notification,
+    notification: NotificationDto,
     modifier: Modifier = Modifier,
     isAppeal: Boolean = false, // 소명 알림 여부
     onClick: () -> Unit = {},
@@ -201,7 +201,7 @@ private fun NotificationBodyPreview() {
 @Composable
 private fun NotificationHistoryContentPreview() {
     NotificationHistoryContent(
-        notification = Notification(
+        notification = NotificationDto(
             title = "알림",
             body = "알림 내용",
             isRead = false,


### PR DESCRIPTION
# [SG-113] 신고 관련 api 변경 사항 적용

## 작업 사항
- reportHistoryDto 추가
- 신고 관련 비즈니스 로직 수정
- 신고된 posts 필터링 작업

## GIF
![report_post_flow](https://github.com/user-attachments/assets/cbca47ea-e1a3-43ba-9b5f-340742a02c65)

## 비고
GIF가 자동 재생이라서 바로 넘어가는데, 다시 들어갔을 때 신고 게시물은 숨김처리 되었습니다.

[SG-113]: https://captures2024.atlassian.net/browse/SG-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ