### PR TITLE
[SG-132] refactor post

### DIFF
--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/PostLikeRepository.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/PostLikeRepository.kt
@@ -1,16 +1,16 @@
 package com.captures2024.soongan.core.data.repository
 
-import com.captures2024.soongan.core.model.dto.ResultConditionDto
+import com.captures2024.soongan.core.model.dto.PostLikeDto
 
 interface PostLikeRepository {
 
     suspend fun putPostLike(
         postId: Long,
         contestType: String,
-    ): ResultConditionDto
+    ): PostLikeDto
 
     suspend fun deletePostLike(
         postId: Long,
         contestType: String,
-    ): ResultConditionDto
+    ): PostLikeDto
 }

--- a/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/PostLikeRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/captures2024/soongan/core/data/repository/impl/PostLikeRepositoryImpl.kt
@@ -3,7 +3,7 @@ package com.captures2024.soongan.core.data.repository.impl
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.data.source.post_like.remote.PostLikeRemoteDataSource
 import com.captures2024.soongan.core.data.repository.PostLikeRepository
-import com.captures2024.soongan.core.model.dto.ResultConditionDto
+import com.captures2024.soongan.core.model.dto.PostLikeDto
 import javax.inject.Inject
 
 class PostLikeRepositoryImpl
@@ -20,7 +20,7 @@ constructor(
     override suspend fun putPostLike(
         postId: Long,
         contestType: String,
-    ): ResultConditionDto {
+    ): PostLikeDto {
         val data = dataSource.putPostLike(
             postId = postId,
             contestType = contestType,
@@ -30,13 +30,13 @@ constructor(
             throw NullPointerException("postLikeDto(PUT) is null")
         }
 
-        return ResultConditionDto(postId == data.postId)
+        return data
     }
 
     override suspend fun deletePostLike(
         postId: Long,
         contestType: String,
-    ): ResultConditionDto {
+    ): PostLikeDto {
         val data = dataSource.deletePostLike(
             postId = postId,
             contestType = contestType,
@@ -46,6 +46,6 @@ constructor(
             throw NullPointerException("postLikeDto(DELETE) is null")
         }
 
-        return ResultConditionDto(postId == data.postId)
+        return data
     }
 }

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/like/DeletePostLikeUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/like/DeletePostLikeUseCase.kt
@@ -2,6 +2,7 @@ package com.captures2024.soongan.core.domain.usecase.like
 
 import com.captures2024.soongan.core.data.repository.PostLikeRepository
 import com.captures2024.soongan.core.domain.runSuspendCatching
+import com.captures2024.soongan.core.model.dto.PostLikeDto
 import javax.inject.Inject
 
 class DeletePostLikeUseCase
@@ -10,12 +11,12 @@ constructor(
     private val repository: PostLikeRepository,
 ) {
 
-    suspend operator fun invoke(postId: Long, contestType: String): Result<Boolean> = runSuspendCatching {
+    suspend operator fun invoke(postId: Long, contestType: String): Result<PostLikeDto> = runSuspendCatching {
         val resultConditionDto = repository.deletePostLike(
             postId = postId,
             contestType = contestType,
         )
 
-        return@runSuspendCatching resultConditionDto.result
+        return@runSuspendCatching resultConditionDto
     }
 }

--- a/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/like/PutPostLikeUseCase.kt
+++ b/core/domain/src/main/kotlin/com/captures2024/soongan/core/domain/usecase/like/PutPostLikeUseCase.kt
@@ -2,6 +2,7 @@ package com.captures2024.soongan.core.domain.usecase.like
 
 import com.captures2024.soongan.core.data.repository.PostLikeRepository
 import com.captures2024.soongan.core.domain.runSuspendCatching
+import com.captures2024.soongan.core.model.dto.PostLikeDto
 import javax.inject.Inject
 
 class PutPostLikeUseCase
@@ -10,12 +11,12 @@ constructor(
     private val repository: PostLikeRepository,
 ) {
 
-    suspend operator fun invoke(postId: Long, contestType: String): Result<Boolean> = runSuspendCatching {
+    suspend operator fun invoke(postId: Long, contestType: String): Result<PostLikeDto> = runSuspendCatching {
         val resultConditionDto = repository.putPostLike(
             postId = postId,
             contestType = contestType,
         )
 
-        return@runSuspendCatching resultConditionDto.result
+        return@runSuspendCatching resultConditionDto
     }
 }

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/AppConst.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/AppConst.kt
@@ -17,6 +17,12 @@ object AppConst {
             const val MAX_REGISTER_POST_COUNT: Int = 3
             const val MAX_INPUT_LENGTH: Int = 15
         }
+
+        object Post {
+            const val REPORT_REASON_MAX_LENGTH = 200
+
+            const val IMAGE_DEFAULT_DURATION: Long = 1L * 1L * 1000L
+        }
     }
 
     object Notification {

--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/post/EditPostNavigator.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/post/EditPostNavigator.kt
@@ -1,4 +1,4 @@
-package com.captures2024.soongan.core.navigator.screen.main.home
+package com.captures2024.soongan.core.navigator.screen.main.post
 
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions

--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/post/ImageViewerNavigator.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/post/ImageViewerNavigator.kt
@@ -1,0 +1,23 @@
+package com.captures2024.soongan.core.navigator.screen.main.post
+
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ImageViewerNavigator(
+    val url: String,
+)
+
+fun NavController.navigateToImageViewer(url: String) = navigateToImageViewer(
+    url = url,
+    navOptions = null,
+)
+
+fun NavController.navigateToImageViewer(
+    url: String,
+    navOptions: NavOptions?,
+) = navigate(
+    route = ImageViewerNavigator(url),
+    navOptions = navOptions,
+)

--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/post/PostInfoNavigator.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/post/PostInfoNavigator.kt
@@ -1,0 +1,25 @@
+package com.captures2024.soongan.core.navigator.screen.main.post
+
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PostInfoNavigator(
+    val id: Long,
+)
+
+fun NavController.navigateToPostInfo(id: Long) = navigateToPostInfo(
+    id = id,
+    navOptions = null,
+)
+
+fun NavController.navigateToPostInfo(
+    id: Long,
+    navOptions: NavOptions?,
+) = navigate(
+    route = PostInfoNavigator(
+        id = id,
+    ),
+    navOptions = navOptions,
+)

--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/report/CheckReportReasonNavigator.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/report/CheckReportReasonNavigator.kt
@@ -1,0 +1,17 @@
+package com.captures2024.soongan.core.navigator.screen.main.report
+
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object CheckReportReasonNavigator
+
+fun NavController.navigateToCheckReportReason() = navigateToCheckReportReason(
+    navOptions = null,
+)
+
+fun NavController.navigateToCheckReportReason(navOptions: NavOptions?) = navigate(
+    route = CheckReportReasonNavigator,
+    navOptions = navOptions,
+)

--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/report/DoneReportReasonNavigator.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/report/DoneReportReasonNavigator.kt
@@ -1,0 +1,17 @@
+package com.captures2024.soongan.core.navigator.screen.main.report
+
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object DoneReportReasonNavigator
+
+fun NavController.navigateToDoneReportReason() = navigateToDoneReportReason(
+    navOptions = null,
+)
+
+fun NavController.navigateToDoneReportReason(navOptions: NavOptions?) = navigate(
+    route = DoneReportReasonNavigator,
+    navOptions = navOptions,
+)

--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/report/SelectReportReasonNavigator.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/report/SelectReportReasonNavigator.kt
@@ -1,0 +1,17 @@
+package com.captures2024.soongan.core.navigator.screen.main.report
+
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object SelectReportReasonNavigator
+
+fun NavController.navigateToSelectReportReason() = navigateToSelectReportReason(
+    navOptions = null,
+)
+
+fun NavController.navigateToSelectReportReason(navOptions: NavOptions?) = navigate(
+    route = SelectReportReasonNavigator,
+    navOptions = navOptions,
+)

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/post/EditPostViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/post/EditPostViewModel.kt
@@ -12,7 +12,7 @@ import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.domain.usecase.weekly.contests.EditPostTitleUseCase
-import com.captures2024.soongan.core.navigator.screen.main.home.EditPostNavigator
+import com.captures2024.soongan.core.navigator.screen.main.post.EditPostNavigator
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/navigation/HomeNavigation.kt
@@ -5,7 +5,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.captures2024.soongan.core.navigator.screen.main.home.HomeGalleryNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.HomeNavigator
-import com.captures2024.soongan.core.navigator.screen.main.home.EditPostNavigator
+import com.captures2024.soongan.core.navigator.screen.main.post.EditPostNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.HomePostNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.HomePostPhotoNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.RegistrationPostNavigator

--- a/feature/main/src/main/kotlin/com/captures2024/soongan/feature/main/navigation/MainRouteNavHost.kt
+++ b/feature/main/src/main/kotlin/com/captures2024/soongan/feature/main/navigation/MainRouteNavHost.kt
@@ -11,7 +11,7 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.navOptions
 import com.captures2024.soongan.core.navigator.screen.main.home.HomeNavigator
-import com.captures2024.soongan.core.navigator.screen.main.home.navigateToEditPost
+import com.captures2024.soongan.core.navigator.screen.main.post.navigateToEditPost
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHome
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHomeGallery
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHomePost

--- a/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/navigation/MainHomeNavigation.kt
+++ b/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/navigation/MainHomeNavigation.kt
@@ -12,6 +12,7 @@ import com.captures2024.soongan.presentation.feature.main.home.route.HomeRoute
 import com.captures2024.soongan.presentation.feature.main.home.route.RegistrationPostRoute
 
 fun NavGraphBuilder.mainHome(
+    getHidedPostId: () -> Long,
     navigateToBack: () -> Unit,
     navigateToRegistrationPost: () -> Unit,
     navigateToGallery: () -> Unit,
@@ -40,6 +41,7 @@ fun NavGraphBuilder.mainHome(
 
     composable<HomeGalleryNavigator> {
         HomeGalleryRoute(
+            getHidePostId = getHidedPostId,
             navigateToBack = navigateToBack,
             navigateToPost = { navigateToPost(it, null) },
             navigateToRegistrationPost = navigateToRegistrationPost,

--- a/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/route/HomeGalleryRoute.kt
+++ b/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/route/HomeGalleryRoute.kt
@@ -5,11 +5,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import com.captures2024.soongan.presentation.feature.main.home.component.screen.HomeGalleryScreen
 import com.captures2024.soongan.presentation.viewmodel.main.home.HomeGalleryViewModel
 
 @Composable
 internal fun HomeGalleryRoute(
+    getHidePostId: () -> Long,
     navigateToBack: () -> Unit,
     navigateToPost: (Long) -> Unit,
     navigateToRegistrationPost: () -> Unit,
@@ -24,6 +27,14 @@ internal fun HomeGalleryRoute(
                 is HomeGalleryViewModel.Effect.NavigateToPost -> navigateToPost(effect.postId)
                 is HomeGalleryViewModel.Effect.NavigateToRegisterPost -> navigateToRegistrationPost()
             }
+        }
+    }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        val postId = getHidePostId()
+
+        if (postId != -1L) {
+            viewModel.intent(HomeGalleryViewModel.Intent.HidePost(postId))
         }
     }
 

--- a/presentation/feature/main-post/build.gradle.kts
+++ b/presentation/feature/main-post/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    alias(libs.plugins.captures2024.soongan.android.feature)
+}
+
+android {
+    namespace = "com.captures2024.soongan.presentation.feature.main.post"
+}
+
+dependencies {
+    implementation(projects.presentation.viewmodel)
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoBodyComponent.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoBodyComponent.kt
@@ -1,0 +1,133 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.info
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.shimmerBrush
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.theme.dropShadow
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.dto.PostInfoDto
+import com.captures2024.soongan.presentation.feature.main.post.R
+
+@Composable
+internal fun PostInfoBodyComponent(
+    postInfo: PostInfoDto,
+    modifier: Modifier = Modifier,
+    onClickPhoto: () -> Unit,
+) {
+    val showShimmer = remember { mutableStateOf(true) }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Box(
+            modifier = Modifier
+                .width(360.dp)
+                .height(460.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(postInfo.imageUrl)
+                    .build(),
+                contentDescription = postInfo.title,
+                modifier = modifier
+                    .widthIn(max = 360.dp)
+                    .heightIn(max = 460.dp)
+                    .background(
+                        brush = shimmerBrush(
+                            targetValue = 1300f,
+                            showShimmer = showShimmer.value,
+                        ),
+                    )
+                    .dropShadow(
+                        shape = RoundedCornerShape(0.dp),
+                        color = SGColor.Grayscale.black100.copy(alpha = 0.3f),
+                        blur = 3.dp,
+                        offsetX = 6.dp,
+                        offsetY = 6.dp,
+                    )
+                    .clickable(onClick = onClickPhoto),
+                contentScale = ContentScale.Fit,
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 40.dp),
+        ) {
+            SGText(
+                text = postInfo.title,
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 24.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = 0.em,
+                ),
+            )
+
+            HeightSpacer(8.dp)
+
+            SGText(
+                text = stringResource(R.string.post_info_nickname_prefix) + postInfo.nickname,
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Normal,
+                    lineHeight = 16.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-2).em,
+                ),
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewPostInfoBodyComponent() {
+    SGTheme {
+        PostInfoBodyComponent(
+            postInfo = PostInfoDto(),
+            onClickPhoto = {},
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoBodyComponent.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoBodyComponent.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -46,11 +48,13 @@ internal fun PostInfoBodyComponent(
     onClickPhoto: () -> Unit,
 ) {
     val showShimmer = remember { mutableStateOf(true) }
+    val scrollState = rememberScrollState()
 
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp),
+            .padding(horizontal = 16.dp)
+            .verticalScroll(scrollState),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.SpaceBetween,
     ) {

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoBottomBarComponent.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoBottomBarComponent.kt
@@ -1,0 +1,148 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.info
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconFillHeart
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillHeart
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillMenu
+import com.captures2024.soongan.core.designsystem.ui.component.WidthSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGIconButton
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGDimension
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.theme.dropShadow
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.designsystem.ui.util.extension.toKM
+import com.captures2024.soongan.presentation.feature.main.post.R
+
+@Composable
+internal fun PostInfoBottomBarComponent(
+    isLiked: Boolean,
+    likeCount: Int,
+    modifier: Modifier = Modifier,
+    onClickMenu: () -> Unit,
+    onClickHeart: () -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(SGDimension.bottomBarHeight)
+            .dropShadow(
+                shape = RoundedCornerShape(0.dp),
+                color = SGColor.black.copy(alpha = 0.3f),
+                blur = 4.dp,
+                offsetX = 0.dp,
+                offsetY = (-2).dp,
+            )
+            .background(color = SGColor.Grayscale.white)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        SGIconButton(
+            onClick = onClickMenu,
+        ) {
+            Icon(
+                imageVector = MyIconPack.IconNonFillMenu,
+                contentDescription = stringResource(R.string.menu_description),
+                tint = SGColor.primaryA,
+                modifier = Modifier.size(
+                    width = 4.dp,
+                    height = 20.dp,
+                ),
+            )
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Crossfade(
+                targetState = isLiked,
+                animationSpec = tween(
+                    durationMillis = 300,
+                    easing = LinearEasing,
+                ),
+                label = "isLiked icon ease out animation",
+            ) { isLiked ->
+                SGIconButton(
+                    onClick = onClickHeart,
+                ) {
+                    Icon(
+                        imageVector = when (isLiked) {
+                            true -> MyIconPack.IconFillHeart
+                            false -> MyIconPack.IconNonFillHeart
+                        },
+                        contentDescription = stringResource(R.string.heart_description),
+                        tint = SGColor.Grayscale.black100,
+                        modifier = Modifier.size(
+                            width = 24.dp,
+                            height = 21.dp,
+                        ),
+                    )
+                }
+            }
+
+            WidthSpacer(8.dp)
+
+            SGText(
+                text = likeCount.toKM(),
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Light,
+                    lineHeight = 12.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-2).em,
+                ),
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewPostInfoBottomBarComponent_Default() {
+    SGTheme {
+        PostInfoBottomBarComponent(
+            isLiked = false,
+            likeCount = 0,
+            onClickMenu = {},
+            onClickHeart = {},
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewPostInfoBottomBarComponent_BigNum() {
+    SGTheme {
+        PostInfoBottomBarComponent(
+            isLiked = true,
+            likeCount = 1_234_567,
+            onClickMenu = {},
+            onClickHeart = {},
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoEditTitleComponent.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoEditTitleComponent.kt
@@ -1,0 +1,125 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.info
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.theme.dropShadow
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.post.R
+
+@Composable
+internal fun PostInfoEditTitleComponent(
+    value: String,
+    maxInputLength: Int,
+    onValueChange: (String) -> Unit,
+) {
+    val focusManager = LocalFocusManager.current
+
+    val commonStyle = getSGNonScaleTextStyle(
+        color = SGColor.Grayscale.black100,
+        fontSize = 18.sp,
+        fontWeight = FontWeight.Bold,
+        lineHeight = 22.sp,
+        fontFamily = SGTypography.pretendard,
+        letterSpacing = (-5).em,
+    )
+
+    Column(horizontalAlignment = Alignment.End) {
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.width(289.dp)
+                .height(40.dp),
+            textStyle = commonStyle,
+            decorationBox = { innerTextField ->
+                Box(
+                    modifier = Modifier.fillMaxSize()
+                        .dropShadow(
+                            shape = RectangleShape,
+                            color = SGColor.black.copy(0.25f),
+                            offsetX = 0.dp,
+                            offsetY = 2.dp,
+                            blur = 4.dp,
+                            spread = 0.dp,
+                        )
+                        .background(
+                            color = SGColor.Grayscale.white,
+                            shape = RoundedCornerShape(4.dp),
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    innerTextField()
+
+                    if (value.isEmpty()) {
+                        SGText(
+                            text = stringResource(R.string.post_info_edit_title_hint),
+                            style = commonStyle.copy(color = SGColor.buttonDisableGray),
+                        )
+                    }
+                }
+            },
+            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    focusManager.clearFocus()
+                },
+            ),
+        )
+
+        HeightSpacer(8.dp)
+
+        Row(
+            modifier = Modifier.padding(end = 4.dp),
+        ) {
+            SGText(
+                text = "${value.length}/$maxInputLength",
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.primaryA,
+                    fontSize = 8.sp,
+                    fontWeight = FontWeight.Normal,
+                    lineHeight = 8.sp,
+                    fontFamily = SGTypography.nanumSquareNeo,
+                    letterSpacing = 0.em,
+                ),
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewPostInfoEditTitleComponent() {
+    SGTheme {
+        PostInfoEditTitleComponent(
+            value = "",
+            maxInputLength = 15,
+            onValueChange = {},
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoTopBarComponent.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoTopBarComponent.kt
@@ -1,0 +1,48 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.info
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillLeftArrow
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGIconCircleButton
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.post.R
+
+@Composable
+internal fun PostInfoTopBarComponent(
+    onClickBack: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(20.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        SGIconCircleButton(
+            imageVector = MyIconPack.IconNonFillLeftArrow,
+            contentDescription = stringResource(R.string.back_description),
+            iconWidth = 20.dp,
+            iconHeight = 16.dp,
+            color = SGColor.Grayscale.black100,
+            onClick = onClickBack,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewPostInfoTopBarComponent() {
+    SGTheme {
+        PostInfoTopBarComponent(
+            onClickBack = {},
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoTopBarComponent.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoTopBarComponent.kt
@@ -1,39 +1,98 @@
 package com.captures2024.soongan.presentation.feature.main.post.component.info
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
 import com.captures2024.soongan.core.designsystem.icon.MyIconPack
 import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillLeftArrow
 import com.captures2024.soongan.core.designsystem.ui.component.button.SGIconCircleButton
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
 import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
 import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
 import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
 import com.captures2024.soongan.presentation.feature.main.post.R
 
 @Composable
 internal fun PostInfoTopBarComponent(
+    round: Int,
+    subject: String,
+    modifier: Modifier = Modifier,
     onClickBack: () -> Unit,
 ) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .padding(20.dp),
-        contentAlignment = Alignment.CenterStart,
+            .padding(vertical = 14.dp),
+        contentAlignment = Alignment.Center,
     ) {
-        SGIconCircleButton(
-            imageVector = MyIconPack.IconNonFillLeftArrow,
-            contentDescription = stringResource(R.string.back_description),
-            iconWidth = 20.dp,
-            iconHeight = 16.dp,
-            color = SGColor.Grayscale.black100,
-            onClick = onClickBack,
-        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            SGIconCircleButton(
+                imageVector = MyIconPack.IconNonFillLeftArrow,
+                contentDescription = stringResource(R.string.back_description),
+                color = SGColor.Grayscale.black100,
+                iconWidth = 20.dp,
+                iconHeight = 16.dp,
+                onClick = onClickBack,
+            )
+        }
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            SGText(
+                text = round.toString() + stringResource(R.string.round_unit),
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 20.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = 0.em,
+                ),
+            )
+
+            SGText(
+                text = "|",
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Medium,
+                    lineHeight = 20.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = 0.em,
+                ),
+            )
+
+            SGText(
+                text = subject,
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.primaryA,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 20.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = 0.em,
+                ),
+            )
+        }
     }
 }
 
@@ -42,6 +101,8 @@ internal fun PostInfoTopBarComponent(
 private fun PreviewPostInfoTopBarComponent() {
     SGTheme {
         PostInfoTopBarComponent(
+            round = 1,
+            subject = "평화",
             onClickBack = {},
         )
     }

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/menu/PostInfoMenuBottomSheet.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/menu/PostInfoMenuBottomSheet.kt
@@ -1,0 +1,48 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.menu
+
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.presentation.feature.main.post.component.screen.PostInfoMenuScreen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun PostInfoMenuBottomSheet(
+    isMyPost: Boolean,
+    modifier: Modifier = Modifier,
+    onDismissRequest: () -> Unit,
+    onClickDelete: () -> Unit,
+    onClickEditPost: () -> Unit,
+    onClickReport: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        modifier = modifier
+            .heightIn(min = 240.dp),
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = SGColor.Grayscale.white,
+    ) {
+        PostInfoMenuScreen(
+            isMyPost = isMyPost,
+            onClickEdit = {
+                onDismissRequest()
+                onClickDelete()
+            },
+            onClickDelete = {
+                onDismissRequest()
+                onClickEditPost()
+            },
+            onClickReport = {
+                onDismissRequest()
+                onClickReport()
+            },
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/menu/PostInfoMenuBottomSheet.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/menu/PostInfoMenuBottomSheet.kt
@@ -33,11 +33,11 @@ internal fun PostInfoMenuBottomSheet(
             isMyPost = isMyPost,
             onClickEdit = {
                 onDismissRequest()
-                onClickDelete()
+                onClickEditPost()
             },
             onClickDelete = {
                 onDismissRequest()
-                onClickEditPost()
+                onClickDelete()
             },
             onClickReport = {
                 onDismissRequest()

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/menu/PostInfoMenuItemComponent.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/menu/PostInfoMenuItemComponent.kt
@@ -1,0 +1,101 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.menu
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillEdit
+import com.captures2024.soongan.core.designsystem.ui.component.WidthSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.post.R
+
+@Composable
+internal fun PostInfoMenuItemComponent(
+    text: String,
+    color: Color,
+    icon: ImageVector,
+    isVisibleDivider: Boolean,
+    isEnabled: Boolean,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.let {
+            when (isEnabled) {
+                true -> it.clickable(onClick = onClick)
+                false -> it
+            }
+        },
+    ) {
+        Row(
+            modifier = Modifier
+                .heightIn(min = 56.dp)
+                .padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            SGText(
+                text = text,
+                style = getSGNonScaleTextStyle(
+                    color = color,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 24.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = 0.em,
+                ),
+                modifier = Modifier.weight(1f),
+            )
+
+            WidthSpacer(4.dp)
+
+            Icon(
+                imageVector = icon,
+                contentDescription = stringResource(R.string.back_description),
+                tint = color,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+
+        if (isVisibleDivider) {
+            HorizontalDivider(
+                modifier = Modifier.fillMaxWidth(),
+                color = SGColor.Grayscale.black100.copy(alpha = 0.3f),
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewPostInfoMenuItemComponent() {
+    SGTheme {
+        PostInfoMenuItemComponent(
+            text = "수정하기",
+            color = SGColor.Grayscale.black100,
+            icon = MyIconPack.IconNonFillEdit,
+            isVisibleDivider = true,
+            isEnabled = true,
+            onClick = {},
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/report/ReportBottomSheet.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/report/ReportBottomSheet.kt
@@ -1,0 +1,113 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.report
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.navigator.screen.main.report.CheckReportReasonNavigator
+import com.captures2024.soongan.core.navigator.screen.main.report.DoneReportReasonNavigator
+import com.captures2024.soongan.core.navigator.screen.main.report.SelectReportReasonNavigator
+import com.captures2024.soongan.core.navigator.screen.main.report.navigateToCheckReportReason
+import com.captures2024.soongan.core.navigator.screen.main.report.navigateToDoneReportReason
+import com.captures2024.soongan.presentation.feature.main.post.route.CheckReportReasonRoute
+import com.captures2024.soongan.presentation.feature.main.post.route.DoneReportReasonRoute
+import com.captures2024.soongan.presentation.feature.main.post.route.SelectReportReasonRoute
+import com.captures2024.soongan.presentation.viewmodel.main.post.PostReportViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ReportBottomSheet(
+    id: Long,
+    modifier: Modifier = Modifier,
+    onDismissRequest: () -> Unit,
+    onDoneReport: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val postReportViewModel = hiltViewModel<PostReportViewModel>()
+
+    val scope = rememberCoroutineScope()
+    val navController = rememberNavController()
+
+    var isAvailableBack by remember { mutableStateOf(true) }
+
+    val navigateToBack: () -> Unit = {
+        if (isAvailableBack) {
+            isAvailableBack = false
+            navController.navigateUp()
+
+            scope.launch {
+                delay(500L)
+                isAvailableBack = true
+            }
+        }
+    }
+
+    LaunchedEffect(id) {
+        postReportViewModel.intent(PostReportViewModel.Intent.InitId(id))
+    }
+
+    ModalBottomSheet(
+        modifier = modifier.fillMaxWidth(),
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = SGColor.white,
+        dragHandle = @Composable {
+            ReportBottomSheetDragHandleComponent()
+        },
+    ) {
+        ReportBottomSheetTopBarComponent(
+            onClickBack = navigateToBack,
+        )
+
+        NavHost(
+            modifier = modifier,
+            navController = navController,
+            startDestination = SelectReportReasonNavigator,
+            enterTransition = { EnterTransition.None },
+            exitTransition = { ExitTransition.None },
+            popEnterTransition = { EnterTransition.None },
+            popExitTransition = { ExitTransition.None },
+        ) {
+            composable<SelectReportReasonNavigator> {
+                SelectReportReasonRoute(
+                    viewModel = postReportViewModel,
+                    navigateToCheckReportType = navController::navigateToCheckReportReason,
+                )
+            }
+
+            composable<CheckReportReasonNavigator> {
+                CheckReportReasonRoute(
+                    viewModel = postReportViewModel,
+                    navigateToDoneReportReason = navController::navigateToDoneReportReason,
+                )
+            }
+
+            composable<DoneReportReasonNavigator> {
+                DoneReportReasonRoute(
+                    viewModel = postReportViewModel,
+                    navigateToHidePost = {
+                        onDismissRequest()
+                        onDoneReport()
+                    },
+                )
+            }
+        }
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/report/ReportBottomSheetDragHandleComponent.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/report/ReportBottomSheetDragHandleComponent.kt
@@ -1,0 +1,36 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.report
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+
+@Composable
+internal fun ReportBottomSheetDragHandleComponent(
+    modifier: Modifier = Modifier,
+) = Box(
+    modifier = modifier.padding(top = 16.dp)
+        .background(
+            color = SGColor.Grayscale.black100,
+            shape = RoundedCornerShape(50),
+        )
+        .size(
+            width = 40.dp,
+            height = 4.dp,
+        ),
+)
+
+@DevicePreviews
+@Composable
+private fun PreviewReportBottomSheetDragHandleComponent() {
+    SGTheme {
+        ReportBottomSheetDragHandleComponent()
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/report/ReportBottomSheetTopBarComponent.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/report/ReportBottomSheetTopBarComponent.kt
@@ -1,0 +1,78 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.report
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillLeftArrow
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGIconButton
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.post.R
+
+@Composable
+internal fun ReportBottomSheetTopBarComponent(
+    modifier: Modifier = Modifier,
+    hasBackIcon: Boolean = false,
+    onClickBack: () -> Unit,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .minimumInteractiveComponentSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (hasBackIcon) {
+                SGIconButton(
+                    imageVector = MyIconPack.IconNonFillLeftArrow,
+                    contentDescription = MyIconPack.IconNonFillLeftArrow.name,
+                    modifier = Modifier.align(Alignment.CenterStart),
+                    onClick = onClickBack,
+                )
+            }
+
+            SGText(
+                text = stringResource(R.string.report_top_bar_title),
+                getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                    lineHeight = 20.sp,
+                ),
+            )
+        }
+
+        HorizontalDivider(color = SGColor.Grayscale.black100.copy(alpha = 0.12f))
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewReportBottomSheetTopBarComponent() {
+    SGTheme {
+        ReportBottomSheetTopBarComponent(
+            onClickBack = {},
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/report/ReportReasonTextFieldComponent.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/report/ReportReasonTextFieldComponent.kt
@@ -1,0 +1,119 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.report
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+
+@Composable
+internal fun ReportReasonTextFieldComponent(
+    text: String,
+    onValueChanged: (String) -> Unit,
+    maxLength: Int,
+    modifier: Modifier = Modifier,
+) {
+    val focusManager = LocalFocusManager.current
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = SGColor.Grayscale.white,
+                shape = RoundedCornerShape(8.dp),
+            )
+            .border(
+                border = BorderStroke(
+                    width = 1.dp,
+                    color = SGColor.Grayscale.black100,
+                ),
+                shape = RoundedCornerShape(8.dp),
+            )
+            .height(160.dp),
+    ) {
+        BasicTextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp)
+                .height(160.dp),
+            value = text,
+            onValueChange = { newText ->
+                if (newText.length <= maxLength) {
+                    onValueChanged(newText)
+                }
+            },
+            textStyle = getSGNonScaleTextStyle(
+                color = SGColor.Grayscale.black100,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Normal,
+                lineHeight = 20.sp,
+                fontFamily = SGTypography.pretendard,
+                letterSpacing = (-5).em,
+            ),
+            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions { focusManager.clearFocus() },
+            decorationBox = { innerTextField ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(
+                            color = SGColor.Grayscale.white,
+                            shape = RoundedCornerShape(8.dp),
+                        ),
+                ) {
+                    if (text.isEmpty()) {
+                        SGText(
+                            text = "신고 사유를 입력해주세요",
+                            style = getSGNonScaleTextStyle(
+                                color = SGColor.Grayscale.black100.copy(alpha = 0.3f),
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.Normal,
+                                lineHeight = 20.sp,
+                                fontFamily = SGTypography.pretendard,
+                                letterSpacing = (-5).em,
+                            ),
+                        )
+                    }
+                    innerTextField()
+                }
+            },
+        )
+
+        SGText(
+            text = "${text.length}/$maxLength",
+            style = getSGNonScaleTextStyle(
+                color = when (text.length < maxLength) {
+                    true -> SGColor.Grayscale.black100
+                    false -> SGColor.negative
+                },
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Normal,
+                lineHeight = 16.sp,
+                fontFamily = SGTypography.pretendard,
+                letterSpacing = 0.sp,
+            ),
+            modifier = Modifier
+                .padding(8.dp)
+                .align(Alignment.BottomEnd),
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/report/ReportReasonTextFieldComponent.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/report/ReportReasonTextFieldComponent.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -24,6 +25,7 @@ import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
 import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
 import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
 import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.presentation.feature.main.post.R
 
 @Composable
 internal fun ReportReasonTextFieldComponent(
@@ -82,7 +84,7 @@ internal fun ReportReasonTextFieldComponent(
                 ) {
                     if (text.isEmpty()) {
                         SGText(
-                            text = "신고 사유를 입력해주세요",
+                            text = stringResource(R.string.report_reason_input_hint),
                             style = getSGNonScaleTextStyle(
                                 color = SGColor.Grayscale.black100.copy(alpha = 0.3f),
                                 fontSize = 16.sp,

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/DoneReportReasonScreen.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/DoneReportReasonScreen.kt
@@ -1,0 +1,113 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGTextButtonType2
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.post.R
+
+@Composable
+internal fun DoneReportReasonScreen(
+    hasExtraMessage: Boolean,
+    modifier: Modifier = Modifier,
+    onClickConfirm: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = 20.dp)
+            .padding(bottom = 28.dp),
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = 20.dp,
+                    vertical = 40.dp,
+                ),
+        ) {
+            SGText(
+                text = stringResource(R.string.report_done_message),
+                getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Normal,
+                    lineHeight = 24.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            if (hasExtraMessage) {
+                SGText(
+                    text = stringResource(R.string.report_done_extra_message),
+                    getSGNonScaleTextStyle(
+                        color = SGColor.Grayscale.black100,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Normal,
+                        lineHeight = 24.sp,
+                        fontFamily = SGTypography.pretendard,
+                        letterSpacing = (-5).em,
+                        textDecoration = TextDecoration.Underline,
+                    ),
+                )
+            }
+
+            SGText(
+                text = stringResource(R.string.report_done_last_message),
+                getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Normal,
+                    lineHeight = 24.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+            )
+        }
+
+        SGTextButtonType2(
+            text = stringResource(R.string.button_confirm),
+            modifier = Modifier.fillMaxWidth(),
+            onClick = onClickConfirm,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewDoneReportReasonScreen_Default() {
+    SGTheme {
+        DoneReportReasonScreen(
+            hasExtraMessage = false,
+            onClickConfirm = {},
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewDoneReportReasonScreen_Extra() {
+    SGTheme {
+        DoneReportReasonScreen(
+            hasExtraMessage = true,
+            onClickConfirm = {},
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/ImageViewerScreen.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/ImageViewerScreen.kt
@@ -1,0 +1,131 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.drawable.toBitmap
+import coil.ImageLoader
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.captures2024.soongan.core.android.utils.LocalAnalyticsHelper
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillLeftArrow
+import com.captures2024.soongan.core.designsystem.ui.component.ZoomableBox
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGIconCircleButton
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.AppConst
+import com.captures2024.soongan.presentation.feature.main.post.R
+import com.captures2024.soongan.presentation.viewmodel.main.post.ImageViewerViewModel
+import kotlinx.coroutines.delay
+
+@Composable
+internal fun ImageViewerScreen(
+    state: ImageViewerViewModel.State,
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit,
+) {
+    val analyticsHelper = LocalAnalyticsHelper.current
+    val context = LocalContext.current
+    var currentTimerValue by remember { mutableLongStateOf(AppConst.Main.Post.IMAGE_DEFAULT_DURATION) }
+
+    val model = ImageRequest.Builder(context)
+        .data(state.url)
+        .build()
+
+    val imageLoader = ImageLoader(context)
+
+    LaunchedEffect(key1 = currentTimerValue) {
+        if (currentTimerValue > 0) {
+            delay(1000L)
+            currentTimerValue -= 1000L
+        }
+
+        val bitmap = imageLoader.execute(model).drawable?.toBitmap()
+        analyticsHelper.d { "height = ${bitmap?.height}, width = ${bitmap?.width}" }
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(SGColor.black),
+        contentAlignment = Alignment.TopStart,
+    ) {
+        ZoomableBox(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = {
+                        if (currentTimerValue > 0L) {
+                            currentTimerValue -= 1000L
+                        }
+                    },
+                ),
+        ) {
+            AsyncImage(
+                model = model,
+                contentDescription = stringResource(R.string.image_description),
+                modifier = Modifier
+                    .graphicsLayer(
+                        scaleX = scale,
+                        scaleY = scale,
+                        translationX = offsetX,
+                        translationY = offsetY,
+                    ),
+                contentScale = ContentScale.FillWidth,
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
+                .height(80.dp),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            if (currentTimerValue <= 0) {
+                SGIconCircleButton(
+                    imageVector = MyIconPack.IconNonFillLeftArrow,
+                    contentDescription = stringResource(R.string.back_description),
+                    iconWidth = 20.dp,
+                    iconHeight = 16.dp,
+                    onClick = onClickBack,
+                )
+            }
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewImageViewerScreen() {
+    SGTheme {
+        ImageViewerScreen(
+            state = ImageViewerViewModel.State(
+                url = "",
+            ),
+            onClickBack = {},
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/PostInfoEditScreen.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/PostInfoEditScreen.kt
@@ -1,0 +1,139 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.WeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGTextButtonType2
+import com.captures2024.soongan.core.designsystem.ui.component.dialog.SGSingleButtonDialog
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.post.R
+import com.captures2024.soongan.presentation.feature.main.post.component.info.PostInfoEditTitleComponent
+import com.captures2024.soongan.presentation.feature.main.post.component.info.PostInfoTopBarComponent
+import com.captures2024.soongan.presentation.viewmodel.main.post.PostInfoEditViewModel
+
+@Composable
+internal fun PostInfoEditScreen(
+    state: PostInfoEditViewModel.State,
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit,
+    onTitleValueChanged: (String) -> Unit,
+    onClickEdit: () -> Unit,
+    onClickConfirmInitErrorDialog: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scrollState = rememberScrollState()
+
+    Scaffold(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = SGColor.BG.background),
+        topBar = @Composable {
+            PostInfoTopBarComponent(
+                round = state.round,
+                subject = state.subject,
+                onClickBack = onClickBack,
+            )
+        },
+        containerColor = SGColor.transparent,
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+                .padding(
+                    top = 28.dp,
+                    bottom = 58.dp,
+                )
+                .padding(horizontal = 20.dp)
+                .verticalScroll(scrollState),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(360.dp)
+                    .height(460.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                AsyncImage(
+                    model = ImageRequest.Builder(context)
+                        .data(state.defaultUrl)
+                        .build(),
+                    contentDescription = stringResource(R.string.image_description),
+                    modifier = modifier
+                        .widthIn(max = 360.dp)
+                        .heightIn(max = 460.dp),
+                    contentScale = ContentScale.Fit,
+                )
+            }
+            HeightSpacer(36.dp)
+
+            PostInfoEditTitleComponent(
+                value = state.editTitle,
+                maxInputLength = state.maxInputLength,
+                onValueChange = onTitleValueChanged,
+            )
+
+            WeightSpacer(1f)
+
+            SGTextButtonType2(
+                text = stringResource(R.string.button_edit),
+                enabled = state.isEditable,
+                onClick = onClickEdit,
+            )
+        }
+    }
+
+    if (state.isShowInitErrorDialog) {
+        SGSingleButtonDialog(
+            content = stringResource(R.string.post_info_edit_init_error_content),
+            confirmContent = stringResource(R.string.button_confirm),
+            onClickConfirm = onClickConfirmInitErrorDialog,
+            onDismissRequest = onClickConfirmInitErrorDialog,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewPostInfoEditScreen() {
+    SGTheme {
+        PostInfoEditScreen(
+            state = PostInfoEditViewModel.State(
+                round = 1,
+                subject = "평화",
+                postId = -1L,
+                defaultUrl = "test",
+                defaultTitle = "test",
+                editTitle = "test",
+                maxInputLength = 15,
+                isShowInitErrorDialog = false,
+            ),
+            onClickBack = {},
+            onTitleValueChanged = {},
+            onClickEdit = {},
+            onClickConfirmInitErrorDialog = {},
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/PostInfoMenuScreen.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/PostInfoMenuScreen.kt
@@ -1,0 +1,94 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillEdit
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillPaperDelete
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillReport
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.post.R
+import com.captures2024.soongan.presentation.feature.main.post.component.menu.PostInfoMenuItemComponent
+
+@Composable
+internal fun PostInfoMenuScreen(
+    isMyPost: Boolean,
+    onClickEdit: () -> Unit,
+    onClickDelete: () -> Unit,
+    onClickReport: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth()
+            .padding(
+                horizontal = 20.dp,
+                vertical = 16.dp,
+            ),
+    ) {
+        PostInfoMenuItemComponent(
+            text = stringResource(R.string.post_info_menu_edit_title),
+            color = when (isMyPost) {
+                true -> SGColor.Grayscale.black100
+                false -> SGColor.Grayscale.black100.copy(alpha = 0.3f)
+            },
+            icon = MyIconPack.IconNonFillEdit,
+            isVisibleDivider = true,
+            isEnabled = isMyPost,
+            onClick = onClickEdit,
+        )
+        PostInfoMenuItemComponent(
+            text = stringResource(R.string.post_info_menu_delete_title),
+            color = when (isMyPost) {
+                true -> SGColor.Grayscale.black100
+                false -> SGColor.Grayscale.black100.copy(alpha = 0.3f)
+            },
+            icon = MyIconPack.IconNonFillPaperDelete,
+            isVisibleDivider = true,
+            isEnabled = isMyPost,
+            onClick = onClickDelete,
+        )
+        PostInfoMenuItemComponent(
+            text = stringResource(R.string.post_info_menu_report_title),
+            color = when (isMyPost) {
+                true -> SGColor.Grayscale.black100.copy(alpha = 0.3f)
+                false -> SGColor.negative
+            },
+            icon = MyIconPack.IconNonFillReport,
+            isVisibleDivider = false,
+            isEnabled = !isMyPost,
+            onClick = onClickReport,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewPostInfoMenuScreen_Default() {
+    SGTheme {
+        PostInfoMenuScreen(
+            isMyPost = false,
+            onClickEdit = {},
+            onClickDelete = {},
+            onClickReport = {},
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewPostInfoMenuScreen_My() {
+    SGTheme {
+        PostInfoMenuScreen(
+            isMyPost = true,
+            onClickEdit = {},
+            onClickDelete = {},
+            onClickReport = {},
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/PostInfoScreen.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/PostInfoScreen.kt
@@ -35,9 +35,13 @@ internal fun PostInfoScreen(
     Scaffold(
         modifier = modifier
             .fillMaxSize()
-            .background(color = SGColor.tempPrimaryD),
+            .background(color = SGColor.BG.background),
         topBar = @Composable {
-            PostInfoTopBarComponent(onClickBack = onClickBack)
+            PostInfoTopBarComponent(
+                round = state.round,
+                subject = state.subject,
+                onClickBack = onClickBack,
+            )
         },
         bottomBar = @Composable {
             state.postInfo?.let { info ->
@@ -85,6 +89,8 @@ private fun PreviewPostInfoScreen_Default() {
     SGTheme {
         PostInfoScreen(
             state = PostInfoViewModel.State(
+                round = 0,
+                subject = "평화",
                 postId = -1L,
                 postInfo = null,
                 isShowMenuBottomSheet = false,
@@ -111,6 +117,8 @@ private fun PreviewPostInfoScreen_Info() {
     SGTheme {
         PostInfoScreen(
             state = PostInfoViewModel.State(
+                round = 0,
+                subject = "평화",
                 postId = -1L,
                 postInfo = PostInfoDto(),
                 isShowMenuBottomSheet = false,

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/PostInfoScreen.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/PostInfoScreen.kt
@@ -1,0 +1,132 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.dto.PostInfoDto
+import com.captures2024.soongan.presentation.feature.main.post.component.info.PostInfoBodyComponent
+import com.captures2024.soongan.presentation.feature.main.post.component.info.PostInfoBottomBarComponent
+import com.captures2024.soongan.presentation.feature.main.post.component.info.PostInfoTopBarComponent
+import com.captures2024.soongan.presentation.feature.main.post.component.menu.PostInfoMenuBottomSheet
+import com.captures2024.soongan.presentation.feature.main.post.component.report.ReportBottomSheet
+import com.captures2024.soongan.presentation.viewmodel.main.post.PostInfoViewModel
+
+@Composable
+internal fun PostInfoScreen(
+    state: PostInfoViewModel.State,
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit,
+    onClickMenu: () -> Unit,
+    onClickHeart: () -> Unit,
+    onClickPhoto: () -> Unit,
+    onDismissRequestMenuBottomSheet: () -> Unit,
+    onClickDelete: () -> Unit,
+    onClickEditPost: () -> Unit,
+    onClickReport: () -> Unit,
+    onDismissRequestReportBottomSheet: () -> Unit,
+    onDoneReport: () -> Unit,
+) {
+    Scaffold(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = SGColor.tempPrimaryD),
+        topBar = @Composable {
+            PostInfoTopBarComponent(onClickBack = onClickBack)
+        },
+        bottomBar = @Composable {
+            state.postInfo?.let { info ->
+                PostInfoBottomBarComponent(
+                    isLiked = info.isLiked,
+                    likeCount = info.likeCount,
+                    onClickMenu = onClickMenu,
+                    onClickHeart = onClickHeart,
+                )
+            }
+        },
+        containerColor = SGColor.transparent,
+    ) { innerPadding ->
+        state.postInfo?.let { info ->
+            PostInfoBodyComponent(
+                postInfo = info,
+                modifier = Modifier.padding(innerPadding),
+                onClickPhoto = onClickPhoto,
+            )
+        }
+    }
+
+    if (state.isShowMenuBottomSheet) {
+        PostInfoMenuBottomSheet(
+            isMyPost = state.isMyPost,
+            onDismissRequest = onDismissRequestMenuBottomSheet,
+            onClickDelete = onClickDelete,
+            onClickEditPost = onClickEditPost,
+            onClickReport = onClickReport,
+        )
+    }
+
+    if (state.isShowReportBottomSheet) {
+        ReportBottomSheet(
+            id = state.postId,
+            onDismissRequest = onDismissRequestReportBottomSheet,
+            onDoneReport = onDoneReport,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewPostInfoScreen_Default() {
+    SGTheme {
+        PostInfoScreen(
+            state = PostInfoViewModel.State(
+                postId = -1L,
+                postInfo = null,
+                isShowMenuBottomSheet = false,
+                isShowReportBottomSheet = false,
+                currentMemberNickname = "",
+            ),
+            onClickBack = {},
+            onClickMenu = {},
+            onClickHeart = {},
+            onClickPhoto = {},
+            onDismissRequestMenuBottomSheet = {},
+            onClickDelete = {},
+            onClickEditPost = {},
+            onClickReport = {},
+            onDismissRequestReportBottomSheet = {},
+            onDoneReport = {},
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewPostInfoScreen_Info() {
+    SGTheme {
+        PostInfoScreen(
+            state = PostInfoViewModel.State(
+                postId = -1L,
+                postInfo = PostInfoDto(),
+                isShowMenuBottomSheet = false,
+                isShowReportBottomSheet = false,
+                currentMemberNickname = "",
+            ),
+            onClickBack = {},
+            onClickMenu = {},
+            onClickHeart = {},
+            onClickPhoto = {},
+            onDismissRequestMenuBottomSheet = {},
+            onClickDelete = {},
+            onClickEditPost = {},
+            onClickReport = {},
+            onDismissRequestReportBottomSheet = {},
+            onDoneReport = {},
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/ReportInputReasonScreen.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/ReportInputReasonScreen.kt
@@ -1,0 +1,68 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGTextButtonType2
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.utils.ReportType
+import com.captures2024.soongan.presentation.feature.main.post.R
+import com.captures2024.soongan.presentation.feature.main.post.component.report.ReportReasonTextFieldComponent
+import com.captures2024.soongan.presentation.viewmodel.main.post.PostReportViewModel
+
+@Composable
+internal fun ReportInputReasonScreen(
+    state: PostReportViewModel.State,
+    modifier: Modifier = Modifier,
+    onReasonValueChanged: (String) -> Unit,
+    onClickSubmit: () -> Unit,
+) {
+    val isEnabled = state.reason.isNotEmpty()
+
+    Column(
+        modifier = modifier
+            .padding(horizontal = 20.dp)
+            .padding(
+                top = 40.dp,
+                bottom = 28.dp,
+            ),
+    ) {
+        ReportReasonTextFieldComponent(
+            text = state.reason,
+            onValueChanged = onReasonValueChanged,
+            maxLength = state.maxReasonLength,
+        )
+
+        HeightSpacer(48.dp)
+
+        SGTextButtonType2(
+            text = stringResource(R.string.button_confirm),
+            modifier = Modifier.fillMaxWidth(),
+            enabled = isEnabled,
+            onClick = onClickSubmit,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewReportInputReasonScreen() {
+    SGTheme {
+        ReportInputReasonScreen(
+            state = PostReportViewModel.State(
+                id = -1L,
+                selectedReportType = ReportType.OTHER,
+                reason = "",
+                maxReasonLength = 200,
+            ),
+            onReasonValueChanged = {},
+            onClickSubmit = {},
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/ReportReasonScreen.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/ReportReasonScreen.kt
@@ -1,0 +1,103 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.ParagraphStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGTextButtonType2
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleSpanStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.utils.ReportType
+import com.captures2024.soongan.presentation.viewmodel.main.post.PostReportViewModel
+import com.captures2024.soongan.presentation.feature.main.post.R
+import com.captures2024.soongan.presentation.feature.main.post.utils.extension.getTextId
+
+@Composable
+internal fun ReportReasonScreen(
+    state: PostReportViewModel.State,
+    modifier: Modifier = Modifier,
+    onClickSubmit: () -> Unit,
+) {
+    val commonTextStyle = getSGNonScaleSpanStyle(
+        color = SGColor.Grayscale.black100,
+        fontSize = 16.sp,
+        fontWeight = FontWeight.Normal,
+        fontFamily = SGTypography.pretendard,
+        letterSpacing = (-5).em,
+    )
+
+    val checkMassage = buildAnnotatedString {
+        pushStyle(ParagraphStyle(lineHeight = 24.sp))
+        withStyle(style = commonTextStyle) {
+            append(stringResource(R.string.report_reason_check_message_prefix))
+            append("\n")
+        }
+        withStyle(
+            style = commonTextStyle.copy(
+                fontWeight = FontWeight.Bold,
+            ),
+        ) {
+            append(stringResource(id = state.selectedReportType.getTextId()))
+        }
+        withStyle(style = commonTextStyle) {
+            append(stringResource(R.string.report_reason_check_message_suffix))
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .padding(horizontal = 20.dp)
+            .padding(
+                top = 40.dp,
+                bottom = 28.dp,
+            ),
+    ) {
+        Text(
+            text = checkMassage,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+        )
+
+        HeightSpacer(40.dp)
+
+        SGTextButtonType2(
+            text = stringResource(R.string.button_confirm),
+            modifier = Modifier.fillMaxWidth(),
+            onClick = onClickSubmit,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewReportReasonScreen() {
+    SGTheme {
+        ReportReasonScreen(
+            state = PostReportViewModel.State(
+                id = -1L,
+                selectedReportType = ReportType.INAPPROPRIATE_PHOTO_OR_BEHAVIOR,
+                reason = "",
+                maxReasonLength = 200,
+            ),
+            onClickSubmit = {},
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/SelectReportReasonScreen.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/screen/SelectReportReasonScreen.kt
@@ -1,0 +1,87 @@
+package com.captures2024.soongan.presentation.feature.main.post.component.screen
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.utils.ReportType
+import com.captures2024.soongan.presentation.feature.main.post.utils.extension.getTextId
+
+@Composable
+internal fun SelectReportReasonScreen(
+    modifier: Modifier = Modifier,
+    onClickReportType: (ReportType) -> Unit,
+) {
+    val lastIdx = ReportType.entries.lastIndex
+
+    Column(
+        modifier = modifier
+            .padding(horizontal = 20.dp)
+            .padding(bottom = 12.dp),
+    ) {
+        ReportType.entries.forEachIndexed { idx, type ->
+            PostReportDefaultBody(
+                text = stringResource(id = type.getTextId()),
+                isVisibleDivider = (idx != lastIdx),
+                onClick = { onClickReportType(type) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun PostReportDefaultBody(
+    text: String,
+    modifier: Modifier = Modifier,
+    isVisibleDivider: Boolean = true,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp),
+    ) {
+        SGText(
+            text = text,
+            style = getSGNonScaleTextStyle(
+                color = SGColor.Grayscale.black100,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                lineHeight = 20.sp,
+                fontFamily = SGTypography.pretendard,
+            ),
+            modifier = Modifier.padding(vertical = 20.dp),
+        )
+    }
+    if (isVisibleDivider) {
+        HorizontalDivider(
+            modifier = Modifier.fillMaxWidth(),
+            color = SGColor.Grayscale.black100.copy(alpha = 0.3f),
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewSelectReportReasonScreen() {
+    SGTheme {
+        SelectReportReasonScreen(
+            onClickReportType = {},
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/navigation/MainPostNavigation.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/navigation/MainPostNavigation.kt
@@ -1,0 +1,30 @@
+package com.captures2024.soongan.presentation.feature.main.post.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.captures2024.soongan.core.navigator.screen.main.post.ImageViewerNavigator
+import com.captures2024.soongan.core.navigator.screen.main.post.PostInfoNavigator
+import com.captures2024.soongan.presentation.feature.main.post.route.ImageViewerRoute
+import com.captures2024.soongan.presentation.feature.main.post.route.PostInfoRoute
+
+fun NavGraphBuilder.mainPost(
+    navigateToBack: () -> Unit,
+    navigateToImageViewer: (String) -> Unit,
+    navigateToEditPost: () -> Unit,
+    navigateToBackWithHidePost: (Long) -> Unit,
+) {
+    composable<PostInfoNavigator> {
+        PostInfoRoute(
+            navigateToBack = navigateToBack,
+            navigateToImageViewer = navigateToImageViewer,
+            navigateToEditPost = navigateToEditPost,
+            navigateToBackWithHidePost = navigateToBackWithHidePost,
+        )
+    }
+
+    composable<ImageViewerNavigator> {
+        ImageViewerRoute(
+            navigateToBack = navigateToBack,
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/navigation/MainPostNavigation.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/navigation/MainPostNavigation.kt
@@ -2,15 +2,17 @@ package com.captures2024.soongan.presentation.feature.main.post.navigation
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.captures2024.soongan.core.navigator.screen.main.post.EditPostNavigator
 import com.captures2024.soongan.core.navigator.screen.main.post.ImageViewerNavigator
 import com.captures2024.soongan.core.navigator.screen.main.post.PostInfoNavigator
 import com.captures2024.soongan.presentation.feature.main.post.route.ImageViewerRoute
+import com.captures2024.soongan.presentation.feature.main.post.route.PostInfoEditRoute
 import com.captures2024.soongan.presentation.feature.main.post.route.PostInfoRoute
 
 fun NavGraphBuilder.mainPost(
     navigateToBack: () -> Unit,
     navigateToImageViewer: (String) -> Unit,
-    navigateToEditPost: () -> Unit,
+    navigateToEditPost: (Long, String, String) -> Unit,
     navigateToBackWithHidePost: (Long) -> Unit,
 ) {
     composable<PostInfoNavigator> {
@@ -24,6 +26,12 @@ fun NavGraphBuilder.mainPost(
 
     composable<ImageViewerNavigator> {
         ImageViewerRoute(
+            navigateToBack = navigateToBack,
+        )
+    }
+
+    composable<EditPostNavigator> {
+        PostInfoEditRoute(
             navigateToBack = navigateToBack,
         )
     }

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/CheckReportReasonRoute.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/CheckReportReasonRoute.kt
@@ -1,0 +1,44 @@
+package com.captures2024.soongan.presentation.feature.main.post.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import com.captures2024.soongan.core.model.utils.ReportType
+import com.captures2024.soongan.presentation.feature.main.post.component.screen.ReportInputReasonScreen
+import com.captures2024.soongan.presentation.feature.main.post.component.screen.ReportReasonScreen
+import com.captures2024.soongan.presentation.viewmodel.main.post.PostReportViewModel
+
+@Composable
+internal fun CheckReportReasonRoute(
+    viewModel: PostReportViewModel,
+    modifier: Modifier = Modifier,
+    navigateToDoneReportReason: () -> Unit,
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collect { effect ->
+            if (effect is PostReportViewModel.Effect.NavigateToDoneReportReason) {
+                navigateToDoneReportReason()
+            }
+        }
+    }
+
+    when (state.selectedReportType) {
+        ReportType.COPYRIGHT_OR_PRIVACY_VIOLATION,
+        ReportType.OTHER,
+        -> ReportInputReasonScreen(
+            state = state,
+            onReasonValueChanged = { viewModel.intent(PostReportViewModel.Intent.OnReasonValueChanged(it)) },
+            onClickSubmit = { viewModel.intent(PostReportViewModel.Intent.OnClickSubmit) },
+        )
+
+        else -> ReportReasonScreen(
+            state = state,
+            modifier = modifier,
+            onClickSubmit = { viewModel.intent(PostReportViewModel.Intent.OnClickSubmit) },
+        )
+    }
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/DoneReportReasonRoute.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/DoneReportReasonRoute.kt
@@ -1,0 +1,41 @@
+package com.captures2024.soongan.presentation.feature.main.post.route
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import com.captures2024.soongan.core.model.utils.ReportType
+import com.captures2024.soongan.presentation.feature.main.post.component.screen.DoneReportReasonScreen
+import com.captures2024.soongan.presentation.viewmodel.main.post.PostReportViewModel
+
+@Composable
+internal fun DoneReportReasonRoute(
+    viewModel: PostReportViewModel,
+    navigateToHidePost: () -> Unit,
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collect { effect ->
+            if (effect is PostReportViewModel.Effect.NavigateToHidePost) {
+                navigateToHidePost()
+            }
+        }
+    }
+
+    BackHandler {}
+
+    val hasExtraMessage = when (state.selectedReportType) {
+        ReportType.COPYRIGHT_OR_PRIVACY_VIOLATION,
+        ReportType.OTHER,
+        -> true
+
+        else -> false
+    }
+
+    DoneReportReasonScreen(
+        hasExtraMessage = hasExtraMessage,
+        onClickConfirm = { viewModel.intent(PostReportViewModel.Intent.OnClickDoneReport) },
+    )
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/ImageViewerRoute.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/ImageViewerRoute.kt
@@ -1,0 +1,30 @@
+package com.captures2024.soongan.presentation.feature.main.post.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.captures2024.soongan.presentation.feature.main.post.component.screen.ImageViewerScreen
+import com.captures2024.soongan.presentation.viewmodel.main.post.ImageViewerViewModel
+
+@Composable
+internal fun ImageViewerRoute(
+    navigateToBack: () -> Unit,
+    viewModel: ImageViewerViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is ImageViewerViewModel.Effect.NavigateToBack -> navigateToBack()
+            }
+        }
+    }
+
+    ImageViewerScreen(
+        state = state,
+        onClickBack = { viewModel.intent(ImageViewerViewModel.Intent.OnClickBack) },
+    )
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/PostInfoEditRoute.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/PostInfoEditRoute.kt
@@ -1,0 +1,33 @@
+package com.captures2024.soongan.presentation.feature.main.post.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.captures2024.soongan.presentation.feature.main.post.component.screen.PostInfoEditScreen
+import com.captures2024.soongan.presentation.viewmodel.main.post.PostInfoEditViewModel
+
+@Composable
+internal fun PostInfoEditRoute(
+    navigateToBack: () -> Unit,
+    viewModel: PostInfoEditViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is PostInfoEditViewModel.Effect.NavigateToBack -> navigateToBack()
+            }
+        }
+    }
+
+    PostInfoEditScreen(
+        state = state,
+        onClickBack = { viewModel.intent(PostInfoEditViewModel.Intent.OnClickBack) },
+        onTitleValueChanged = { viewModel.intent(PostInfoEditViewModel.Intent.OnTitleValueChanged(it)) },
+        onClickEdit = { viewModel.intent(PostInfoEditViewModel.Intent.OnClickEdit) },
+        onClickConfirmInitErrorDialog = { viewModel.intent(PostInfoEditViewModel.Intent.OnClickConfirmInitErrorDialog) },
+    )
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/PostInfoRoute.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/PostInfoRoute.kt
@@ -11,7 +11,7 @@ import com.captures2024.soongan.presentation.viewmodel.main.post.PostInfoViewMod
 @Composable
 internal fun PostInfoRoute(
     navigateToBack: () -> Unit,
-    navigateToEditPost: () -> Unit,
+    navigateToEditPost: (Long, String, String) -> Unit,
     navigateToImageViewer: (String) -> Unit,
     navigateToBackWithHidePost: (Long) -> Unit,
     viewModel: PostInfoViewModel = hiltViewModel(),
@@ -22,7 +22,7 @@ internal fun PostInfoRoute(
         viewModel.sideEffect.collect { effect ->
             when (effect) {
                 is PostInfoViewModel.Effect.NavigateToBack -> navigateToBack()
-                is PostInfoViewModel.Effect.NavigateToEditPost -> navigateToEditPost()
+                is PostInfoViewModel.Effect.NavigateToEditPost -> navigateToEditPost(effect.postId, effect.url, effect.title)
                 is PostInfoViewModel.Effect.NavigateToImageViewer -> navigateToImageViewer(effect.url)
                 is PostInfoViewModel.Effect.NavigateToBackWithHidePost -> navigateToBackWithHidePost(effect.postId)
             }

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/PostInfoRoute.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/PostInfoRoute.kt
@@ -1,0 +1,45 @@
+package com.captures2024.soongan.presentation.feature.main.post.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.captures2024.soongan.presentation.feature.main.post.component.screen.PostInfoScreen
+import com.captures2024.soongan.presentation.viewmodel.main.post.PostInfoViewModel
+
+@Composable
+internal fun PostInfoRoute(
+    navigateToBack: () -> Unit,
+    navigateToEditPost: () -> Unit,
+    navigateToImageViewer: (String) -> Unit,
+    navigateToBackWithHidePost: (Long) -> Unit,
+    viewModel: PostInfoViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is PostInfoViewModel.Effect.NavigateToBack -> navigateToBack()
+                is PostInfoViewModel.Effect.NavigateToEditPost -> navigateToEditPost()
+                is PostInfoViewModel.Effect.NavigateToImageViewer -> navigateToImageViewer(effect.url)
+                is PostInfoViewModel.Effect.NavigateToBackWithHidePost -> navigateToBackWithHidePost(effect.postId)
+            }
+        }
+    }
+
+    PostInfoScreen(
+        state = state,
+        onClickBack = { viewModel.intent(PostInfoViewModel.Intent.OnClickBack) },
+        onClickMenu = { viewModel.intent(PostInfoViewModel.Intent.OnClickMenu) },
+        onClickHeart = { viewModel.intent(PostInfoViewModel.Intent.OnClickHeart) },
+        onClickPhoto = { viewModel.intent(PostInfoViewModel.Intent.OnClickPhoto) },
+        onDismissRequestMenuBottomSheet = { viewModel.intent(PostInfoViewModel.Intent.OnDismissRequestMenuBottomSheet) },
+        onClickDelete = { viewModel.intent(PostInfoViewModel.Intent.OnClickDelete) },
+        onClickEditPost = { viewModel.intent(PostInfoViewModel.Intent.OnClickEditPost) },
+        onClickReport = { viewModel.intent(PostInfoViewModel.Intent.OnClickReport) },
+        onDismissRequestReportBottomSheet = { viewModel.intent(PostInfoViewModel.Intent.OnDismissRequestReportBottomSheet) },
+        onDoneReport = { viewModel.intent(PostInfoViewModel.Intent.OnDoneReport) },
+    )
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/SelectReportReasonRoute.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/SelectReportReasonRoute.kt
@@ -1,0 +1,27 @@
+package com.captures2024.soongan.presentation.feature.main.post.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import com.captures2024.soongan.presentation.feature.main.post.component.screen.SelectReportReasonScreen
+import com.captures2024.soongan.presentation.viewmodel.main.post.PostReportViewModel
+
+@Composable
+internal fun SelectReportReasonRoute(
+    viewModel: PostReportViewModel,
+    modifier: Modifier = Modifier,
+    navigateToCheckReportType: () -> Unit,
+) {
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collect { effect ->
+            if (effect is PostReportViewModel.Effect.NavigateToCheckReportType) {
+                navigateToCheckReportType()
+            }
+        }
+    }
+
+    SelectReportReasonScreen(
+        modifier = modifier,
+        onClickReportType = { viewModel.intent(PostReportViewModel.Intent.OnClickReportType(it)) },
+    )
+}

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/utils/extension/ReportType.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/utils/extension/ReportType.kt
@@ -1,0 +1,13 @@
+package com.captures2024.soongan.presentation.feature.main.post.utils.extension
+
+import com.captures2024.soongan.core.model.utils.ReportType
+import com.captures2024.soongan.presentation.feature.main.post.R
+
+internal fun ReportType.getTextId(): Int = when (this) {
+    ReportType.INAPPROPRIATE_PHOTO_OR_BEHAVIOR -> R.string.report_type_inappropriate_photo_or_behavior
+    ReportType.PROFANITY_HATE_SPEECH -> R.string.report_type_profanity_hate_speech
+    ReportType.COPYRIGHT_OR_PRIVACY_VIOLATION -> R.string.report_type_copyright_or_privacy_violation
+    ReportType.SPAM -> R.string.report_type_spam
+    ReportType.PROMOTIONAL_CONTENT -> R.string.report_type_promotional_content
+    ReportType.OTHER -> R.string.report_type_other
+}

--- a/presentation/feature/main-post/src/main/res/values/strings.xml
+++ b/presentation/feature/main-post/src/main/res/values/strings.xml
@@ -6,8 +6,10 @@
     <string name="heart_description">heart</string>
     <string name="image_description">image</string>
 
+    <string name="round_unit">회차</string>
 <!-- button   -->
     <string name="button_confirm">확인</string>
+    <string name="button_edit">수정하기</string>
 
 <!--  ReportType  -->
     <string name="report_type_inappropriate_photo_or_behavior">부적절한 사진 게시 및 언행</string>
@@ -36,5 +38,14 @@
 <!--  ReportReasonScreen  -->
     <string name="report_reason_check_message_prefix">이 게시물을</string>
     <string name="report_reason_check_message_suffix">(으)로 정말 신고하시겠습니까?</string>
+
+<!--  PostInfoEditTitleComponent  -->
+    <string name="post_info_edit_title_hint">제목을 입력해주세요.</string>
+
+<!--  ReportReasonTextFieldComponent  -->
+    <string name="report_reason_input_hint">신고 사유를 입력해주세요</string>
+
+<!--  PostInfoEditScreen  -->
+    <string name="post_info_edit_init_error_content">네트워크 오류가 발생했습니다.</string>
 
 </resources>

--- a/presentation/feature/main-post/src/main/res/values/strings.xml
+++ b/presentation/feature/main-post/src/main/res/values/strings.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="back_description">back</string>
+    <string name="menu_description">menu</string>
+    <string name="heart_description">heart</string>
+    <string name="image_description">image</string>
+
+<!-- button   -->
+    <string name="button_confirm">확인</string>
+
+<!--  ReportType  -->
+    <string name="report_type_inappropriate_photo_or_behavior">부적절한 사진 게시 및 언행</string>
+    <string name="report_type_profanity_hate_speech">욕설, 혐오, 비하 등이 포함된 표현</string>
+    <string name="report_type_copyright_or_privacy_violation">도용, 초상권, 저작권 등 타인의 권리 침해</string>
+    <string name="report_type_spam">게시물 도배</string>
+    <string name="report_type_promotional_content">홍보용 사진 혹은 댓글 게시</string>
+    <string name="report_type_other">기타</string>
+
+<!--  PostInfoBodyComponent  -->
+    <string name="post_info_nickname_prefix">\@</string>
+
+<!-- PostInfoMenuScreen   -->
+    <string name="post_info_menu_edit_title">수정하기</string>"
+    <string name="post_info_menu_delete_title">삭제하기</string>"
+    <string name="post_info_menu_report_title">신고하기</string>"
+
+<!--  ReportBottomSheetTopBarComponent  -->
+    <string name="report_top_bar_title">신고</string>
+
+<!-- DoneReportReasonScreen   -->
+    <string name="report_done_message">신고가 완료됐습니다.\n\n해당 게시글은 숨김 처리 되었습니다.\n\n3일 이내로 검토 후 조치가 이뤄질 예정입니다.\n결과가 나오면 알림으로 알려드리겠습니다</string>
+    <string name="report_done_extra_message">신고 내용의 구체적인 확인이 더 필요한 경우 이메일로 연락드릴 예정입니다.</string>
+    <string name="report_done_last_message">감사합니다</string>
+
+<!--  ReportReasonScreen  -->
+    <string name="report_reason_check_message_prefix">이 게시물을</string>
+    <string name="report_reason_check_message_suffix">(으)로 정말 신고하시겠습니까?</string>
+
+</resources>

--- a/presentation/feature/main/build.gradle.kts
+++ b/presentation/feature/main/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(projects.presentation.feature.mainAwards)
     implementation(projects.presentation.feature.mainFeed)
     implementation(projects.presentation.feature.mainHome)
+    implementation(projects.presentation.feature.mainPost)
     implementation(projects.presentation.feature.mainProfile)
 
     implementation(projects.presentation.viewmodel)

--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
@@ -18,6 +18,7 @@ import com.captures2024.soongan.core.navigator.screen.main.home.HomeNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHome
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHomeGallery
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToRegistrationPost
+import com.captures2024.soongan.core.navigator.screen.main.post.navigateToEditPost
 import com.captures2024.soongan.core.navigator.screen.main.post.navigateToImageViewer
 import com.captures2024.soongan.core.navigator.screen.main.post.navigateToPostInfo
 import com.captures2024.soongan.core.navigator.screen.main.util.getHidedPostId
@@ -82,7 +83,7 @@ internal fun MainScreen(navigationState: MainNavigationState) {
             mainPost(
                 navigateToBack = navigateToBack,
                 navigateToImageViewer = navController::navigateToImageViewer,
-                navigateToEditPost = { },
+                navigateToEditPost = navController::navigateToEditPost,
                 navigateToBackWithHidePost = navController::navigateToBackWithHidePost,
             )
             mainProfile()

--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
@@ -18,6 +18,10 @@ import com.captures2024.soongan.core.navigator.screen.main.home.HomeNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHome
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHomeGallery
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToRegistrationPost
+import com.captures2024.soongan.core.navigator.screen.main.post.navigateToImageViewer
+import com.captures2024.soongan.core.navigator.screen.main.post.navigateToPostInfo
+import com.captures2024.soongan.core.navigator.screen.main.util.getHidedPostId
+import com.captures2024.soongan.core.navigator.screen.main.util.navigateToBackWithHidePost
 import com.captures2024.soongan.core.navigator.screen.main.welcome.WelcomeNavigator
 import com.captures2024.soongan.presentation.feature.main.awards.navigation.mainAwards
 import com.captures2024.soongan.presentation.feature.main.component.MainComponent
@@ -25,6 +29,7 @@ import com.captures2024.soongan.presentation.feature.main.feed.navigation.mainFe
 import com.captures2024.soongan.presentation.feature.main.home.navigation.mainHome
 import com.captures2024.soongan.presentation.feature.main.navigation.MainNavigationState
 import com.captures2024.soongan.presentation.feature.main.navigation.welcome
+import com.captures2024.soongan.presentation.feature.main.post.navigation.mainPost
 import com.captures2024.soongan.presentation.feature.main.profile.navigation.mainProfile
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -71,7 +76,14 @@ internal fun MainScreen(navigationState: MainNavigationState) {
                 navigateToBack = navigateToBack,
                 navigateToRegistrationPost = navController::navigateToRegistrationPost,
                 navigateToGallery = navController::navigateToHomeGallery,
-                navigateToPost = { postId, navOptions -> },
+                navigateToPost = navController::navigateToPostInfo,
+                getHidedPostId = navController::getHidedPostId,
+            )
+            mainPost(
+                navigateToBack = navigateToBack,
+                navigateToImageViewer = navController::navigateToImageViewer,
+                navigateToEditPost = { },
+                navigateToBackWithHidePost = navController::navigateToBackWithHidePost,
             )
             mainProfile()
         }

--- a/presentation/viewmodel/build.gradle.kts
+++ b/presentation/viewmodel/build.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
     implementation(projects.core.common)
     implementation(projects.core.domain)
     implementation(projects.core.model)
+    implementation(projects.core.navigator)
 }

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/home/HomeGalleryViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/home/HomeGalleryViewModel.kt
@@ -96,6 +96,10 @@ constructor(
         data class OnClickFilterItem(
             val selectedOrderType: PostOrderType,
         ) : Intent
+
+        data class HidePost(
+            val postId: Long,
+        ) : Intent
     }
 
     init {
@@ -130,6 +134,7 @@ constructor(
             is Intent.OnClickPost -> handleOnClickPost(intent)
             is Intent.OnDismissRequestFilterBottomSheet -> handleOnDismissRequestFilterBottomSheet()
             is Intent.OnClickFilterItem -> loadingLaunch { handleOnClickFilterItem(intent) }
+            is Intent.HidePost -> handleHidePost(intent)
         }
     }
 
@@ -238,6 +243,15 @@ constructor(
         reduce {
             copy(
                 paginationStatus = status,
+            )
+        }
+    }
+
+    private fun handleHidePost(intent: Intent.HidePost) {
+        reduce {
+            copy(
+                posts = currentState.posts
+                    .filter { it.postId != intent.postId },
             )
         }
     }

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/post/ImageViewerViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/post/ImageViewerViewModel.kt
@@ -1,0 +1,73 @@
+package com.captures2024.soongan.presentation.viewmodel.main.post
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.core.navigator.screen.main.post.ImageViewerNavigator
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ImageViewerViewModel
+@Inject
+constructor(
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle: SavedStateHandle,
+) : BaseViewModel<ImageViewerViewModel.State, ImageViewerViewModel.Effect, ImageViewerViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle = savedStateHandle,
+) {
+
+    data class State(
+        val url: String,
+    ) : UIState
+
+    sealed interface Effect : UISideEffect {
+        data object NavigateToBack : Effect
+    }
+
+    sealed interface Intent : UIIntent {
+        data object OnClickBack : Intent
+    }
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State {
+        val route = savedStateHandle.toRoute<ImageViewerNavigator>()
+
+        return State(
+            url = route.url,
+        )
+    }
+
+    override fun handleIntent(intent: Intent) {
+        when (intent) {
+            is Intent.OnClickBack -> handleOnClickBack()
+        }
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        analyticsHelper.e(throwable) { "state: $currentState" }
+    }
+
+    private fun handleOnClickBack() {
+        postSideEffect(Effect.NavigateToBack)
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/post/PostInfoEditViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/post/PostInfoEditViewModel.kt
@@ -1,0 +1,188 @@
+package com.captures2024.soongan.presentation.viewmodel.main.post
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.PostSingleButtonDialogUseCase
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.core.domain.usecase.weekly.contests.EditPostTitleUseCase
+import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetWeeklyContestInfoListUseCase
+import com.captures2024.soongan.core.model.AppConst
+import com.captures2024.soongan.core.model.enums.CommonDialogType
+import com.captures2024.soongan.core.navigator.screen.main.post.EditPostNavigator
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class PostInfoEditViewModel
+@Inject
+constructor(
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle: SavedStateHandle,
+    private val postSingleButtonDialogUseCase: PostSingleButtonDialogUseCase,
+    private val getWeeklyContestInfoListUseCase: GetWeeklyContestInfoListUseCase,
+    private val editPostTitleUseCase: EditPostTitleUseCase,
+) : BaseViewModel<PostInfoEditViewModel.State, PostInfoEditViewModel.Effect, PostInfoEditViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle = savedStateHandle,
+) {
+
+    data class State(
+        val round: Int,
+        val subject: String,
+        val postId: Long,
+        val defaultUrl: String,
+        val defaultTitle: String,
+        val editTitle: String,
+        val maxInputLength: Int,
+        val isShowInitErrorDialog: Boolean,
+    ) : UIState {
+        val isEditable: Boolean
+            get() = defaultTitle != editTitle && editTitle.isNotEmpty()
+    }
+
+    sealed interface Effect : UISideEffect {
+        data object NavigateToBack : Effect
+    }
+
+    sealed interface Intent : UIIntent {
+
+        data object Init : Intent
+
+        data object OnClickBack : Intent
+
+        data class OnTitleValueChanged(
+            val newValue: String,
+        ) : Intent
+
+        data object OnClickConfirmInitErrorDialog : Intent
+
+        data object OnClickEdit : Intent
+    }
+
+    init {
+        intent(Intent.Init)
+    }
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State {
+        val route = savedStateHandle.toRoute<EditPostNavigator>()
+
+        return State(
+            round = 0,
+            subject = AppConst.EMPTY_STRING,
+            postId = route.postId,
+            defaultUrl = route.imageUrl,
+            defaultTitle = route.title,
+            editTitle = route.title,
+            maxInputLength = AppConst.Main.Home.MAX_INPUT_LENGTH,
+            isShowInitErrorDialog = false,
+        )
+    }
+
+    override fun handleIntent(intent: Intent) {
+        when (intent) {
+            is Intent.Init -> loadingLaunch { handleInit() }
+            is Intent.OnClickBack -> handleOnClickBack()
+            is Intent.OnTitleValueChanged -> handleOnTitleValueChanged(intent)
+            is Intent.OnClickConfirmInitErrorDialog -> handleOnClickConfirmInitErrorDialog()
+            is Intent.OnClickEdit -> loadingLaunch { handleOnClickEdit() }
+        }
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        analyticsHelper.e(throwable) { "state: $currentState" }
+    }
+
+    private suspend fun handleInit() {
+        val weeklyInfo = getWeeklyContestInfoListUseCase
+            .invoke()
+            .getOrNull()
+            ?.weeklyContestInfoList
+            ?.lastOrNull()
+
+        if (weeklyInfo == null) {
+            showInitErrorDialog()
+            return
+        }
+
+        reduce {
+            copy(
+                round = weeklyInfo.round,
+                subject = weeklyInfo.subject,
+            )
+        }
+    }
+
+    private fun handleOnClickBack() {
+        postSideEffect(Effect.NavigateToBack)
+    }
+
+    private fun handleOnTitleValueChanged(intent: Intent.OnTitleValueChanged) {
+        val newValue = intent.newValue
+
+        if (newValue.length > currentState.maxInputLength) {
+            return
+        }
+
+        reduce {
+            copy(
+                editTitle = newValue,
+            )
+        }
+    }
+
+    private fun handleOnClickConfirmInitErrorDialog() {
+        dismissInitErrorDialog()
+        postSideEffect(Effect.NavigateToBack)
+    }
+
+    private suspend fun handleOnClickEdit() {
+        val state = currentState
+
+        val result = editPostTitleUseCase(
+            postId = state.postId,
+            title = state.editTitle,
+        ).getOrNull()
+
+        if (result == null) {
+            postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+            return
+        }
+
+        postSideEffect(Effect.NavigateToBack)
+    }
+
+    private fun showInitErrorDialog() {
+        reduce {
+            copy(
+                isShowInitErrorDialog = true,
+            )
+        }
+    }
+
+    private fun dismissInitErrorDialog() {
+        reduce {
+            copy(
+                isShowInitErrorDialog = false,
+            )
+        }
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/post/PostInfoViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/post/PostInfoViewModel.kt
@@ -17,6 +17,7 @@ import com.captures2024.soongan.core.domain.usecase.members.GetCurrentMemberFlow
 import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.domain.usecase.weekly.contests.DeletePostUseCase
 import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetPostInfoUseCase
+import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetWeeklyContestInfoListUseCase
 import com.captures2024.soongan.core.model.AppConst
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import com.captures2024.soongan.core.model.enums.CommonDialogType
@@ -39,6 +40,7 @@ constructor(
     savedStateHandle: SavedStateHandle,
     private val postSingleButtonDialogUseCase: PostSingleButtonDialogUseCase,
     private val currentMemberFlowUseCase: GetCurrentMemberFlowUseCase,
+    private val getWeeklyContestInfoListUseCase: GetWeeklyContestInfoListUseCase,
     private val getPostInfoUseCase: GetPostInfoUseCase,
     private val deletePostUseCase: DeletePostUseCase,
     private val putPostLikeUseCase: PutPostLikeUseCase,
@@ -53,6 +55,8 @@ constructor(
     savedStateHandle = savedStateHandle,
 ) {
     data class State(
+        val round: Int,
+        val subject: String,
         val postId: Long,
         val postInfo: PostInfoDto?,
         val isShowMenuBottomSheet: Boolean,
@@ -67,7 +71,11 @@ constructor(
 
         data object NavigateToBack : Effect
 
-        data object NavigateToEditPost : Effect
+        data class NavigateToEditPost(
+            val postId: Long,
+            val url: String,
+            val title: String,
+        ) : Effect
 
         data class NavigateToImageViewer(
             val url: String,
@@ -110,6 +118,8 @@ constructor(
         val route = savedStateHandle.toRoute<PostInfoNavigator>()
 
         return State(
+            round = 0,
+            subject = AppConst.EMPTY_STRING,
             postId = route.id,
             postInfo = null,
             currentMemberNickname = null,
@@ -141,7 +151,27 @@ constructor(
     private fun handleInit() {
         launch { collectMemberInfo() }
 
-        loadingLaunch { getRemotePostInfo() }
+        loadingLaunch {
+            val weeklyInfo = getWeeklyContestInfoListUseCase
+                .invoke()
+                .getOrNull()
+                ?.weeklyContestInfoList
+                ?.lastOrNull()
+
+            if (weeklyInfo == null) {
+                postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+                return@loadingLaunch
+            }
+
+            reduce {
+                copy(
+                    round = weeklyInfo.round,
+                    subject = weeklyInfo.subject,
+                )
+            }
+
+            loadingLaunch { getRemotePostInfo() }
+        }
     }
 
     private fun handleOnClickBack() {
@@ -210,7 +240,15 @@ constructor(
     }
 
     private fun handleOnClickEditPost() {
-        postSideEffect(Effect.NavigateToEditPost)
+        val postInfo = currentState.postInfo ?: return
+
+        postSideEffect(
+            sideEffect = Effect.NavigateToEditPost(
+                postId = postInfo.postId,
+                url = postInfo.imageUrl,
+                title = postInfo.title,
+            ),
+        )
     }
 
     private fun handleOnClickReport() {

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/post/PostInfoViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/post/PostInfoViewModel.kt
@@ -1,0 +1,285 @@
+package com.captures2024.soongan.presentation.viewmodel.main.post
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.PostSingleButtonDialogUseCase
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.like.DeletePostLikeUseCase
+import com.captures2024.soongan.core.domain.usecase.like.PutPostLikeUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetCurrentMemberFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.core.domain.usecase.weekly.contests.DeletePostUseCase
+import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetPostInfoUseCase
+import com.captures2024.soongan.core.model.AppConst
+import com.captures2024.soongan.core.model.dto.PostInfoDto
+import com.captures2024.soongan.core.model.enums.CommonDialogType
+import com.captures2024.soongan.core.navigator.screen.main.post.PostInfoNavigator
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.ContestType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class PostInfoViewModel
+@Inject
+constructor(
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle: SavedStateHandle,
+    private val postSingleButtonDialogUseCase: PostSingleButtonDialogUseCase,
+    private val currentMemberFlowUseCase: GetCurrentMemberFlowUseCase,
+    private val getPostInfoUseCase: GetPostInfoUseCase,
+    private val deletePostUseCase: DeletePostUseCase,
+    private val putPostLikeUseCase: PutPostLikeUseCase,
+    private val deletePostLikeUseCase: DeletePostLikeUseCase,
+) : BaseViewModel<PostInfoViewModel.State, PostInfoViewModel.Effect, PostInfoViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle = savedStateHandle,
+) {
+    data class State(
+        val postId: Long,
+        val postInfo: PostInfoDto?,
+        val isShowMenuBottomSheet: Boolean,
+        val isShowReportBottomSheet: Boolean,
+        internal val currentMemberNickname: String?,
+    ) : UIState {
+        val isMyPost: Boolean
+            get() = postInfo?.nickname == currentMemberNickname
+    }
+
+    sealed interface Effect : UISideEffect {
+
+        data object NavigateToBack : Effect
+
+        data object NavigateToEditPost : Effect
+
+        data class NavigateToImageViewer(
+            val url: String,
+        ) : Effect
+
+        data class NavigateToBackWithHidePost(
+            val postId: Long,
+        ) : Effect
+    }
+
+    sealed interface Intent : UIIntent {
+        data object Init : Intent
+
+        data object OnClickBack : Intent
+
+        data object OnClickMenu : Intent
+
+        data object OnClickHeart : Intent
+
+        data object OnClickPhoto : Intent
+
+        data object OnDismissRequestMenuBottomSheet : Intent
+
+        data object OnClickDelete : Intent
+
+        data object OnClickEditPost : Intent
+
+        data object OnClickReport : Intent
+
+        data object OnDismissRequestReportBottomSheet : Intent
+
+        data object OnDoneReport : Intent
+    }
+
+    init {
+        intent(Intent.Init)
+    }
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State {
+        val route = savedStateHandle.toRoute<PostInfoNavigator>()
+
+        return State(
+            postId = route.id,
+            postInfo = null,
+            currentMemberNickname = null,
+            isShowMenuBottomSheet = false,
+            isShowReportBottomSheet = false,
+        )
+    }
+
+    override fun handleIntent(intent: Intent) {
+        when (intent) {
+            is Intent.Init -> handleInit()
+            is Intent.OnClickBack -> handleOnClickBack()
+            is Intent.OnClickMenu -> handleOnClickMenu()
+            is Intent.OnClickHeart -> loadingLaunch { handleOnClickHeart() }
+            is Intent.OnClickPhoto -> handleOnClickPhoto()
+            is Intent.OnDismissRequestMenuBottomSheet -> handleOnDismissRequestMenuBottomSheet()
+            is Intent.OnClickDelete -> loadingLaunch { handleOnClickDelete() }
+            is Intent.OnClickEditPost -> handleOnClickEditPost()
+            is Intent.OnClickReport -> handleOnClickReport()
+            is Intent.OnDismissRequestReportBottomSheet -> handleOnDismissRequestReportBottomSheet()
+            is Intent.OnDoneReport -> handleOnDoneReport()
+        }
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        analyticsHelper.e(throwable = throwable) { "state: $currentState" }
+    }
+
+    private fun handleInit() {
+        launch { collectMemberInfo() }
+
+        loadingLaunch { getRemotePostInfo() }
+    }
+
+    private fun handleOnClickBack() {
+        postSideEffect(Effect.NavigateToBack)
+    }
+
+    private fun handleOnClickMenu() {
+        showMenuBottomSheet()
+    }
+
+    private suspend fun handleOnClickHeart() {
+        val postInfo = currentState.postInfo ?: return
+
+        val result = when (postInfo.isLiked) {
+            true -> deletePostLikeUseCase(
+                postId = currentState.postId,
+                contestType = ContestType.WEEKLY.name,
+            ).getOrNull()
+
+            false -> putPostLikeUseCase(
+                postId = currentState.postId,
+                contestType = ContestType.WEEKLY.name,
+            ).getOrNull()
+        }
+
+        if (result == null) {
+            postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+            return
+        }
+
+        reduce {
+            copy(
+                postInfo = postInfo.copy(
+                    isLiked = !postInfo.isLiked,
+                    likeCount = result.likeCount,
+                ),
+            )
+        }
+    }
+
+    private fun handleOnClickPhoto() {
+        postSideEffect(
+            sideEffect = Effect.NavigateToImageViewer(
+                url = currentState.postInfo?.imageUrl ?: AppConst.EMPTY_STRING,
+            ),
+        )
+    }
+
+    private fun handleOnDismissRequestMenuBottomSheet() {
+        dismissMenuBottomSheet()
+    }
+
+    private suspend fun handleOnClickDelete() {
+        val postId = currentState.postId
+
+        val result = deletePostUseCase(
+            postId = postId,
+        ).getOrNull()
+
+        if (result == null) {
+            postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+            return
+        }
+
+        postSideEffect(Effect.NavigateToBackWithHidePost(postId))
+    }
+
+    private fun handleOnClickEditPost() {
+        postSideEffect(Effect.NavigateToEditPost)
+    }
+
+    private fun handleOnClickReport() {
+        showReportBottomSheet()
+    }
+
+    private fun handleOnDismissRequestReportBottomSheet() {
+        dismissReportBottomSheet()
+    }
+
+    private fun handleOnDoneReport() {
+        postSideEffect(Effect.NavigateToBackWithHidePost(currentState.postId))
+    }
+
+    private suspend fun collectMemberInfo() {
+        currentMemberFlowUseCase().collect { currentMember ->
+            reduce {
+                copy(
+                    currentMemberNickname = currentMember?.nickname,
+                )
+            }
+        }
+    }
+
+    private suspend fun getRemotePostInfo() {
+        val postInfo = getPostInfoUseCase(
+            postId = currentState.postId,
+        ).getOrNull()
+
+        if (postInfo == null) {
+            postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+        }
+
+        reduce {
+            copy(
+                postInfo = postInfo,
+            )
+        }
+    }
+
+    private fun showMenuBottomSheet() {
+        reduce {
+            copy(
+                isShowMenuBottomSheet = true,
+            )
+        }
+    }
+
+    private fun dismissMenuBottomSheet() {
+        reduce {
+            copy(
+                isShowMenuBottomSheet = false,
+            )
+        }
+    }
+
+    private fun showReportBottomSheet() {
+        reduce {
+            copy(
+                isShowReportBottomSheet = true,
+            )
+        }
+    }
+
+    private fun dismissReportBottomSheet() {
+        reduce {
+            copy(
+                isShowReportBottomSheet = false,
+            )
+        }
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/post/PostReportViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/post/PostReportViewModel.kt
@@ -1,0 +1,157 @@
+package com.captures2024.soongan.presentation.viewmodel.main.post
+
+import androidx.lifecycle.SavedStateHandle
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.PostSingleButtonDialogUseCase
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.core.domain.usecase.report.PostReportUseCase
+import com.captures2024.soongan.core.model.AppConst
+import com.captures2024.soongan.core.model.enums.CommonDialogType
+import com.captures2024.soongan.core.model.utils.ReportTargetType
+import com.captures2024.soongan.core.model.utils.ReportType
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class PostReportViewModel
+@Inject
+constructor(
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle: SavedStateHandle,
+    private val postSingleButtonDialogUseCase: PostSingleButtonDialogUseCase,
+    private val postReportUseCase: PostReportUseCase,
+) : BaseViewModel<PostReportViewModel.State, PostReportViewModel.Effect, PostReportViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle = savedStateHandle,
+) {
+
+    data class State(
+        val id: Long,
+        val selectedReportType: ReportType,
+        val reason: String,
+        val maxReasonLength: Int,
+    ) : UIState
+
+    sealed interface Effect : UISideEffect {
+        data object NavigateToCheckReportType : Effect
+
+        data object NavigateToDoneReportReason : Effect
+
+        data object NavigateToHidePost : Effect
+    }
+
+    sealed interface Intent : UIIntent {
+        data class InitId(
+            val id: Long,
+        ) : Intent
+
+        data class OnClickReportType(
+            val type: ReportType,
+        ) : Intent
+
+        data class OnReasonValueChanged(
+            val newValue: String,
+        ) : Intent
+
+        data object OnClickSubmit : Intent
+
+        data object OnClickDoneReport : Intent
+    }
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State = State(
+        id = -1L,
+        selectedReportType = ReportType.OTHER,
+        reason = "",
+        maxReasonLength = AppConst.Main.Post.REPORT_REASON_MAX_LENGTH,
+    )
+
+    override fun handleIntent(intent: Intent) {
+        when (intent) {
+            is Intent.InitId -> handleInitId(intent)
+            is Intent.OnClickReportType -> handleOnClickReportType(intent)
+            is Intent.OnReasonValueChanged -> handleOnReasonValueChanged(intent)
+            is Intent.OnClickSubmit -> loadingLaunch { handleOnClickSubmit() }
+            is Intent.OnClickDoneReport -> handleOnClickDoneReport()
+        }
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        analyticsHelper.e(throwable) { "state: $currentState" }
+    }
+
+    private fun handleInitId(intent: Intent.InitId) {
+        reduce {
+            copy(
+                id = intent.id,
+            )
+        }
+    }
+
+    private fun handleOnClickReportType(intent: Intent.OnClickReportType) {
+        reduce {
+            copy(
+                selectedReportType = intent.type,
+            )
+        }
+
+        postSideEffect(Effect.NavigateToCheckReportType)
+    }
+
+    private fun handleOnReasonValueChanged(intent: Intent.OnReasonValueChanged) {
+        if (intent.newValue.length > currentState.maxReasonLength) {
+            return
+        }
+
+        reduce {
+            copy(
+                reason = intent.newValue,
+            )
+        }
+    }
+
+    private suspend fun handleOnClickSubmit() {
+        val state = currentState
+
+        if (state.id == -1L) {
+            return
+        }
+
+        val result = postReportUseCase(
+            params = PostReportUseCase.Params(
+                targetId = state.id,
+                targetType = ReportTargetType.WEEKLY_POST,
+                reportType = state.selectedReportType,
+                reason = state.reason,
+            ),
+        ).getOrNull()
+
+        if (result != true) {
+            postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+            return
+        }
+
+        postSideEffect(Effect.NavigateToDoneReportReason)
+    }
+
+    private fun handleOnClickDoneReport() {
+        postSideEffect(Effect.NavigateToHidePost)
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/ContestType.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/ContestType.kt
@@ -1,0 +1,6 @@
+package com.captures2024.soongan.presentation.viewmodel.model
+
+enum class ContestType {
+    WEEKLY,
+    DAILY,
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -52,6 +52,7 @@ include(
     ":presentation:feature:main-awards",
     ":presentation:feature:main-feed",
     ":presentation:feature:main-home",
+    ":presentation:feature:main-post",
     ":presentation:feature:main-profile",
 
     ":presentation:feature:sign",


### PR DESCRIPTION
# [SG-132] refactor post

## 변경 사항
- 기존 home post 로직 post module로 변경
- report navigator를 sealed interface에서 각각 data object로 변경
- _post edit 현재 refactor 안된 상태여서 해당 파트 merge 이후 작업_
   -  post edit refactor 추가

[SG-132]: https://captures2024.atlassian.net/browse/SG-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ