### PR TITLE
[SG-130] 콘테스트 정보 목록 조회 api 추가

### DIFF
--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/HomeMapper.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/HomeMapper.kt
@@ -1,11 +1,11 @@
 package com.captures2024.soongan.core.data.mapper
 
-import com.captures2024.soongan.core.model.dto.ContestInfoDto
+import com.captures2024.soongan.core.model.dto.HomeContestInfoDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import com.captures2024.soongan.core.model.network.response.home.GetHomeStatusContestInfoResponse
 import com.captures2024.soongan.core.model.network.response.home.GetHomeStatusPostInfoResponse
 
-fun GetHomeStatusContestInfoResponse.toContestInfoDto(): ContestInfoDto = ContestInfoDto(
+fun GetHomeStatusContestInfoResponse.toHomeContestInfoDto(): HomeContestInfoDto = HomeContestInfoDto(
     contestType = contestType,
     subject = subject,
     startAt = startAt,

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/WeeklyContestMapper.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/WeeklyContestMapper.kt
@@ -4,11 +4,15 @@ import com.captures2024.soongan.core.model.dto.GalleryDto
 import com.captures2024.soongan.core.model.dto.GalleryPostDto
 import com.captures2024.soongan.core.model.dto.MyGalleryDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
+import com.captures2024.soongan.core.model.dto.WeeklyContestInfoDto
+import com.captures2024.soongan.core.model.dto.WeeklyContestInfoListDto
 import com.captures2024.soongan.core.model.network.response.weekly.contests.GetGalleryPostInfoResponse
 import com.captures2024.soongan.core.model.network.response.weekly.contests.GetGalleryResponse
 import com.captures2024.soongan.core.model.network.response.weekly.contests.GetMyGalleryPostInfoResponse
 import com.captures2024.soongan.core.model.network.response.weekly.contests.GetMyGalleryResponse
 import com.captures2024.soongan.core.model.network.response.weekly.contests.GetPostInfoResponse
+import com.captures2024.soongan.core.model.network.response.weekly.contests.GetWeeklyContestInfoListResponse
+import com.captures2024.soongan.core.model.network.response.weekly.contests.GetWeeklyContestInfoResponse
 import com.captures2024.soongan.core.model.network.response.weekly.contests.RegisterPostResponse
 
 fun GetGalleryResponse.toGalleryDto(): GalleryDto = GalleryDto(
@@ -50,3 +54,20 @@ fun GetPostInfoResponse.toPostInfoDto(): PostInfoDto = PostInfoDto(
     isLiked = this.isLiked,
     commentCount = this.commentCount,
 )
+
+fun GetWeeklyContestInfoListResponse.toWeeklyContestInfoListDto(): WeeklyContestInfoListDto =
+    WeeklyContestInfoListDto(
+        weeklyContestInfoList = this.weeklyContestInfoList.map { it.toWeeklyContestInfoDto() }
+    )
+
+fun GetWeeklyContestInfoResponse.toWeeklyContestInfoDto(): WeeklyContestInfoDto =
+    WeeklyContestInfoDto(
+        id = this.id,
+        round = this.round,
+        subject = this.subject,
+        startAt = this.startAt,
+        endAt = this.endAt,
+        voteStartAt = this.voteStartAt,
+        voteEndAt = this.voteEndAt,
+        announcedAt = this.announcedAt,
+    )

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/WeeklyContestMapper.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/mapper/WeeklyContestMapper.kt
@@ -57,7 +57,7 @@ fun GetPostInfoResponse.toPostInfoDto(): PostInfoDto = PostInfoDto(
 
 fun GetWeeklyContestInfoListResponse.toWeeklyContestInfoListDto(): WeeklyContestInfoListDto =
     WeeklyContestInfoListDto(
-        weeklyContestInfoList = this.weeklyContestInfoList.map { it.toWeeklyContestInfoDto() }
+        weeklyContestInfoList = this.weeklyContestInfoList.map { it.toWeeklyContestInfoDto() },
     )
 
 fun GetWeeklyContestInfoResponse.toWeeklyContestInfoDto(): WeeklyContestInfoDto =

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/HomeRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/HomeRepository.kt
@@ -1,9 +1,9 @@
 package com.captures2024.soongan.core.data.repository
 
-import com.captures2024.soongan.core.model.dto.ContestInfoDto
+import com.captures2024.soongan.core.model.dto.HomeContestInfoDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 
 interface HomeRepository {
 
-    suspend fun getHome(): Pair<ContestInfoDto, List<PostInfoDto>>
+    suspend fun getHome(): Pair<HomeContestInfoDto, List<PostInfoDto>>
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/WeeklyContestRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/WeeklyContestRepository.kt
@@ -1,5 +1,6 @@
 package com.captures2024.soongan.core.data.repository
 
+import com.captures2024.soongan.core.model.dto.WeeklyContestInfoListDto
 import com.captures2024.soongan.core.model.dto.GalleryDto
 import com.captures2024.soongan.core.model.dto.MyGalleryDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
@@ -30,6 +31,8 @@ interface WeeklyContestRepository {
         postId: Long,
         title: String,
     ): String
+
+    suspend fun getWeeklyContestInfoList(): WeeklyContestInfoListDto
 
     suspend fun getMyGalleryInfo(
         page: Int,

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/HomeRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/HomeRepositoryImpl.kt
@@ -3,7 +3,7 @@ package com.captures2024.soongan.core.data.repository.impl
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.data.source.home.remote.HomeRemoteDataSource
 import com.captures2024.soongan.core.data.repository.HomeRepository
-import com.captures2024.soongan.core.model.dto.ContestInfoDto
+import com.captures2024.soongan.core.model.dto.HomeContestInfoDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import javax.inject.Inject
 
@@ -18,7 +18,7 @@ constructor(
         analyticsHelper.d { "HomeRepository::init" }
     }
 
-    override suspend fun getHome(): Pair<ContestInfoDto, List<PostInfoDto>> {
+    override suspend fun getHome(): Pair<HomeContestInfoDto, List<PostInfoDto>> {
         val response = homeRemoteDataSource.getHomeStatus()
 
         return response ?: error("response is null")

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/WeeklyContestRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/WeeklyContestRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.captures2024.soongan.core.data.repository.WeeklyContestRepository
 import com.captures2024.soongan.core.model.dto.GalleryDto
 import com.captures2024.soongan.core.model.dto.MyGalleryDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
+import com.captures2024.soongan.core.model.dto.WeeklyContestInfoListDto
 import javax.inject.Inject
 
 class WeeklyContestRepositoryImpl
@@ -32,7 +33,7 @@ constructor(
             pageSize = pageSize,
         )
 
-        return galleryInfo ?: throw java.lang.NullPointerException("galleryDto is null")
+        return galleryInfo ?: throw NullPointerException("galleryDto is null")
     }
 
     override suspend fun registerPost(
@@ -52,7 +53,7 @@ constructor(
             postId = postId,
         )
 
-        return postInfoDto ?: throw java.lang.NullPointerException("postInfoDto is null")
+        return postInfoDto ?: throw NullPointerException("postInfoDto is null")
     }
 
     override suspend fun deletePost(postId: Long): Boolean =
@@ -64,7 +65,13 @@ constructor(
             title = title,
         )
 
-        return editedTitle ?: throw java.lang.NullPointerException("editedTitle is null")
+        return editedTitle ?: throw NullPointerException("editedTitle is null")
+    }
+
+    override suspend fun getWeeklyContestInfoList(): WeeklyContestInfoListDto {
+        val weeklyContestInfoListDto = weeklyContestRemoteDataSource.getWeeklyContestInfoList()
+
+        return weeklyContestInfoListDto ?: throw NullPointerException("weeklyContestInfoListDto is null")
     }
 
     override suspend fun getMyGalleryInfo(page: Int, pageSize: Int): MyGalleryDto {
@@ -73,6 +80,6 @@ constructor(
             pageSize = pageSize,
         )
 
-        return myGalleryInfo ?: throw java.lang.NullPointerException("myGalleryDto is null")
+        return myGalleryInfo ?: throw NullPointerException("myGalleryDto is null")
     }
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/WeeklyContestService.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/service/WeeklyContestService.kt
@@ -4,6 +4,7 @@ import com.captures2024.soongan.core.model.AppConst
 import com.captures2024.soongan.core.model.network.request.weekly.contests.EditPostRequest
 import com.captures2024.soongan.core.model.network.response.BaseResponse
 import com.captures2024.soongan.core.model.network.response.weekly.contests.EditPostResponse
+import com.captures2024.soongan.core.model.network.response.weekly.contests.GetWeeklyContestInfoListResponse
 import com.captures2024.soongan.core.model.network.response.weekly.contests.GetGalleryResponse
 import com.captures2024.soongan.core.model.network.response.weekly.contests.GetMyGalleryResponse
 import com.captures2024.soongan.core.model.network.response.weekly.contests.GetPostInfoResponse
@@ -62,6 +63,10 @@ interface WeeklyContestService {
         @Path("postId") postId: Long,
         @Body request: EditPostRequest,
     ): Response<BaseResponse<EditPostResponse>>
+
+    @Headers(AppConst.Network.ACCESS_TOKEN_ALLOW)
+    @GET("weekly/contests")
+    suspend fun getContestInfoList(): Response<BaseResponse<GetWeeklyContestInfoListResponse>>
 
     @Headers(AppConst.Network.ACCESS_TOKEN_ALLOW)
     @GET("weekly/contests/posts/my-hisotry")

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/source/home/remote/HomeRemoteDataSource.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/source/home/remote/HomeRemoteDataSource.kt
@@ -1,9 +1,9 @@
 package com.captures2024.soongan.core.data.source.home.remote
 
-import com.captures2024.soongan.core.model.dto.ContestInfoDto
+import com.captures2024.soongan.core.model.dto.HomeContestInfoDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 
 interface HomeRemoteDataSource {
 
-    suspend fun getHomeStatus(): Pair<ContestInfoDto, List<PostInfoDto>>?
+    suspend fun getHomeStatus(): Pair<HomeContestInfoDto, List<PostInfoDto>>?
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/source/home/remote/HomeRemoteDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/source/home/remote/HomeRemoteDataSourceImpl.kt
@@ -1,11 +1,11 @@
 package com.captures2024.soongan.core.data.source.home.remote
 
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
-import com.captures2024.soongan.core.data.mapper.toContestInfoDto
+import com.captures2024.soongan.core.data.mapper.toHomeContestInfoDto
 import com.captures2024.soongan.core.data.mapper.toPostInfoDto
 import com.captures2024.soongan.core.data.service.HomeService
 import com.captures2024.soongan.core.data.utils.safeAPICall
-import com.captures2024.soongan.core.model.dto.ContestInfoDto
+import com.captures2024.soongan.core.model.dto.HomeContestInfoDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import javax.inject.Inject
 
@@ -20,7 +20,7 @@ constructor(
         analyticsHelper.d { "HomeRemoteDataSource::init" }
     }
 
-    override suspend fun getHomeStatus(): Pair<ContestInfoDto, List<PostInfoDto>>? {
+    override suspend fun getHomeStatus(): Pair<HomeContestInfoDto, List<PostInfoDto>>? {
         analyticsHelper.d { "getHomeStatus - entry" }
 
         val response = safeAPICall { homeService.getHomeStatusWithToken() }
@@ -39,6 +39,6 @@ constructor(
             return null
         }
 
-        return responseData.contestInfo.toContestInfoDto() to responseData.postInfo.map { it.toPostInfoDto() }
+        return responseData.contestInfo.toHomeContestInfoDto() to responseData.postInfo.map { it.toPostInfoDto() }
     }
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/source/weekly_contest/remote/WeeklyContestRemoteDataSource.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/source/weekly_contest/remote/WeeklyContestRemoteDataSource.kt
@@ -1,5 +1,6 @@
 package com.captures2024.soongan.core.data.source.weekly_contest.remote
 
+import com.captures2024.soongan.core.model.dto.WeeklyContestInfoListDto
 import com.captures2024.soongan.core.model.dto.GalleryDto
 import com.captures2024.soongan.core.model.dto.MyGalleryDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
@@ -26,6 +27,8 @@ interface WeeklyContestRemoteDataSource {
         postId: Long,
         title: String,
     ): String?
+
+    suspend fun getWeeklyContestInfoList(): WeeklyContestInfoListDto?
 
     suspend fun getMyGalleryInfo(
         page: Int,

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/source/weekly_contest/remote/WeeklyContestRemoteDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/source/weekly_contest/remote/WeeklyContestRemoteDataSourceImpl.kt
@@ -2,12 +2,14 @@ package com.captures2024.soongan.core.data.source.weekly_contest.remote
 
 import android.content.Context
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.data.mapper.toWeeklyContestInfoListDto
 import com.captures2024.soongan.core.data.mapper.toGalleryDto
 import com.captures2024.soongan.core.data.mapper.toMyGalleryDto
 import com.captures2024.soongan.core.data.mapper.toPostInfoDto
 import com.captures2024.soongan.core.data.service.WeeklyContestService
 import com.captures2024.soongan.core.data.utils.safeAPICall
 import com.captures2024.soongan.core.data.utils.toImageMultiPart
+import com.captures2024.soongan.core.model.dto.WeeklyContestInfoListDto
 import com.captures2024.soongan.core.model.dto.GalleryDto
 import com.captures2024.soongan.core.model.dto.MyGalleryDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
@@ -136,6 +138,24 @@ constructor(
         analyticsHelper.d { "editPostTitle - responseBody: $responseBody" }
 
         return responseBody?.responseData?.title
+    }
+
+    override suspend fun getWeeklyContestInfoList(): WeeklyContestInfoListDto? {
+        analyticsHelper.d { "getContestInfoList - no param" }
+
+        val response = safeAPICall {
+            service.getContestInfoList()
+        }
+
+        val responseHeader = response.headers
+
+        analyticsHelper.d { "getMyGalleryInfo - responseHeader: $responseHeader" }
+
+        val responseBody = response.body
+
+        analyticsHelper.d { "getMyGalleryInfo - responseBody: $responseBody" }
+
+        return responseBody?.responseData?.toWeeklyContestInfoListDto()
     }
 
     override suspend fun getMyGalleryInfo(

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/home/GetHomeUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/home/GetHomeUseCase.kt
@@ -2,7 +2,7 @@ package com.captures2024.soongan.core.domain.usecase.home
 
 import com.captures2024.soongan.core.data.repository.HomeRepository
 import com.captures2024.soongan.core.domain.runSuspendCatching
-import com.captures2024.soongan.core.model.dto.ContestInfoDto
+import com.captures2024.soongan.core.model.dto.HomeContestInfoDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import javax.inject.Inject
 
@@ -12,7 +12,7 @@ constructor(
     private val homeRepository: HomeRepository,
 ) {
 
-    suspend operator fun invoke(): Result<Pair<ContestInfoDto, List<PostInfoDto>>> = runSuspendCatching {
+    suspend operator fun invoke(): Result<Pair<HomeContestInfoDto, List<PostInfoDto>>> = runSuspendCatching {
         homeRepository.getHome()
     }
 }

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/weekly/contests/GetWeeklyContestInfoListUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/weekly/contests/GetWeeklyContestInfoListUseCase.kt
@@ -1,0 +1,19 @@
+package com.captures2024.soongan.core.domain.usecase.weekly.contests
+
+import com.captures2024.soongan.core.data.repository.WeeklyContestRepository
+import com.captures2024.soongan.core.domain.runSuspendCatching
+import com.captures2024.soongan.core.model.dto.WeeklyContestInfoListDto
+import javax.inject.Inject
+
+class GetWeeklyContestInfoListUseCase
+@Inject
+constructor(
+    private val weeklyContestRepository: WeeklyContestRepository,
+) {
+
+    suspend operator fun invoke(): Result<WeeklyContestInfoListDto> = runSuspendCatching {
+        val myGalleryDto = weeklyContestRepository.getWeeklyContestInfoList()
+
+        return@runSuspendCatching myGalleryDto
+    }
+}

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/HomeContestInfoDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/HomeContestInfoDto.kt
@@ -1,6 +1,6 @@
 package com.captures2024.soongan.core.model.dto
 
-data class ContestInfoDto(
+data class HomeContestInfoDto(
     val contestType: String = "",
     val subject: String = "",
     val startAt: String = "",

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/WeeklyContestInfoDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/WeeklyContestInfoDto.kt
@@ -1,0 +1,12 @@
+package com.captures2024.soongan.core.model.dto
+
+data class WeeklyContestInfoDto(
+    val id: Long = -1L,
+    val round: Int = -1,
+    val subject: String = "",
+    val startAt: String = "",
+    val endAt: String = "",
+    val voteStartAt: String = "",
+    val voteEndAt: String = "",
+    val announcedAt: String = "",
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/WeeklyContestInfoListDto.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/WeeklyContestInfoListDto.kt
@@ -1,0 +1,5 @@
+package com.captures2024.soongan.core.model.dto
+
+data class WeeklyContestInfoListDto(
+    val weeklyContestInfoList: List<WeeklyContestInfoDto> = emptyList(),
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/weekly/contests/GetWeeklyContestInfoListResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/weekly/contests/GetWeeklyContestInfoListResponse.kt
@@ -1,0 +1,10 @@
+package com.captures2024.soongan.core.model.network.response.weekly.contests
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetWeeklyContestInfoListResponse(
+    @SerialName("contests")
+    val weeklyContestInfoList: List<GetWeeklyContestInfoResponse>
+)

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/weekly/contests/GetWeeklyContestInfoListResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/weekly/contests/GetWeeklyContestInfoListResponse.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class GetWeeklyContestInfoListResponse(
     @SerialName("contests")
-    val weeklyContestInfoList: List<GetWeeklyContestInfoResponse>
+    val weeklyContestInfoList: List<GetWeeklyContestInfoResponse>,
 )

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/weekly/contests/GetWeeklyContestInfoResponse.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/network/response/weekly/contests/GetWeeklyContestInfoResponse.kt
@@ -1,0 +1,24 @@
+package com.captures2024.soongan.core.model.network.response.weekly.contests
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetWeeklyContestInfoResponse(
+    @SerialName("id")
+    val id: Long,
+    @SerialName("round")
+    val round: Int,
+    @SerialName("subject")
+    val subject: String,
+    @SerialName("startAt")
+    val startAt: String,
+    @SerialName("endAt")
+    val endAt: String,
+    @SerialName("voteStartAt")
+    val voteStartAt: String,
+    @SerialName("voteEndAt")
+    val voteEndAt: String,
+    @SerialName("announcedAt")
+    val announcedAt: String,
+)

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeViewModel.kt
@@ -11,7 +11,7 @@ import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
-import com.captures2024.soongan.core.model.dto.ContestInfoDto
+import com.captures2024.soongan.core.model.dto.HomeContestInfoDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -41,7 +41,7 @@ constructor(
 
     data class State(
         val isLoading: Boolean = false,
-        val contestInfo: ContestInfoDto = ContestInfoDto(),
+        val contestInfo: HomeContestInfoDto = HomeContestInfoDto(),
         val postList: List<PostInfoDto> = emptyList(),
         val isWeeklySelected: Boolean = true,
         val isOpenBottomSheet: Boolean = false,

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/home/HomeScreen.kt
@@ -16,7 +16,7 @@ import com.captures2024.soongan.core.designsystem.ui.R
 import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
 import com.captures2024.soongan.core.designsystem.ui.component.WeightSpacer
 import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
-import com.captures2024.soongan.core.model.dto.ContestInfoDto
+import com.captures2024.soongan.core.model.dto.HomeContestInfoDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import com.captures2024.soongan.core.viewmodel.home.HomeViewModel
 import com.captures2024.soongan.feature.home.ui.home.component.ContestPeriodText
@@ -102,7 +102,7 @@ private fun HomeScreenPreview() {
     HomeScreen(
         modifier = modifier,
         uiState = HomeViewModel.State(
-            contestInfo = ContestInfoDto(
+            contestInfo = HomeContestInfoDto(
                 subject = stringResource(com.captures2024.soongan.feature.home.R.string.home_top_bar_topic_example),
                 startAt = "2024.05.10",
                 endAt = "2024.06.10",
@@ -124,7 +124,7 @@ private fun HomeScreenMultiPostPreview() {
     HomeScreen(
         modifier = modifier,
         uiState = HomeViewModel.State(
-            contestInfo = ContestInfoDto(
+            contestInfo = HomeContestInfoDto(
                 subject = stringResource(com.captures2024.soongan.feature.home.R.string.home_top_bar_topic_example),
                 startAt = "2024.05.10",
                 endAt = "2024.06.10",


### PR DESCRIPTION
# [SG-130] 콘테스트 정보 목록 조회 api 추가

## 작업 사항
- 신규 api 추가
- 기존 ContestInfoDto -> HomeContestInfoDto 네이밍 수정

[SG-130]: https://captures2024.atlassian.net/browse/SG-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ