### PR TITLE
[SG-135] refactor profile

### DIFF
--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/AppConst.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/AppConst.kt
@@ -18,6 +18,11 @@ object AppConst {
             const val MAX_INPUT_LENGTH: Int = 15
         }
 
+        object Profile {
+            const val MAX_NICKNAME_LENGTH = Sign.SignUp.MAX_NICKNAME_LENGTH
+            const val MAX_INTRODUCTION_LENGTH = 20
+        }
+
         object Post {
             const val REPORT_REASON_MAX_LENGTH = 200
 

--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/profile/menu/ProfileMenuDefaultNavigator.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/profile/menu/ProfileMenuDefaultNavigator.kt
@@ -1,0 +1,15 @@
+package com.captures2024.soongan.core.navigator.screen.main.profile.menu
+
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object ProfileMenuDefaultNavigator
+
+fun NavController.navigateToProfileMenuDefault() = navigateToProfileMenuDefault(null)
+
+fun NavController.navigateToProfileMenuDefault(navOptions: NavOptions?) = navigate(
+    route = ProfileMenuDefaultNavigator,
+    navOptions = navOptions,
+)

--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/profile/menu/ProfileMenuNotificationSettingNavigator.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/profile/menu/ProfileMenuNotificationSettingNavigator.kt
@@ -1,0 +1,15 @@
+package com.captures2024.soongan.core.navigator.screen.main.profile.menu
+
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object ProfileMenuNotificationSettingNavigator
+
+fun NavController.navigateToProfileMenuNotificationSetting() = navigateToProfileMenuNotificationSetting(null)
+
+fun NavController.navigateToProfileMenuNotificationSetting(navOptions: NavOptions?) = navigate(
+    route = ProfileMenuNotificationSettingNavigator,
+    navOptions = navOptions,
+)

--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/profile/menu/ProfileMenuSignOutNavigator.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/profile/menu/ProfileMenuSignOutNavigator.kt
@@ -1,0 +1,15 @@
+package com.captures2024.soongan.core.navigator.screen.main.profile.menu
+
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object ProfileMenuSignOutNavigator
+
+fun NavController.navigateToProfileMenuSignOut() = navigateToProfileMenuSignOut(null)
+
+fun NavController.navigateToProfileMenuSignOut(navOptions: NavOptions?) = navigate(
+    route = ProfileMenuSignOutNavigator,
+    navOptions = navOptions,
+)

--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/profile/menu/ProfileMenuWithdrawNavigator.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/profile/menu/ProfileMenuWithdrawNavigator.kt
@@ -1,0 +1,15 @@
+package com.captures2024.soongan.core.navigator.screen.main.profile.menu
+
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object ProfileMenuWithdrawNavigator
+
+fun NavController.navigateToProfileMenuWithdraw() = navigateToProfileMenuWithdraw(null)
+
+fun NavController.navigateToProfileMenuWithdraw(navOptions: NavOptions?) = navigate(
+    route = ProfileMenuWithdrawNavigator,
+    navOptions = navOptions,
+)

--- a/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/component/screen/HomeGalleryScreen.kt
+++ b/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/component/screen/HomeGalleryScreen.kt
@@ -101,7 +101,7 @@ internal fun HomeGalleryScreen(
                             item(span = StaggeredGridItemSpan.FullLine) {
                                 SGGalleryEmptyItem(
                                     emptyText = stringResource(R.string.home_gallery_post_empty_content),
-                                    registrationText = stringResource(R.string.home_gallery_post_empty_content),
+                                    registrationText = stringResource(R.string.home_gallery_post_empty_button),
                                     modifier = modifier.padding(top = 100.dp),
                                     onClickRegistrationText = onClickRegisterPost,
                                 )

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/faq/FaqItemComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/faq/FaqItemComponent.kt
@@ -1,0 +1,110 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.faq
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.utils.extension.getAnswerResId
+import com.captures2024.soongan.presentation.feature.main.profile.utils.extension.getQuestionResId
+import com.captures2024.soongan.presentation.viewmodel.model.FaqCategoryItem
+
+@Composable
+internal fun FaqItemComponent(
+    faqCategoryItem: FaqCategoryItem,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier
+            .padding(horizontal = 24.dp)
+            .animateContentSize(),
+    ) {
+        Box(
+            modifier = Modifier
+                .height(60.dp)
+                .fillMaxWidth()
+                .clickable { expanded = !expanded },
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            SGText(
+                text = stringResource(faqCategoryItem.getQuestionResId()),
+                modifier = Modifier.padding(horizontal = 8.dp),
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 20.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+                maxLines = when (expanded) {
+                    true -> Int.MAX_VALUE
+                    false -> 1
+                },
+                overflow = when (expanded) {
+                    true -> TextOverflow.Visible
+                    false -> TextOverflow.Ellipsis
+                },
+            )
+        }
+
+        if (expanded) {
+            HeightSpacer(12.dp)
+
+            SGText(
+                text = stringResource(faqCategoryItem.getAnswerResId()),
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .padding(bottom = 20.dp),
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 20.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+            )
+        }
+
+        HorizontalDivider(
+            thickness = 1.dp,
+            color = SGColor.buttonDisableGray,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewFaqItemComponent() {
+    SGTheme {
+        FaqItemComponent(
+            faqCategoryItem = FaqCategoryItem.Default.First,
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/faq/FaqTabComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/faq/FaqTabComponent.kt
@@ -1,0 +1,59 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.faq
+
+import androidx.compose.material3.Tab
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.utils.extension.getTabResId
+import com.captures2024.soongan.presentation.viewmodel.model.FaqCategory
+
+@Composable
+internal fun FaqTabComponent(
+    category: FaqCategory,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Tab(
+        modifier = when (selected) {
+            true -> Modifier
+            false -> Modifier.graphicsLayer(alpha = 0.4f)
+        },
+        selected = selected,
+        onClick = onClick,
+        text = @Composable {
+            SGText(
+                text = stringResource(category.getTabResId()),
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 20.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+            )
+        },
+    )
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewFaqTabComponent() {
+    SGTheme {
+        FaqTabComponent(
+            category = FaqCategory.DEFAULT,
+            selected = true,
+            onClick = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/faq/FaqTapRowComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/faq/FaqTapRowComponent.kt
@@ -1,0 +1,93 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.faq
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.SecondaryTabRow
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.viewmodel.model.FaqCategory
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun FaqTapRowComponent(
+    tabs: List<FaqCategory>,
+    selectedCategory: FaqCategory,
+    pagerState: PagerState,
+    modifier: Modifier = Modifier,
+    onClickCategory: (FaqCategory) -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+
+    val tabIndex = tabs.indexOf(selectedCategory)
+
+    LaunchedEffect(selectedCategory) {
+        scope.launch {
+            pagerState.animateScrollToPage(tabIndex)
+        }
+    }
+
+    SecondaryTabRow(
+        selectedTabIndex = tabIndex,
+        modifier = modifier,
+        containerColor = SGColor.Grayscale.white,
+        indicator = @Composable {
+            TabRowDefaults.SecondaryIndicator(
+                Modifier
+                    .tabIndicatorOffset(
+                        selectedTabIndex = tabIndex,
+                        matchContentSize = false,
+                    )
+                    .padding(horizontal = 10.dp),
+                height = 2.dp,
+                color = SGColor.Grayscale.black100,
+            )
+        },
+        divider = @Composable {
+            HorizontalDivider(
+                modifier = Modifier.graphicsLayer(alpha = 0.4f),
+                thickness = 1.dp,
+                color = SGColor.Grayscale.black100.copy(alpha = 0.3f),
+            )
+        },
+        tabs = @Composable {
+            tabs.forEachIndexed { index, tab ->
+                FaqTabComponent(
+                    category = tab,
+                    selected = (tabIndex == index),
+                    onClick = { onClickCategory(tab) },
+                )
+            }
+        },
+    )
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewFaqTapRowComponent() {
+    val pagerState = rememberPagerState(
+        pageCount = { 3 },
+        initialPageOffsetFraction = 0f,
+        initialPage = 0,
+    )
+
+    SGTheme {
+        FaqTapRowComponent(
+            tabs = FaqCategory.entries,
+            selectedCategory = FaqCategory.DEFAULT,
+            pagerState = pagerState,
+            onClickCategory = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/faq/FaqTopBarComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/faq/FaqTopBarComponent.kt
@@ -1,0 +1,87 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.faq
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillLeftArrow
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGIconButton
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.R
+
+@Composable
+internal fun FaqTopBarComponent(
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = SGColor.Grayscale.white)
+            .padding(
+                horizontal = 20.dp,
+                vertical = 16.dp,
+            ),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        SGIconButton(onClick = onClickBack) {
+            Icon(
+                MyIconPack.IconNonFillLeftArrow,
+                contentDescription = stringResource(R.string.back_description),
+                modifier = Modifier.size(
+                    height = 20.dp,
+                    width = 16.dp,
+                ),
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(24.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            SGText(
+                text = stringResource(R.string.faq_top_bar_title),
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 20.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = 0.em,
+                ),
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewFaqTopBarComponent() {
+    SGTheme {
+        FaqTopBarComponent(
+            onClickBack = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/menu/ProfileMenuBottomSheet.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/menu/ProfileMenuBottomSheet.kt
@@ -1,0 +1,118 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.menu
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.navigator.screen.main.profile.menu.ProfileMenuDefaultNavigator
+import com.captures2024.soongan.core.navigator.screen.main.profile.menu.ProfileMenuNotificationSettingNavigator
+import com.captures2024.soongan.core.navigator.screen.main.profile.menu.ProfileMenuSignOutNavigator
+import com.captures2024.soongan.core.navigator.screen.main.profile.menu.ProfileMenuWithdrawNavigator
+import com.captures2024.soongan.core.navigator.screen.main.profile.menu.navigateToProfileMenuNotificationSetting
+import com.captures2024.soongan.core.navigator.screen.main.profile.menu.navigateToProfileMenuSignOut
+import com.captures2024.soongan.core.navigator.screen.main.profile.menu.navigateToProfileMenuWithdraw
+import com.captures2024.soongan.presentation.feature.main.profile.route.ProfileMenuDefaultRoute
+import com.captures2024.soongan.presentation.feature.main.profile.route.ProfileMenuNotificationSettingRoute
+import com.captures2024.soongan.presentation.feature.main.profile.route.ProfileMenuSignOutRoute
+import com.captures2024.soongan.presentation.feature.main.profile.route.ProfileMenuWithdrawRoute
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ProfileMenuBottomSheet(
+    modifier: Modifier = Modifier,
+    onDismissRequest: () -> Unit,
+    navigateToEditProfile: () -> Unit,
+    navigateToFaq: () -> Unit,
+    navigateToTerms: () -> Unit,
+) {
+    val sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val navController = rememberNavController()
+
+    val scope = rememberCoroutineScope()
+
+    var isAvailableBack by remember { mutableStateOf(true) }
+
+    val navigateToBack: () -> Unit = {
+        if (isAvailableBack) {
+            isAvailableBack = false
+            navController.navigateUp()
+
+            scope.launch {
+                delay(500L)
+                isAvailableBack = true
+            }
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier.fillMaxWidth(),
+        sheetState = sheetState,
+        containerColor = SGColor.Grayscale.white,
+    ) {
+        NavHost(
+            navController = navController,
+            startDestination = ProfileMenuDefaultNavigator,
+            enterTransition = { EnterTransition.None },
+            exitTransition = { ExitTransition.None },
+            popEnterTransition = { EnterTransition.None },
+            popExitTransition = { ExitTransition.None },
+        ) {
+            composable<ProfileMenuDefaultNavigator> {
+                ProfileMenuDefaultRoute(
+                    navigateToEditProfile = {
+                        onDismissRequest()
+                        navigateToEditProfile()
+                    },
+                    navigateToFaq = {
+                        onDismissRequest()
+                        navigateToFaq()
+                    },
+                    navigateToPush = navController::navigateToProfileMenuNotificationSetting,
+                    navigateToSignOut = navController::navigateToProfileMenuSignOut,
+                    navigateToTerms = {
+                        onDismissRequest()
+                        navigateToTerms()
+                    },
+                    navigateToWithdraw = navController::navigateToProfileMenuWithdraw,
+                )
+            }
+
+            composable<ProfileMenuNotificationSettingNavigator> {
+                ProfileMenuNotificationSettingRoute(
+                    navigateToBack = navigateToBack,
+                )
+            }
+
+            composable<ProfileMenuWithdrawNavigator> {
+                ProfileMenuWithdrawRoute(
+                    onDismissRequest = onDismissRequest,
+                    navigateToBack = navigateToBack,
+                )
+            }
+
+            composable<ProfileMenuSignOutNavigator> {
+                ProfileMenuSignOutRoute(
+                    onDismissRequest = onDismissRequest,
+                    navigateToBack = navigateToBack,
+                )
+            }
+        }
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/menu/ProfileMenuItemTopBarComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/menu/ProfileMenuItemTopBarComponent.kt
@@ -1,0 +1,73 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.menu
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillLeftArrow
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGIconButton
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+
+@Composable
+internal fun ProfileMenuItemTopBarComponent(
+    title: String,
+    modifier: Modifier = Modifier,
+    hasBackIcon: Boolean = false,
+    onClickBack: (() -> Unit)? = null,
+) {
+    Column(modifier = modifier) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .minimumInteractiveComponentSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (hasBackIcon && onClickBack != null) {
+                SGIconButton(
+                    imageVector = MyIconPack.IconNonFillLeftArrow,
+                    contentDescription = MyIconPack.IconNonFillLeftArrow.name,
+                    onClick = onClickBack,
+                    modifier = Modifier.align(Alignment.CenterStart),
+                )
+            }
+            SGText(
+                text = title,
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 20.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+            )
+        }
+
+        HorizontalDivider(color = SGColor.Grayscale.black100.copy(alpha = 0.12f))
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileMenuItemTopBarComponent() {
+    SGTheme {
+        ProfileMenuItemTopBarComponent(
+            title = "test",
+            hasBackIcon = true,
+            onClickBack = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationBodyComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationBodyComponent.kt
@@ -1,0 +1,67 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.notification
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.mock.mockNotificationsCountTable
+import com.captures2024.soongan.core.model.mock.mockNotificationsTable
+import com.captures2024.soongan.core.model.utils.NotificationType
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileNotificationViewModel
+
+@Composable
+internal fun NotificationBodyComponent(
+    state: ProfileNotificationViewModel.State,
+    modifier: Modifier = Modifier,
+    onClickCategory: (NotificationType) -> Unit,
+    onClickNotification: (Int) -> Unit,
+    onDeleteNotification: (Int) -> Unit,
+) {
+    val pagerState = rememberPagerState(
+        pageCount = { state.notificationCategories.size },
+        initialPageOffsetFraction = 0f,
+        initialPage = 0,
+    )
+
+    Column(modifier = modifier) {
+        NotificationTapRowComponent(
+            tabs = state.notificationCategories,
+            selectedCategory = state.selectedNotificationCategory,
+            notificationsCountTable = state.notificationsCount,
+            pagerState = pagerState,
+            onClickCategory = onClickCategory,
+        )
+
+        HorizontalPager(
+            state = pagerState,
+            userScrollEnabled = false,
+        ) { page ->
+            NotificationPageComponent(
+                notifications = state.notifications[state.selectedNotificationCategory] ?: emptyMap(),
+                onClickNotification = onClickNotification,
+                onDeleteNotification = onDeleteNotification,
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewNotificationBodyComponent() {
+    SGTheme {
+        NotificationBodyComponent(
+            state = ProfileNotificationViewModel.State(
+                notificationCategories = NotificationType.entries,
+                selectedNotificationCategory = NotificationType.CONTEST,
+                notifications = mockNotificationsTable,
+                notificationsCount = mockNotificationsCountTable,
+            ),
+            onClickCategory = {},
+            onClickNotification = {},
+            onDeleteNotification = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationEmptyComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationEmptyComponent.kt
@@ -1,0 +1,48 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.notification
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.R
+
+@Composable
+internal fun NotificationEmptyComponent(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        SGText(
+            text = stringResource(R.string.notification_empty_description),
+            style = getSGNonScaleTextStyle(
+                color = SGColor.Grayscale.black100,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Normal,
+                lineHeight = 12.sp,
+                fontFamily = SGTypography.pretendard,
+                letterSpacing = (-5).em,
+            ),
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewNotificationEmptyComponent() {
+    SGTheme {
+        NotificationEmptyComponent()
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationItemComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationItemComponent.kt
@@ -1,0 +1,150 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.notification
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.WidthSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.dto.NotificationDto
+
+@Composable
+internal fun NotificationItemComponent(
+    notification: NotificationDto,
+    modifier: Modifier = Modifier,
+    isAppeal: Boolean = false, // 소명 알림 여부
+    onClick: () -> Unit,
+) {
+    // 소명 알림 여부
+    val badgeColor = when (isAppeal) {
+        true -> SGColor.negative
+
+        false -> when (notification.isRead) {
+            true -> SGColor.transparent
+            false -> SGColor.accent
+        }
+    }
+
+    val titleColor = when (isAppeal) {
+        true -> SGColor.negative
+        false -> SGColor.Grayscale.black100
+    }
+
+    val bodyColor = when (isAppeal) {
+        true -> SGColor.negative
+        false -> SGColor.tempNotificationBody
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(
+                enabled = !notification.isRead,
+                onClick = onClick,
+            ),
+    ) {
+        HeightSpacer(20.dp)
+
+        Row(
+            modifier = Modifier.padding(start = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            NotificationBadge(color = badgeColor)
+
+            WidthSpacer(12.dp)
+
+            SGText(
+                text = notification.title,
+                style = getSGNonScaleTextStyle(
+                    color = titleColor,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 16.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+            )
+        }
+
+        HeightSpacer(8.dp)
+
+        SGText(
+            text = notification.body,
+            style = getSGNonScaleTextStyle(
+                color = bodyColor,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold,
+                lineHeight = 20.sp,
+                fontFamily = SGTypography.pretendard,
+                letterSpacing = (-5).em,
+            ),
+            modifier = Modifier.padding(horizontal = 32.dp),
+        )
+
+        HeightSpacer(8.dp)
+
+        SGText(
+            text = notification.createdAt,
+            style = getSGNonScaleTextStyle(
+                color = bodyColor,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Normal,
+                lineHeight = 20.sp,
+                fontFamily = SGTypography.pretendard,
+                letterSpacing = (-5).em,
+            ),
+            modifier = Modifier.padding(horizontal = 32.dp),
+        )
+
+        HeightSpacer(20.dp)
+    }
+}
+
+@Composable
+private fun NotificationBadge(
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(8.dp)
+            .clip(CircleShape)
+            .background(color = color),
+    )
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewNotificationItemComponent() {
+    SGTheme {
+        NotificationItemComponent(
+            notification = NotificationDto(
+                title = "알림",
+                body = "알림 내용",
+                isRead = false,
+                createdAt = "2일전",
+            ),
+            onClick = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationPageComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationPageComponent.kt
@@ -1,0 +1,111 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.notification
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillDelete
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.dto.NotificationDto
+import com.captures2024.soongan.core.model.mock.mockNotificationsTable
+import com.captures2024.soongan.core.model.utils.NotificationSubType
+import com.captures2024.soongan.core.model.utils.NotificationType
+import com.captures2024.soongan.presentation.feature.main.profile.R
+
+@Composable
+internal fun NotificationPageComponent(
+    notifications: Map<Int, NotificationDto>,
+    modifier: Modifier = Modifier,
+    onClickNotification: (Int) -> Unit,
+    onDeleteNotification: (Int) -> Unit,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        when (notifications.isEmpty()) {
+            true -> NotificationEmptyComponent()
+
+            false -> LazyColumn(modifier = modifier) {
+                items(
+                    items = notifications.entries.toList(),
+                    key = { it.key },
+                ) {
+                    val notification = it.value
+
+                    when (notification.subType) {
+                        NotificationSubType.APPEAL,
+                        NotificationSubType.NOTICE,
+                        -> NotificationItemComponent(
+                            notification = notification,
+                            isAppeal = (notification.subType == NotificationSubType.APPEAL),
+                            onClick = { onClickNotification(it.key) },
+                        )
+
+                        else -> NotificationSwipeableBoxComponent(
+                            actions = @Composable {
+                                DeleteActionBox(
+                                    onClick = { onDeleteNotification(it.key) },
+                                )
+                            },
+                            onExpanded = {},
+                            onCollapsed = {},
+                            content = @Composable {
+                                NotificationItemComponent(
+                                    notification = notification,
+                                    onClick = { onClickNotification(it.key) },
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeleteActionBox(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier
+            .fillMaxHeight()
+            .background(SGColor.negative)
+            .padding(horizontal = 12.dp)
+            .clickable(onClick = onClick),
+    ) {
+        Icon(
+            imageVector = MyIconPack.IconNonFillDelete,
+            contentDescription = stringResource(R.string.delete_description),
+            modifier = Modifier.align(Alignment.Center),
+            tint = SGColor.Grayscale.white,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewNotificationPageComponent() {
+    SGTheme {
+        NotificationPageComponent(
+            notifications = mockNotificationsTable[NotificationType.CONTEST] ?: emptyMap(),
+            onClickNotification = {},
+            onDeleteNotification = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationScreen.kt
@@ -1,0 +1,57 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.notification
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.utils.NotificationType
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileNotificationViewModel
+
+@Composable
+internal fun NotificationScreen(
+    state: ProfileNotificationViewModel.State,
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit,
+    onClickCategory: (NotificationType) -> Unit,
+    onClickNotification: (Int) -> Unit,
+    onDeleteNotification: (Int) -> Unit,
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = @Composable {
+            NotificationTopBarComponent(
+                onClickBack = onClickBack,
+            )
+        },
+    ) { paddingValues ->
+        NotificationBodyComponent(
+            state = state,
+            modifier = Modifier.padding(paddingValues),
+            onClickCategory = onClickCategory,
+            onClickNotification = onClickNotification,
+            onDeleteNotification = onDeleteNotification,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewNotificationScreen() {
+    SGTheme {
+        NotificationScreen(
+            state = ProfileNotificationViewModel.State(
+                notificationCategories = NotificationType.entries,
+                selectedNotificationCategory = NotificationType.CONTEST,
+                notifications = emptyMap(),
+                notificationsCount = emptyMap(),
+            ),
+            onClickBack = {},
+            onClickCategory = {},
+            onClickNotification = {},
+            onDeleteNotification = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationSwipeableBoxComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationSwipeableBoxComponent.kt
@@ -1,0 +1,129 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.notification
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillDelete
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+@Composable
+internal fun NotificationSwipeableBoxComponent(
+    actions: @Composable RowScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    onExpanded: () -> Unit,
+    onCollapsed: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    var boxWidth by remember { mutableFloatStateOf(0f) }
+    val offset = remember { Animatable(0f) }
+    val scope = rememberCoroutineScope()
+
+    val onHorizontalDrag: (PointerInputChange, Float) -> Unit = { _, dragAmount ->
+        scope.launch {
+            val newOffset = (offset.value + dragAmount).coerceIn(-boxWidth, 0f)
+            offset.snapTo(newOffset)
+        }
+    }
+
+    val onDragEnd: () -> Unit = {
+        when {
+            offset.value <= -boxWidth / 2f -> scope.launch {
+                offset.animateTo(-boxWidth)
+                onExpanded()
+            }
+
+            else -> scope.launch {
+                offset.animateTo(0f)
+                onCollapsed()
+            }
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .height(IntrinsicSize.Min),
+    ) {
+        Row(
+            modifier = Modifier
+                .onSizeChanged { boxWidth = it.width.toFloat() }
+                .align(Alignment.CenterEnd),
+        ) {
+            actions()
+        }
+
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .offset { IntOffset(offset.value.roundToInt(), 0) }
+                .pointerInput(boxWidth) {
+                    detectHorizontalDragGestures(
+                        onHorizontalDrag = onHorizontalDrag,
+                        onDragEnd = onDragEnd,
+                    )
+                },
+            color = SGColor.Grayscale.white,
+        ) {
+            content()
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewNotificationSwipeableBoxComponent() {
+    SGTheme {
+        NotificationSwipeableBoxComponent(
+            modifier = Modifier.height(100.dp),
+            actions = @Composable {
+                Box(
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .background(color = SGColor.negative)
+                        .padding(horizontal = 12.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(MyIconPack.IconNonFillDelete, null, tint = SGColor.white)
+                }
+            },
+            onExpanded = {},
+            onCollapsed = {},
+            content = @Composable {
+                Box(contentAlignment = Alignment.Center) {
+                    Text(text = "SwipeBox from left to right", fontSize = 20.sp)
+                }
+            },
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationTabComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationTabComponent.kt
@@ -1,0 +1,45 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.notification
+
+import androidx.compose.material3.Tab
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.AnnotatedString
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.utils.nonScaleAnnotatedTitle
+
+@Composable
+internal fun NotificationTabComponent(
+    annotatedString: AnnotatedString,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Tab(
+        modifier = when (selected) {
+            true -> Modifier
+            false -> Modifier.graphicsLayer(alpha = 0.4f)
+        },
+        selected = selected,
+        onClick = onClick,
+        text = @Composable {
+            SGText(annotatedString = annotatedString)
+        },
+    )
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewNotificationTabComponent() {
+    SGTheme {
+        NotificationTabComponent(
+            annotatedString = nonScaleAnnotatedTitle(
+                title = "test",
+                count = 0,
+            ),
+            selected = true,
+            onClick = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationTapRowComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationTapRowComponent.kt
@@ -1,0 +1,102 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.notification
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.SecondaryTabRow
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.utils.NotificationType
+import com.captures2024.soongan.core.model.utils.NotificationsCountTable
+import com.captures2024.soongan.presentation.feature.main.profile.utils.extension.getTabResId
+import com.captures2024.soongan.presentation.feature.main.profile.utils.nonScaleAnnotatedTitle
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun NotificationTapRowComponent(
+    tabs: List<NotificationType>,
+    selectedCategory: NotificationType,
+    notificationsCountTable: NotificationsCountTable,
+    pagerState: PagerState,
+    modifier: Modifier = Modifier,
+    onClickCategory: (NotificationType) -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+
+    val tabIndex = tabs.indexOf(selectedCategory)
+
+    LaunchedEffect(selectedCategory) {
+        scope.launch {
+            pagerState.animateScrollToPage(tabIndex)
+        }
+    }
+
+    SecondaryTabRow(
+        selectedTabIndex = tabIndex,
+        modifier = modifier,
+        containerColor = SGColor.Grayscale.white,
+        indicator = @Composable {
+            TabRowDefaults.SecondaryIndicator(
+                Modifier
+                    .tabIndicatorOffset(
+                        selectedTabIndex = tabIndex,
+                        matchContentSize = false,
+                    )
+                    .padding(horizontal = 10.dp),
+                height = 2.dp,
+                color = SGColor.Grayscale.black100,
+            )
+        },
+        divider = @Composable {
+            HorizontalDivider(
+                modifier = Modifier.graphicsLayer(alpha = 0.4f),
+                thickness = 1.dp,
+                color = SGColor.Grayscale.black100.copy(alpha = 0.3f),
+            )
+        },
+        tabs = @Composable {
+            tabs.forEachIndexed { index, tab ->
+                NotificationTabComponent(
+                    annotatedString = nonScaleAnnotatedTitle(
+                        title = stringResource(tab.getTabResId()),
+                        count = notificationsCountTable[tab] ?: 0,
+                    ),
+                    selected = (tabIndex == index),
+                    onClick = { onClickCategory(tab) },
+                )
+            }
+        },
+    )
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewNotificationTapRowComponent() {
+    val pagerState = rememberPagerState(
+        pageCount = { 3 },
+        initialPageOffsetFraction = 0f,
+        initialPage = 0,
+    )
+
+    SGTheme {
+        NotificationTapRowComponent(
+            tabs = NotificationType.entries,
+            selectedCategory = NotificationType.CONTEST,
+            notificationsCountTable = emptyMap(),
+            pagerState = pagerState,
+            onClickCategory = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationTopBarComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/notification/NotificationTopBarComponent.kt
@@ -1,0 +1,87 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.notification
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillLeftArrow
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGIconButton
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.R
+
+@Composable
+internal fun NotificationTopBarComponent(
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = SGColor.Grayscale.white)
+            .padding(
+                horizontal = 20.dp,
+                vertical = 16.dp,
+            ),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        SGIconButton(onClick = onClickBack) {
+            Icon(
+                MyIconPack.IconNonFillLeftArrow,
+                contentDescription = stringResource(R.string.back_description),
+                modifier = Modifier.size(
+                    height = 20.dp,
+                    width = 16.dp,
+                ),
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(24.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            SGText(
+                text = stringResource(R.string.notification_top_bar_title),
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 20.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = 0.em,
+                ),
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewNotificationTopBarComponent() {
+    SGTheme {
+        NotificationTopBarComponent(
+            onClickBack = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileAddIconComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileAddIconComponent.kt
@@ -1,0 +1,45 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.profile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillPlus
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+
+@Composable
+internal fun ProfileAddIconComponent(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .size(44.dp)
+            .clip(CircleShape)
+            .background(color = SGColor.black)
+            .border(width = 1.dp, color = SGColor.Grayscale.white, shape = CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = MyIconPack.IconNonFillPlus,
+            contentDescription = MyIconPack.IconNonFillPlus.name,
+            modifier = Modifier.size(22.dp),
+            tint = SGColor.Grayscale.white,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileAddIconComponent() {
+    SGTheme {
+        ProfileAddIconComponent()
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileBodyComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileBodyComponent.kt
@@ -1,0 +1,128 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.profile
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
+import androidx.compose.foundation.lazy.staggeredgrid.items
+import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGallery
+import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGalleryEmptyItem
+import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGalleryErrorItem
+import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGalleryImageItem
+import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGallerySkeletonItem
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.R
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.PaginationStatus
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ProfileBodyComponent(
+    state: ProfileViewModel.State.MyGalleryState,
+    modifier: Modifier = Modifier,
+    onRefresh: () -> Unit,
+    onLoadNextPage: () -> Unit,
+    onClickPost: (Long) -> Unit,
+    onClickRegisterPost: () -> Unit,
+) {
+    val pullToRefreshState = rememberPullToRefreshState()
+    val lazyStaggeredGridState = rememberLazyStaggeredGridState()
+    val rememberSkeletonItemHeight = remember { List(16) { (150..300).random() } }
+
+    PullToRefreshBox(
+        isRefreshing = state.isRefreshing,
+        onRefresh = onRefresh,
+        modifier = modifier.fillMaxSize(),
+        state = pullToRefreshState,
+        indicator = {
+            Indicator(
+                modifier = Modifier.align(Alignment.TopCenter),
+                isRefreshing = state.isRefreshing,
+                containerColor = SGColor.Grayscale.white,
+                color = SGColor.Grayscale.black100,
+                state = pullToRefreshState,
+            )
+        },
+    ) {
+        SGGallery(
+            modifier = Modifier.fillMaxSize(),
+            lazyStaggeredGridState = lazyStaggeredGridState,
+            isInitPage = state.isInitPage,
+            hasNextPage = state.hasNextPage,
+            onLoadNextPage = onLoadNextPage,
+        ) {
+            when {
+                state.posts.isEmpty() -> when (state.paginationStatus) {
+                    PaginationStatus.DEFAULT,
+                    PaginationStatus.REFRESH_LOAD,
+                    PaginationStatus.PAGING_LOAD,
+                    -> items(
+                        items = rememberSkeletonItemHeight,
+                    ) { height ->
+                        SGGallerySkeletonItem(height = height)
+                    }
+
+                    PaginationStatus.SUCCESS -> {
+                        item(span = StaggeredGridItemSpan.FullLine) {
+                            SGGalleryEmptyItem(
+                                emptyText = stringResource(R.string.profile_gallery_post_empty_content),
+                                registrationText = stringResource(R.string.profile_gallery_post_empty_button),
+                                modifier = modifier.padding(top = 100.dp),
+                                onClickRegistrationText = onClickRegisterPost,
+                            )
+                        }
+                    }
+
+                    PaginationStatus.FAILED -> item(span = StaggeredGridItemSpan.FullLine) {
+                        SGGalleryErrorItem(
+                            errorText = stringResource(R.string.profile_gallery_post_error),
+                        )
+                    }
+                }
+
+                else -> items(
+                    items = state.posts,
+                    key = { it.postId },
+                ) {
+                    SGGalleryImageItem(
+                        imageUrl = it.imageUrl,
+                        onClick = { onClickPost(it.postId) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileBodyComponent() {
+    SGTheme {
+        ProfileBodyComponent(
+            state = ProfileViewModel.State.MyGalleryState(
+                isRefreshing = false,
+                posts = emptyList(),
+                paginationStatus = PaginationStatus.DEFAULT,
+                loadPage = 0,
+                loadPageSize = 50,
+                hasNextPage = false,
+            ),
+            onRefresh = {},
+            onLoadNextPage = {},
+            onClickPost = {},
+            onClickRegisterPost = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileEditBodyComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileEditBodyComponent.kt
@@ -1,0 +1,152 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.profile
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.captures2024.soongan.core.common.Validation
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.WeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGTextButtonType2
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.AppConst
+import com.captures2024.soongan.presentation.feature.main.profile.R
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileEditViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.UserProfile
+import com.captures2024.soongan.core.designsystem.ui.R as RDesign
+
+@Composable
+internal fun ProfileEditBodyComponent(
+    state: ProfileEditViewModel.State,
+    modifier: Modifier = Modifier,
+    onClickProfileImage: () -> Unit,
+    onNicknameValueChanged: (String) -> Unit,
+    onIntroductionValueChanged: (String) -> Unit,
+    onClickEdit: () -> Unit,
+) {
+    val editingState = state.editingState
+    val isValidNickname = editingState.isValidNickname == Validation.NicknameValidState.Success
+    val isValidIntroduction = editingState.isValidIntroduction == Validation.IntroductionValidState.Success
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        ProfileBox(
+            profileImage = editingState.editingProfile.profileImageUrl,
+            onClick = onClickProfileImage,
+        )
+
+        HeightSpacer(44.dp)
+
+        ProfileEditOutlinedTextField(
+            value = editingState.editingProfile.nickname,
+            onValueChange = onNicknameValueChanged,
+            detailTitle = stringResource(R.string.profile_edit_nickname_description),
+            placeholder = stringResource(R.string.profile_edit_nickname_placeholder),
+            isInvalid = editingState.isDuplicatedNickname || !isValidNickname,
+            hint = when {
+                editingState.isDuplicatedNickname -> stringResource(R.string.profile_edit_nickname_error_duplicated)
+                editingState.isValidNickname == Validation.NicknameValidState.Regex -> stringResource(R.string.profile_edit_nickname_error_regex)
+                editingState.isValidNickname == Validation.NicknameValidState.Length -> stringResource(R.string.profile_edit_nickname_error_length)
+                else -> AppConst.EMPTY_STRING
+            },
+            maxInputLength = state.maxNicknameLength,
+        )
+
+        HeightSpacer(36.dp)
+
+        ProfileEditOutlinedTextField(
+            value = editingState.editingProfile.selfIntroduction,
+            onValueChange = onIntroductionValueChanged,
+            detailTitle = stringResource(R.string.profile_edit_introduction_description),
+            placeholder = stringResource(R.string.profile_edit_introduction_placeholder),
+            isInvalid = !isValidIntroduction,
+            hint = when {
+                editingState.isValidIntroduction == Validation.IntroductionValidState.Length -> stringResource(
+                    id = R.string.profile_edit_introduction_error_length,
+                )
+                else -> AppConst.EMPTY_STRING
+            },
+            maxInputLength = state.maxIntroductionLength,
+        )
+
+        WeightSpacer(1f)
+
+        SGTextButtonType2(
+            text = stringResource(R.string.button_edit_confirm),
+            modifier = Modifier.widthIn(min = 120.dp),
+            enabled = state.isEditable && !editingState.isDuplicatedNickname && isValidNickname && isValidIntroduction,
+            onClick = onClickEdit,
+        )
+
+        WeightSpacer(1f)
+    }
+}
+
+@Composable
+private fun ProfileBox(
+    profileImage: String?,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Box(
+        modifier = modifier
+            .size(180.dp)
+            .clickable(
+                onClick = onClick,
+                interactionSource = interactionSource,
+                indication = null,
+            ),
+    ) {
+        AsyncImage(
+            model = profileImage,
+            contentDescription = stringResource(R.string.image_description),
+            modifier = Modifier
+                .size(180.dp)
+                .clip(CircleShape),
+            contentScale = ContentScale.Crop,
+            placeholder = painterResource(RDesign.drawable.ic_border_profile),
+            error = painterResource(RDesign.drawable.ic_border_profile),
+        )
+
+        Box(modifier = Modifier.align(Alignment.BottomEnd)) {
+            ProfileAddIconComponent()
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileEditBodyComponent() {
+    SGTheme {
+        ProfileEditBodyComponent(
+            state = ProfileEditViewModel.State(
+                userProfile = UserProfile(),
+                editingState = ProfileEditViewModel.State.EditingProfileState(),
+                isShowEditBottomSheet = false,
+            ),
+            onClickProfileImage = {},
+            onNicknameValueChanged = {},
+            onIntroductionValueChanged = {},
+            onClickEdit = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileEditImageBottomSheet.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileEditImageBottomSheet.kt
@@ -1,0 +1,104 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.profile
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ProfileEditImageBottomSheet(
+    modifier: Modifier = Modifier,
+    onDismissRequest: () -> Unit,
+    onClickOpenPhotoPicker: () -> Unit,
+    onClickDefaultImage: () -> Unit,
+) {
+    val sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier.fillMaxWidth(),
+        sheetState = sheetState,
+        containerColor = SGColor.Grayscale.white,
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 24.dp),
+        ) {
+            BottomSheetRow(
+                itemText = stringResource(R.string.profile_image_gallery),
+                onClick = onClickOpenPhotoPicker,
+            )
+
+            HorizontalDivider(color = SGColor.Grayscale.black100.copy(alpha = 0.3f))
+
+            BottomSheetRow(
+                itemText = stringResource(R.string.profile_image_default),
+                onClick = onClickDefaultImage,
+            )
+        }
+    }
+}
+
+@Composable
+private fun BottomSheetRow(
+    itemText: String,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .padding(horizontal = 16.dp)
+            .clickable(onClick = onClick),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        SGText(
+            text = itemText,
+            style = getSGNonScaleTextStyle(
+                color = SGColor.Grayscale.black100,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                lineHeight = 20.sp,
+                fontFamily = SGTypography.pretendard,
+                letterSpacing = (-5).em,
+            ),
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileEditImageBottomSheet() {
+    SGTheme {
+        ProfileEditImageBottomSheet(
+            onDismissRequest = {},
+            onClickOpenPhotoPicker = {},
+            onClickDefaultImage = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileEditOutlinedTextField.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileEditOutlinedTextField.kt
@@ -1,0 +1,154 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.profile
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.field.SGTextFieldFormState
+import com.captures2024.soongan.core.designsystem.ui.component.text.field.SGTextFieldTypeForm
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+
+@Composable
+internal fun ProfileEditOutlinedTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    detailTitle: String = "",
+    placeholder: String = "",
+    isInvalid: Boolean = false,
+    hint: String = "",
+    maxInputLength: Int = 20,
+) {
+    val focusManager = LocalFocusManager.current
+
+    Column(modifier = modifier) {
+        Box(
+            modifier = modifier.padding(start = 12.dp),
+        ) {
+            SGText(
+                text = detailTitle,
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 8.sp,
+                    fontWeight = FontWeight.Normal,
+                    lineHeight = 8.sp,
+                    fontFamily = SGTypography.pretendard,
+                ),
+            )
+        }
+
+        HeightSpacer(4.dp)
+
+        SGTextFieldTypeForm(
+            value = value,
+            onValueChange = { newValue ->
+                if (newValue.length <= maxInputLength + 1) {
+                    onValueChange(newValue)
+                }
+            },
+            textStyle = getSGNonScaleTextStyle(
+                color = SGColor.Grayscale.black100,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Normal,
+                lineHeight = 24.sp,
+                fontFamily = SGTypography.pretendard,
+                letterSpacing = (-5).em,
+            ),
+            hint = placeholder,
+            modifier = Modifier.fillMaxWidth(),
+            state = when (isInvalid) {
+                true -> SGTextFieldFormState.Error
+                false -> SGTextFieldFormState.Default
+            },
+            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+        )
+
+        HeightSpacer(4.dp)
+
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(
+                    start = 12.dp,
+                    end = 4.dp,
+                ),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            SGText(
+                text = hint,
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.negative,
+                    fontSize = 8.sp,
+                    fontWeight = FontWeight.Normal,
+                    lineHeight = 8.sp,
+                    fontFamily = SGTypography.pretendard,
+                ),
+            )
+
+            SGText(
+                text = "${value.length}/$maxInputLength",
+                style = getSGNonScaleTextStyle(
+                    color = when {
+                        value.length <= maxInputLength -> SGColor.Grayscale.black100
+                        else -> SGColor.negative
+                    },
+                    fontSize = 8.sp,
+                    fontWeight = FontWeight.Normal,
+                    lineHeight = 8.sp,
+                    fontFamily = SGTypography.pretendard,
+                ),
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileOutlinedTextField_Default() {
+    SGTheme {
+        ProfileEditOutlinedTextField(
+            value = "asdads",
+            onValueChange = {},
+            isInvalid = false,
+            hint = "",
+            maxInputLength = 20,
+            detailTitle = "닉네임은 한글, 영문, 숫자만 입력해주세요",
+            placeholder = "닉네임은 한글, 영문, 숫자만 입력해주세요",
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileOutlinedTextField_Error() {
+    SGTheme {
+        ProfileEditOutlinedTextField(
+            value = "",
+            onValueChange = {},
+            isInvalid = true,
+            hint = "에러메시지",
+            maxInputLength = 20,
+            detailTitle = "닉네임은 한글, 영문, 숫자만 입력해주세요",
+            placeholder = "닉네임은 한글, 영문, 숫자만 입력해주세요",
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileEditTopBarComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileEditTopBarComponent.kt
@@ -1,0 +1,47 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.profile
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillLeftArrow
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGIconCircleButton
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.R
+
+@Composable
+internal fun ProfileEditTopBarComponent(
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 20.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        SGIconCircleButton(
+            imageVector = MyIconPack.IconNonFillLeftArrow,
+            contentDescription = stringResource(R.string.back_description),
+            iconWidth = 20.dp,
+            iconHeight = 16.dp,
+            onClick = onClickBack,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileEditTopBarComponent() {
+    SGTheme {
+        ProfileEditTopBarComponent(
+            onClickBack = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileTopBarComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileTopBarComponent.kt
@@ -1,0 +1,170 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.profile
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Badge
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillBell
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillMenu
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.WeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.WidthSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.R
+import com.captures2024.soongan.presentation.viewmodel.model.UserProfile
+import com.captures2024.soongan.core.designsystem.ui.R as RDesign
+
+@Composable
+internal fun ProfileTopBarComponent(
+    userProfile: UserProfile,
+    modifier: Modifier = Modifier,
+    onClickNotification: () -> Unit,
+    onClickMenu: () -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth(),
+    ) {
+        ProfileCard(
+            userProfile = userProfile,
+            modifier = Modifier.padding(top = 8.dp),
+        )
+
+        WeightSpacer(1f)
+
+        IconBox(
+            onClickNotification = onClickNotification,
+            onClickMenu = onClickMenu,
+        )
+    }
+}
+
+@Composable
+private fun ProfileCard(
+    userProfile: UserProfile,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier) {
+        AsyncImage(
+            model = userProfile.profileImageUrl,
+            contentDescription = stringResource(R.string.image_description),
+            modifier = Modifier
+                .size(60.dp)
+                .clip(CircleShape),
+            placeholder = painterResource(RDesign.drawable.ic_border_profile),
+            error = painterResource(RDesign.drawable.ic_border_profile),
+            contentScale = ContentScale.Crop,
+        )
+
+        WidthSpacer(16.dp)
+
+        Column {
+            SGText(
+                text = userProfile.nickname,
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium,
+                    lineHeight = 20.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+            )
+
+            HeightSpacer(8.dp)
+
+            SGText(
+                text = userProfile.selfIntroduction,
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Normal,
+                    lineHeight = 12.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun IconBox(
+    modifier: Modifier = Modifier,
+    onClickNotification: () -> Unit,
+    onClickMenu: () -> Unit,
+) {
+    Row(modifier = modifier) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clickable(onClick = onClickNotification),
+            contentAlignment = Alignment.Center,
+        ) {
+            Badge(
+                modifier = Modifier
+                    .size(8.dp)
+                    .offset(
+                        x = (-6).dp,
+                        y = (-6).dp,
+                    ),
+                containerColor = Color(0xffFBC304),
+            )
+            Icon(
+                imageVector = MyIconPack.IconNonFillBell,
+                contentDescription = stringResource(R.string.notification_description),
+            )
+        }
+        WidthSpacer(8.dp)
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clickable(onClick = onClickMenu),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = MyIconPack.IconNonFillMenu,
+                contentDescription = stringResource(R.string.menu_description),
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileTopBarComponent() {
+    SGTheme {
+        ProfileTopBarComponent(
+            userProfile = UserProfile(),
+            onClickNotification = {},
+            onClickMenu = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/FaqScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/FaqScreen.kt
@@ -1,0 +1,140 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.WeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.R
+import com.captures2024.soongan.presentation.feature.main.profile.component.faq.FaqItemComponent
+import com.captures2024.soongan.presentation.feature.main.profile.component.faq.FaqTapRowComponent
+import com.captures2024.soongan.presentation.feature.main.profile.component.faq.FaqTopBarComponent
+import com.captures2024.soongan.presentation.viewmodel.main.profile.FaqViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.FaqCategory
+
+@Composable
+internal fun FaqScreen(
+    state: FaqViewModel.State,
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit,
+    onClickCategory: (FaqCategory) -> Unit,
+    onClickInquiry: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+
+    val pagerState = rememberPagerState(
+        pageCount = { state.categories.size },
+        initialPageOffsetFraction = 0f,
+        initialPage = 0,
+    )
+
+    val categoryItems = state.selectedCategory.getCategoryItems()
+
+    Column(modifier = modifier.fillMaxSize()) {
+        FaqTopBarComponent(
+            onClickBack = onClickBack,
+        )
+
+        FaqTapRowComponent(
+            tabs = state.categories,
+            selectedCategory = state.selectedCategory,
+            pagerState = pagerState,
+            onClickCategory = onClickCategory,
+        )
+
+        HorizontalPager(
+            state = pagerState,
+            userScrollEnabled = false,
+        ) { page ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(color = SGColor.Grayscale.white)
+                    .verticalScroll(state = scrollState),
+            ) {
+                categoryItems.forEach { categoryItem ->
+                    FaqItemComponent(
+                        faqCategoryItem = categoryItem,
+                    )
+                }
+
+                WeightSpacer(1f)
+
+                InquiryBox(
+                    modifier = Modifier.padding(
+                        top = 48.dp,
+                        bottom = 64.dp,
+                    ),
+                    onClick = onClickInquiry,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InquiryBox(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    val commonTextStyle = getSGNonScaleTextStyle(
+        color = SGColor.Grayscale.black100,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Bold,
+        lineHeight = 12.sp,
+        fontFamily = SGTypography.pretendard,
+    )
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        SGText(
+            text = stringResource(R.string.faq_inquiry_question_message),
+            style = commonTextStyle,
+        )
+        HeightSpacer(12.dp)
+        SGText(
+            text = stringResource(R.string.faq_inquiry_text),
+            modifier = Modifier.clickable(onClick = onClick),
+            style = commonTextStyle.copy(textDecoration = TextDecoration.Underline),
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewFaqScreen() {
+    SGTheme {
+        FaqScreen(
+            state = FaqViewModel.State(
+                categories = FaqCategory.entries,
+                selectedCategory = FaqCategory.DEFAULT,
+            ),
+            onClickBack = {},
+            onClickCategory = {},
+            onClickInquiry = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileEditScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileEditScreen.kt
@@ -1,0 +1,91 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.component.profile.ProfileEditBodyComponent
+import com.captures2024.soongan.presentation.feature.main.profile.component.profile.ProfileEditImageBottomSheet
+import com.captures2024.soongan.presentation.feature.main.profile.component.profile.ProfileEditTopBarComponent
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileEditViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.UserProfile
+
+@Composable
+internal fun ProfileEditScreen(
+    state: ProfileEditViewModel.State,
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit,
+    onClickProfileImage: () -> Unit,
+    onNicknameValueChanged: (String) -> Unit,
+    onIntroductionValueChanged: (String) -> Unit,
+    onClickEdit: () -> Unit,
+    onDismissRequest: () -> Unit,
+    onClickOpenPhotoPicker: () -> Unit,
+    onClickDefaultImage: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = SGColor.Grayscale.white)
+            .padding(horizontal = 20.dp),
+    ) {
+        ProfileEditTopBarComponent(
+            onClickBack = onClickBack,
+        )
+
+        HeightSpacer(8.dp)
+
+        ProfileEditBodyComponent(
+            state = state,
+            modifier = Modifier.verticalScroll(scrollState),
+            onClickProfileImage = onClickProfileImage,
+            onNicknameValueChanged = onNicknameValueChanged,
+            onIntroductionValueChanged = onIntroductionValueChanged,
+            onClickEdit = onClickEdit,
+        )
+    }
+
+    if (state.isShowEditBottomSheet) {
+        ProfileEditImageBottomSheet(
+            onDismissRequest = onDismissRequest,
+            onClickOpenPhotoPicker = onClickOpenPhotoPicker,
+            onClickDefaultImage = onClickDefaultImage,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileEditScreen() {
+    SGTheme {
+        ProfileEditScreen(
+            state = ProfileEditViewModel.State(
+                userProfile = UserProfile(),
+                editingState = ProfileEditViewModel.State.EditingProfileState(
+                    editingProfile = UserProfile(),
+                    isDuplicatedNickname = false,
+                ),
+                isShowEditBottomSheet = false,
+            ),
+            onClickBack = {},
+            onClickProfileImage = {},
+            onNicknameValueChanged = {},
+            onIntroductionValueChanged = {},
+            onClickEdit = {},
+            onDismissRequest = {},
+            onClickOpenPhotoPicker = {},
+            onClickDefaultImage = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileMenuDefaultScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileMenuDefaultScreen.kt
@@ -1,0 +1,112 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.screen
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.utils.extension.getColor
+import com.captures2024.soongan.presentation.feature.main.profile.utils.extension.getIcon
+import com.captures2024.soongan.presentation.feature.main.profile.utils.extension.getStringResId
+import com.captures2024.soongan.presentation.viewmodel.model.ProfileBottomSheetMenuItem
+
+@Composable
+internal fun ProfileMenuDefaultScreen(
+    modifier: Modifier = Modifier,
+    onClickMenuItem: (ProfileBottomSheetMenuItem) -> Unit,
+) {
+    Column(modifier = modifier) {
+        ProfileBottomSheetMenuItem.entries.forEachIndexed { idx, item ->
+            ProfileMenuRow(
+                item = item,
+                onClick = onClickMenuItem,
+                modifier = Modifier.padding(horizontal = 24.dp),
+            )
+
+            if (idx != ProfileBottomSheetMenuItem.entries.lastIndex) {
+                HorizontalDivider(
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                    color = SGColor.Grayscale.black100.copy(alpha = 0.3f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProfileMenuRow(
+    item: ProfileBottomSheetMenuItem,
+    modifier: Modifier = Modifier,
+    onClick: (ProfileBottomSheetMenuItem) -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .padding(horizontal = 18.dp)
+            .clickable(
+                onClick = { onClick(item) },
+                interactionSource = interactionSource,
+                indication = null,
+            ),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        SGText(
+            text = stringResource(item.getStringResId()),
+            style = getSGNonScaleTextStyle(
+                color = item.getColor(),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                lineHeight = 20.sp,
+                fontFamily = SGTypography.pretendard,
+                letterSpacing = (-5).em,
+            ),
+        )
+
+        Box(
+            modifier = Modifier.size(24.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = item.getIcon(),
+                contentDescription = stringResource(item.getStringResId()),
+                tint = item.getColor(),
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileMenuDefaultScreen() {
+    SGTheme {
+        ProfileMenuDefaultScreen(
+            onClickMenuItem = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileMenuNotificationSettingScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileMenuNotificationSettingScreen.kt
@@ -1,0 +1,143 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.R
+import com.captures2024.soongan.presentation.feature.main.profile.component.menu.ProfileMenuItemTopBarComponent
+import com.captures2024.soongan.presentation.feature.main.profile.utils.extension.getDescriptionResId
+import com.captures2024.soongan.presentation.feature.main.profile.utils.extension.getTitleResId
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileNotificationSettingViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.NotificationSettingType
+
+@Composable
+internal fun ProfileMenuNotificationSettingScreen(
+    state: ProfileNotificationSettingViewModel.State.NotificationSettingState,
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit,
+    onSwitchNotificationSettingType: (NotificationSettingType) -> Unit,
+) {
+    Column(modifier = modifier) {
+        ProfileMenuItemTopBarComponent(
+            title = stringResource(R.string.profile_menu_notification_setting_title),
+            hasBackIcon = true,
+            onClickBack = onClickBack,
+        )
+
+        NotificationSettingType.entries.forEachIndexed { idx, type ->
+            NotificationToggleRow(
+                text = stringResource(type.getTitleResId()),
+                detailText = stringResource(type.getDescriptionResId()),
+                checked = state.getStateByType(type),
+                onCheckedChange = { onSwitchNotificationSettingType(type) },
+            )
+
+            if (idx != NotificationSettingType.entries.lastIndex) {
+                HorizontalDivider(
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                    color = SGColor.Grayscale.black100.copy(alpha = 0.3f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NotificationToggleRow(
+    text: String,
+    detailText: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 20.dp)
+            .padding(
+                start = 40.dp,
+                end = 24.dp,
+            ),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            SGText(
+                text = text,
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 20.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+            )
+
+            if (detailText.isNotEmpty()) {
+                SGText(
+                    text = detailText,
+                    style = getSGNonScaleTextStyle(
+                        color = SGColor.tempNotificationBody,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Normal,
+                        lineHeight = 12.sp,
+                        fontFamily = SGTypography.pretendard,
+                        letterSpacing = 0.em,
+                    ),
+                )
+            }
+        }
+
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            modifier = Modifier.size(
+                height = 28.dp,
+                width = 48.dp,
+            ),
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = SGColor.Grayscale.white,
+                checkedTrackColor = SGColor.accent,
+                checkedBorderColor = SGColor.transparent,
+                uncheckedThumbColor = SGColor.Grayscale.white,
+                uncheckedTrackColor = SGColor.Grayscale.black100.copy(alpha = 0.3f),
+                uncheckedBorderColor = SGColor.transparent,
+            ),
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileMenuNotificationSettingScreen() {
+    SGTheme {
+        ProfileMenuNotificationSettingScreen(
+            state = ProfileNotificationSettingViewModel.State.NotificationSettingState(),
+            onClickBack = {},
+            onSwitchNotificationSettingType = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileMenuSignOutDoneScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileMenuSignOutDoneScreen.kt
@@ -1,0 +1,71 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGTextButtonType2
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.R
+import com.captures2024.soongan.presentation.feature.main.profile.component.menu.ProfileMenuItemTopBarComponent
+
+@Composable
+internal fun ProfileMenuSignOutDoneScreen(
+    modifier: Modifier = Modifier,
+    onClickDone: () -> Unit,
+) {
+    Column(modifier = modifier) {
+        ProfileMenuItemTopBarComponent(
+            title = stringResource(R.string.profile_menu_sign_out_done_title),
+        )
+
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(all = 40.dp),
+        ) {
+            SGText(
+                text = stringResource(R.string.profile_menu_sign_out_done_description),
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Normal,
+                    lineHeight = 24.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+            )
+        }
+
+        SGTextButtonType2(
+            text = stringResource(R.string.button_confirm),
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 28.dp),
+            enabled = true,
+            onClick = onClickDone,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileMenuSignOutDoneScreen() {
+    SGTheme {
+        ProfileMenuSignOutDoneScreen(
+            onClickDone = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileMenuSignOutScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileMenuSignOutScreen.kt
@@ -1,0 +1,75 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGTextButtonType2
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.R
+import com.captures2024.soongan.presentation.feature.main.profile.component.menu.ProfileMenuItemTopBarComponent
+
+@Composable
+internal fun ProfileMenuSignOutScreen(
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit,
+    onClickSignOut: () -> Unit,
+) {
+    Column(modifier = modifier) {
+        ProfileMenuItemTopBarComponent(
+            title = stringResource(R.string.profile_menu_sign_out_title),
+            hasBackIcon = true,
+            onClickBack = onClickBack,
+        )
+
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(all = 40.dp),
+        ) {
+            SGText(
+                text = stringResource(R.string.profile_menu_sign_out_description),
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Normal,
+                    lineHeight = 24.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+            )
+        }
+
+        SGTextButtonType2(
+            text = stringResource(R.string.button_confirm),
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 28.dp),
+            enabled = true,
+            onClick = onClickSignOut,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileMenuSignOutScreen() {
+    SGTheme {
+        ProfileMenuSignOutScreen(
+            onClickBack = {},
+            onClickSignOut = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileMenuWithdrawDoneScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileMenuWithdrawDoneScreen.kt
@@ -1,0 +1,71 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGTextButtonType2
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.R
+import com.captures2024.soongan.presentation.feature.main.profile.component.menu.ProfileMenuItemTopBarComponent
+
+@Composable
+internal fun ProfileMenuWithdrawDoneScreen(
+    modifier: Modifier = Modifier,
+    onClickDone: () -> Unit,
+) {
+    Column(modifier = modifier) {
+        ProfileMenuItemTopBarComponent(
+            title = stringResource(R.string.profile_menu_withdraw_done_title),
+        )
+
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(all = 40.dp),
+        ) {
+            SGText(
+                text = stringResource(R.string.profile_menu_withdraw_done_description),
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Normal,
+                    lineHeight = 24.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+            )
+
+            SGTextButtonType2(
+                text = stringResource(R.string.button_confirm),
+                modifier = modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 28.dp),
+                enabled = true,
+                onClick = onClickDone,
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileMenuWithdrawDoneScreen() {
+    SGTheme {
+        ProfileMenuWithdrawDoneScreen(
+            onClickDone = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileMenuWithdrawScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileMenuWithdrawScreen.kt
@@ -1,0 +1,163 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.screen
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGTextButtonType2
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.R
+import com.captures2024.soongan.presentation.feature.main.profile.component.menu.ProfileMenuItemTopBarComponent
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileWithdrawViewModel
+
+@Composable
+internal fun ProfileMenuWithdrawScreen(
+    state: ProfileWithdrawViewModel.State,
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit,
+    onInputValueChanged: (String) -> Unit,
+    onClickWithdraw: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+
+    val placeholder = stringResource(R.string.profile_menu_withdraw_placeholder)
+
+    Column(modifier = modifier) {
+        ProfileMenuItemTopBarComponent(
+            title = stringResource(R.string.profile_menu_withdraw_title),
+            hasBackIcon = true,
+            onClickBack = onClickBack,
+        )
+
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(all = 40.dp)
+                .verticalScroll(scrollState),
+        ) {
+            SGText(
+                text = stringResource(R.string.profile_menu_withdraw_description),
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Normal,
+                    lineHeight = 24.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+            )
+
+            HeightSpacer(32.dp)
+
+            WithdrawInputTextField(
+                value = state.input,
+                onValueChange = onInputValueChanged,
+                placeholder = placeholder,
+            )
+        }
+
+        SGTextButtonType2(
+            text = stringResource(R.string.button_confirm),
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 28.dp),
+            enabled = state.input == placeholder,
+            onClick = onClickWithdraw,
+        )
+    }
+}
+
+@Composable
+private fun WithdrawInputTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String,
+) {
+    val focusManager = LocalFocusManager.current
+
+    val contentStyle = getSGNonScaleTextStyle(
+        color = SGColor.Grayscale.black100,
+        fontSize = 18.sp,
+        fontWeight = FontWeight.Normal,
+        lineHeight = 24.sp,
+        fontFamily = SGTypography.pretendard,
+        letterSpacing = (-5).em,
+    )
+
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .border(
+                width = 1.dp,
+                color = SGColor.Grayscale.black100,
+                shape = RoundedCornerShape(8.dp),
+            ),
+        textStyle = contentStyle,
+        keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+        decorationBox = { innerTextField ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(start = 14.dp),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                if (value.isEmpty()) {
+                    SGText(
+                        text = placeholder,
+                        style = contentStyle.copy(color = SGColor.buttonDisableGray),
+                    )
+                }
+                innerTextField()
+            }
+        },
+    )
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileMenuWithdrawScreen() {
+    SGTheme {
+        ProfileMenuWithdrawScreen(
+            state = ProfileWithdrawViewModel.State(
+                input = "",
+                isSuccessWithdraw = false,
+            ),
+            onClickBack = {},
+            onInputValueChanged = {},
+            onClickWithdraw = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileScreen.kt
@@ -12,8 +12,10 @@ import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
 import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
 import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
 import com.captures2024.soongan.presentation.feature.main.profile.component.menu.ProfileMenuBottomSheet
+import com.captures2024.soongan.presentation.feature.main.profile.component.profile.ProfileBodyComponent
 import com.captures2024.soongan.presentation.feature.main.profile.component.profile.ProfileTopBarComponent
 import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.PaginationStatus
 import com.captures2024.soongan.presentation.viewmodel.model.UserProfile
 
 @Composable
@@ -26,6 +28,10 @@ internal fun ProfileScreen(
     onClickEditProfile: () -> Unit,
     onClickFaq: () -> Unit,
     onClickTerms: () -> Unit,
+    onRefresh: () -> Unit,
+    onLoadNextPage: () -> Unit,
+    onClickPost: (Long) -> Unit,
+    onClickRegisterPost: () -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -45,7 +51,13 @@ internal fun ProfileScreen(
 
         HeightSpacer(28.dp)
 
-        // TODO POST
+        ProfileBodyComponent(
+            state = state.myGalleryState,
+            onRefresh = onRefresh,
+            onLoadNextPage = onLoadNextPage,
+            onClickPost = onClickPost,
+            onClickRegisterPost = onClickRegisterPost,
+        )
     }
 
     if (state.isShowMenuBottomSheet) {
@@ -65,6 +77,14 @@ private fun PreviewProfileScreen() {
         ProfileScreen(
             state = ProfileViewModel.State(
                 userProfile = UserProfile(),
+                myGalleryState = ProfileViewModel.State.MyGalleryState(
+                    isRefreshing = false,
+                    posts = emptyList(),
+                    paginationStatus = PaginationStatus.DEFAULT,
+                    loadPage = 0,
+                    loadPageSize = 50,
+                    hasNextPage = false,
+                ),
                 isShowMenuBottomSheet = false,
             ),
             onClickNotification = {},
@@ -73,6 +93,10 @@ private fun PreviewProfileScreen() {
             onClickEditProfile = {},
             onClickFaq = {},
             onClickTerms = {},
+            onRefresh = {},
+            onLoadNextPage = {},
+            onClickPost = {},
+            onClickRegisterPost = {},
         )
     }
 }

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileScreen.kt
@@ -1,0 +1,78 @@
+package com.captures2024.soongan.presentation.feature.main.profile.component.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTheme
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.profile.component.menu.ProfileMenuBottomSheet
+import com.captures2024.soongan.presentation.feature.main.profile.component.profile.ProfileTopBarComponent
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.UserProfile
+
+@Composable
+internal fun ProfileScreen(
+    state: ProfileViewModel.State,
+    modifier: Modifier = Modifier,
+    onClickNotification: () -> Unit,
+    onClickMenu: () -> Unit,
+    onDismissRequestMenuBottomSheet: () -> Unit,
+    onClickEditProfile: () -> Unit,
+    onClickFaq: () -> Unit,
+    onClickTerms: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = SGColor.Grayscale.white)
+            .padding(top = 26.dp),
+    ) {
+        ProfileTopBarComponent(
+            userProfile = state.userProfile,
+            modifier = Modifier.padding(
+                start = 20.dp,
+                end = 16.dp,
+            ),
+            onClickNotification = onClickNotification,
+            onClickMenu = onClickMenu,
+        )
+
+        HeightSpacer(28.dp)
+
+        // TODO POST
+    }
+
+    if (state.isShowMenuBottomSheet) {
+        ProfileMenuBottomSheet(
+            onDismissRequest = onDismissRequestMenuBottomSheet,
+            navigateToEditProfile = onClickEditProfile,
+            navigateToFaq = onClickFaq,
+            navigateToTerms = onClickTerms,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewProfileScreen() {
+    SGTheme {
+        ProfileScreen(
+            state = ProfileViewModel.State(
+                userProfile = UserProfile(),
+                isShowMenuBottomSheet = false,
+            ),
+            onClickNotification = {},
+            onClickMenu = {},
+            onDismissRequestMenuBottomSheet = {},
+            onClickEditProfile = {},
+            onClickFaq = {},
+            onClickTerms = {},
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/navigation/MainProfileNavigation.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/navigation/MainProfileNavigation.kt
@@ -2,10 +2,51 @@ package com.captures2024.soongan.presentation.feature.main.profile.navigation
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.captures2024.soongan.core.model.utils.NotificationSubType
+import com.captures2024.soongan.core.navigator.screen.main.profile.FAQNavigator
+import com.captures2024.soongan.core.navigator.screen.main.profile.NotificationNavigator
+import com.captures2024.soongan.core.navigator.screen.main.profile.ProfileEditNavigator
 import com.captures2024.soongan.core.navigator.screen.main.profile.ProfileNavigator
+import com.captures2024.soongan.presentation.feature.main.profile.route.FaqRoute
+import com.captures2024.soongan.presentation.feature.main.profile.route.NotificationRoute
+import com.captures2024.soongan.presentation.feature.main.profile.route.ProfileEditRoute
+import com.captures2024.soongan.presentation.feature.main.profile.route.ProfileRoute
 
-fun NavGraphBuilder.mainProfile() {
+fun NavGraphBuilder.mainProfile(
+    navigateToBack: () -> Unit,
+    navigateToNotification: () -> Unit,
+    navigateToPostInfo: (Long) -> Unit,
+    navigateToRegistrationPost: () -> Unit,
+    navigateToEditProfile: () -> Unit,
+    navigateToFAQ: () -> Unit,
+    navigateFromNotification: (NotificationSubType, String?) -> Unit,
+) {
     composable<ProfileNavigator> {
-        // TODO
+        ProfileRoute(
+            navigateToNotification = navigateToNotification,
+            navigateToPostInfo = navigateToPostInfo,
+            navigateToRegistrationPost = navigateToRegistrationPost,
+            navigateToEditProfile = navigateToEditProfile,
+            navigateToFAQ = navigateToFAQ,
+        )
+    }
+
+    composable<ProfileEditNavigator> {
+        ProfileEditRoute(
+            navigateToBack = navigateToBack,
+        )
+    }
+
+    composable<NotificationNavigator> {
+        NotificationRoute(
+            navigateToBack = navigateToBack,
+            navigateFromNotification = navigateFromNotification,
+        )
+    }
+
+    composable<FAQNavigator> {
+        FaqRoute(
+            navigateToBack = navigateToBack,
+        )
     }
 }

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/FaqRoute.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/FaqRoute.kt
@@ -1,0 +1,32 @@
+package com.captures2024.soongan.presentation.feature.main.profile.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.captures2024.soongan.presentation.feature.main.profile.component.screen.FaqScreen
+import com.captures2024.soongan.presentation.viewmodel.main.profile.FaqViewModel
+
+@Composable
+internal fun FaqRoute(
+    navigateToBack: () -> Unit,
+    viewModel: FaqViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is FaqViewModel.Effect.NavigateToBack -> navigateToBack()
+            }
+        }
+    }
+
+    FaqScreen(
+        state = state,
+        onClickBack = { viewModel.intent(FaqViewModel.Intent.OnClickBack) },
+        onClickCategory = { viewModel.intent(FaqViewModel.Intent.OnClickCategory(it)) },
+        onClickInquiry = { viewModel.intent(FaqViewModel.Intent.OnClickInquiry) },
+    )
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/NotificationRoute.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/NotificationRoute.kt
@@ -1,0 +1,39 @@
+package com.captures2024.soongan.presentation.feature.main.profile.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.captures2024.soongan.core.model.utils.NotificationSubType
+import com.captures2024.soongan.presentation.feature.main.profile.component.notification.NotificationScreen
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileNotificationViewModel
+
+@Composable
+internal fun NotificationRoute(
+    navigateToBack: () -> Unit,
+    navigateFromNotification: (NotificationSubType, String?) -> Unit,
+    viewModel: ProfileNotificationViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(viewModel.state) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is ProfileNotificationViewModel.Effect.NavigateToBack -> navigateToBack()
+                is ProfileNotificationViewModel.Effect.NavigateFromNotification -> navigateFromNotification(
+                    effect.subType,
+                    effect.url,
+                )
+            }
+        }
+    }
+
+    NotificationScreen(
+        state = state,
+        onClickBack = { viewModel.intent(ProfileNotificationViewModel.Intent.OnClickBack) },
+        onClickCategory = { viewModel.intent(ProfileNotificationViewModel.Intent.OnClickCategory(it)) },
+        onClickNotification = { viewModel.intent(ProfileNotificationViewModel.Intent.OnClickNotification(it)) },
+        onDeleteNotification = { viewModel.intent(ProfileNotificationViewModel.Intent.OnDeleteNotification(it)) },
+    )
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/ProfileEditRoute.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/ProfileEditRoute.kt
@@ -1,0 +1,51 @@
+package com.captures2024.soongan.presentation.feature.main.profile.route
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.captures2024.soongan.presentation.feature.main.profile.component.screen.ProfileEditScreen
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileEditViewModel
+
+@Composable
+internal fun ProfileEditRoute(
+    navigateToBack: () -> Unit,
+    viewModel: ProfileEditViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    val pickMedia = rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+        uri?.let {
+            viewModel.intent(ProfileEditViewModel.Intent.OnProfileImageChanged(it.toString()))
+        }
+    }
+
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is ProfileEditViewModel.Effect.NavigateToBack -> navigateToBack()
+                is ProfileEditViewModel.Effect.OpenMediaPicker -> pickMedia.launch(
+                    PickVisualMediaRequest(
+                        ActivityResultContracts.PickVisualMedia.ImageOnly,
+                    ),
+                )
+            }
+        }
+    }
+
+    ProfileEditScreen(
+        state = state,
+        onClickBack = { viewModel.intent(ProfileEditViewModel.Intent.OnClickBack) },
+        onClickProfileImage = { viewModel.intent(ProfileEditViewModel.Intent.OnClickProfileImage) },
+        onNicknameValueChanged = { viewModel.intent(ProfileEditViewModel.Intent.OnNicknameValueChanged(it)) },
+        onIntroductionValueChanged = { viewModel.intent(ProfileEditViewModel.Intent.OnIntroductionValueChanged(it)) },
+        onClickEdit = { viewModel.intent(ProfileEditViewModel.Intent.OnClickEditButton) },
+        onDismissRequest = { viewModel.intent(ProfileEditViewModel.Intent.OnDismissRequestEditBottomSheet) },
+        onClickOpenPhotoPicker = { viewModel.intent(ProfileEditViewModel.Intent.OpenPhotoPicker) },
+        onClickDefaultImage = { viewModel.intent(ProfileEditViewModel.Intent.OnChangeDefaultProfileImage) },
+    )
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/ProfileMenuDefaultRoute.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/ProfileMenuDefaultRoute.kt
@@ -1,0 +1,35 @@
+package com.captures2024.soongan.presentation.feature.main.profile.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.captures2024.soongan.presentation.feature.main.profile.component.screen.ProfileMenuDefaultScreen
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileBottomSheetViewModel
+
+@Composable
+internal fun ProfileMenuDefaultRoute(
+    navigateToEditProfile: () -> Unit,
+    navigateToFaq: () -> Unit,
+    navigateToPush: () -> Unit,
+    navigateToSignOut: () -> Unit,
+    navigateToTerms: () -> Unit,
+    navigateToWithdraw: () -> Unit,
+    viewModel: ProfileBottomSheetViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                ProfileBottomSheetViewModel.Effect.NavigateToEdit -> navigateToEditProfile()
+                ProfileBottomSheetViewModel.Effect.NavigateToFaq -> navigateToFaq()
+                ProfileBottomSheetViewModel.Effect.NavigateToPush -> navigateToPush()
+                ProfileBottomSheetViewModel.Effect.NavigateToSignOut -> navigateToSignOut()
+                ProfileBottomSheetViewModel.Effect.NavigateToTerms -> navigateToTerms()
+                ProfileBottomSheetViewModel.Effect.NavigateToWithdraw -> navigateToWithdraw()
+            }
+        }
+    }
+
+    ProfileMenuDefaultScreen(
+        onClickMenuItem = { viewModel.intent(ProfileBottomSheetViewModel.Intent.OnClickMenuItem(it)) },
+    )
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/ProfileMenuNotificationSettingRoute.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/ProfileMenuNotificationSettingRoute.kt
@@ -1,0 +1,31 @@
+package com.captures2024.soongan.presentation.feature.main.profile.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.captures2024.soongan.presentation.feature.main.profile.component.screen.ProfileMenuNotificationSettingScreen
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileNotificationSettingViewModel
+
+@Composable
+internal fun ProfileMenuNotificationSettingRoute(
+    navigateToBack: () -> Unit,
+    viewModel: ProfileNotificationSettingViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is ProfileNotificationSettingViewModel.Effect.NavigateToBack -> navigateToBack()
+            }
+        }
+    }
+
+    ProfileMenuNotificationSettingScreen(
+        state = state.notificationSettingState,
+        onClickBack = { viewModel.intent(ProfileNotificationSettingViewModel.Intent.OnClickBack) },
+        onSwitchNotificationSettingType = { viewModel.intent(ProfileNotificationSettingViewModel.Intent.OnSwitchNotificationSettingType(it)) },
+    )
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/ProfileMenuSignOutRoute.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/ProfileMenuSignOutRoute.kt
@@ -1,0 +1,39 @@
+package com.captures2024.soongan.presentation.feature.main.profile.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.captures2024.soongan.presentation.feature.main.profile.component.screen.ProfileMenuSignOutDoneScreen
+import com.captures2024.soongan.presentation.feature.main.profile.component.screen.ProfileMenuSignOutScreen
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileSignOutViewModel
+
+@Composable
+internal fun ProfileMenuSignOutRoute(
+    onDismissRequest: () -> Unit,
+    navigateToBack: () -> Unit,
+    viewModel: ProfileSignOutViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is ProfileSignOutViewModel.Effect.NavigateToBack -> navigateToBack()
+                is ProfileSignOutViewModel.Effect.NavigateToDone -> onDismissRequest()
+            }
+        }
+    }
+
+    when (state.isSuccess) {
+        true -> ProfileMenuSignOutDoneScreen(
+            onClickDone = { viewModel.intent(ProfileSignOutViewModel.Intent.OnClickDoneSignOut) },
+        )
+
+        false -> ProfileMenuSignOutScreen(
+            onClickBack = { viewModel.intent(ProfileSignOutViewModel.Intent.OnClickBack) },
+            onClickSignOut = { viewModel.intent(ProfileSignOutViewModel.Intent.OnClickConfirmSignOut) },
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/ProfileMenuWithdrawRoute.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/ProfileMenuWithdrawRoute.kt
@@ -1,0 +1,41 @@
+package com.captures2024.soongan.presentation.feature.main.profile.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.captures2024.soongan.presentation.feature.main.profile.component.screen.ProfileMenuWithdrawDoneScreen
+import com.captures2024.soongan.presentation.feature.main.profile.component.screen.ProfileMenuWithdrawScreen
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileWithdrawViewModel
+
+@Composable
+internal fun ProfileMenuWithdrawRoute(
+    onDismissRequest: () -> Unit,
+    navigateToBack: () -> Unit,
+    viewModel: ProfileWithdrawViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is ProfileWithdrawViewModel.Effect.NavigateToBack -> navigateToBack()
+                is ProfileWithdrawViewModel.Effect.NavigateToDone -> onDismissRequest()
+            }
+        }
+    }
+
+    when (state.isSuccessWithdraw) {
+        true -> ProfileMenuWithdrawDoneScreen(
+            onClickDone = { viewModel.intent(ProfileWithdrawViewModel.Intent.OnClickDoneWithdraw) },
+        )
+
+        false -> ProfileMenuWithdrawScreen(
+            state = state,
+            onClickBack = { viewModel.intent(ProfileWithdrawViewModel.Intent.OnClickBack) },
+            onInputValueChanged = { viewModel.intent(ProfileWithdrawViewModel.Intent.OnInputValueChanged(it)) },
+            onClickWithdraw = { viewModel.intent(ProfileWithdrawViewModel.Intent.OnClickConfirmWithdraw) },
+        )
+    }
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/ProfileRoute.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/ProfileRoute.kt
@@ -1,0 +1,43 @@
+package com.captures2024.soongan.presentation.feature.main.profile.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.captures2024.soongan.presentation.feature.main.profile.component.screen.ProfileScreen
+import com.captures2024.soongan.presentation.viewmodel.main.profile.ProfileViewModel
+
+@Composable
+internal fun ProfileRoute(
+    navigateToNotification: () -> Unit,
+    navigateToPostInfo: (Long) -> Unit,
+    navigateToRegistrationPost: () -> Unit,
+    navigateToEditProfile: () -> Unit,
+    navigateToFAQ: () -> Unit,
+    viewModel: ProfileViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is ProfileViewModel.Effect.NavigateToEditProfile -> navigateToEditProfile()
+                is ProfileViewModel.Effect.NavigateToFAQ -> navigateToFAQ()
+                is ProfileViewModel.Effect.NavigateToPostInfo -> navigateToPostInfo(effect.postId)
+                is ProfileViewModel.Effect.NavigateToNotification -> navigateToNotification()
+                is ProfileViewModel.Effect.NavigateToRegistrationPost -> navigateToRegistrationPost()
+            }
+        }
+    }
+
+    ProfileScreen(
+        state = state,
+        onClickNotification = { viewModel.intent(ProfileViewModel.Intent.OnClickNotification) },
+        onClickMenu = { viewModel.intent(ProfileViewModel.Intent.OnClickMenu) },
+        onDismissRequestMenuBottomSheet = { viewModel.intent(ProfileViewModel.Intent.OnDismissRequestMenuBottomSheet) },
+        onClickEditProfile = { viewModel.intent(ProfileViewModel.Intent.OnClickEditProfile) },
+        onClickFaq = { viewModel.intent(ProfileViewModel.Intent.OnClickFaq) },
+        onClickTerms = { viewModel.intent(ProfileViewModel.Intent.OnClickTerms) },
+    )
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/ProfileRoute.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/route/ProfileRoute.kt
@@ -39,5 +39,9 @@ internal fun ProfileRoute(
         onClickEditProfile = { viewModel.intent(ProfileViewModel.Intent.OnClickEditProfile) },
         onClickFaq = { viewModel.intent(ProfileViewModel.Intent.OnClickFaq) },
         onClickTerms = { viewModel.intent(ProfileViewModel.Intent.OnClickTerms) },
+        onRefresh = { viewModel.intent(ProfileViewModel.Intent.OnRefresh) },
+        onLoadNextPage = { viewModel.intent(ProfileViewModel.Intent.OnLoadNextPage) },
+        onClickPost = { viewModel.intent(ProfileViewModel.Intent.OnClickPost(it)) },
+        onClickRegisterPost = { viewModel.intent(ProfileViewModel.Intent.OnClickRegisterPost) },
     )
 }

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/utils/extension/FaqCategory.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/utils/extension/FaqCategory.kt
@@ -1,0 +1,12 @@
+package com.captures2024.soongan.presentation.feature.main.profile.utils.extension
+
+import androidx.annotation.StringRes
+import com.captures2024.soongan.presentation.feature.main.profile.R
+import com.captures2024.soongan.presentation.viewmodel.model.FaqCategory
+
+@StringRes
+internal fun FaqCategory.getTabResId(): Int = when (this) {
+    FaqCategory.DEFAULT -> R.string.faq_tab_default
+    FaqCategory.CONTEST -> R.string.faq_tab_contest
+    FaqCategory.COPYRIGHT -> R.string.faq_tab_copy_right
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/utils/extension/FaqCategoryItem.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/utils/extension/FaqCategoryItem.kt
@@ -1,0 +1,37 @@
+package com.captures2024.soongan.presentation.feature.main.profile.utils.extension
+
+import androidx.annotation.StringRes
+import com.captures2024.soongan.presentation.feature.main.profile.R
+import com.captures2024.soongan.presentation.viewmodel.model.FaqCategoryItem
+
+@StringRes
+internal fun FaqCategoryItem.getQuestionResId(): Int = when (this) {
+    FaqCategoryItem.Default.First -> R.string.faq_data_default_q1
+    FaqCategoryItem.Default.Second -> R.string.faq_data_default_q2
+
+    FaqCategoryItem.Contest.First -> R.string.faq_data_contest_q1
+    FaqCategoryItem.Contest.Second -> R.string.faq_data_contest_q2
+    FaqCategoryItem.Contest.Third -> R.string.faq_data_contest_q3
+    FaqCategoryItem.Contest.Fourth -> R.string.faq_data_contest_q4
+    FaqCategoryItem.Contest.Fifth -> R.string.faq_data_contest_q5
+
+    FaqCategoryItem.Copyright.First -> R.string.faq_data_copyright_q1
+    FaqCategoryItem.Copyright.Second -> R.string.faq_data_copyright_q2
+    FaqCategoryItem.Copyright.Third -> R.string.faq_data_copyright_q3
+}
+
+@StringRes
+internal fun FaqCategoryItem.getAnswerResId(): Int = when (this) {
+    FaqCategoryItem.Default.First -> R.string.faq_data_default_a1
+    FaqCategoryItem.Default.Second -> R.string.faq_data_default_a2
+
+    FaqCategoryItem.Contest.First -> R.string.faq_data_contest_a1
+    FaqCategoryItem.Contest.Second -> R.string.faq_data_contest_a2
+    FaqCategoryItem.Contest.Third -> R.string.faq_data_contest_a3
+    FaqCategoryItem.Contest.Fourth -> R.string.faq_data_contest_a4
+    FaqCategoryItem.Contest.Fifth -> R.string.faq_data_contest_a5
+
+    FaqCategoryItem.Copyright.First -> R.string.faq_data_copyright_a1
+    FaqCategoryItem.Copyright.Second -> R.string.faq_data_copyright_a2
+    FaqCategoryItem.Copyright.Third -> R.string.faq_data_copyright_a3
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/utils/extension/NotificationSettingType.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/utils/extension/NotificationSettingType.kt
@@ -1,0 +1,21 @@
+package com.captures2024.soongan.presentation.feature.main.profile.utils.extension
+
+import androidx.annotation.StringRes
+import com.captures2024.soongan.presentation.feature.main.profile.R
+import com.captures2024.soongan.presentation.viewmodel.model.NotificationSettingType
+
+@StringRes
+fun NotificationSettingType.getTitleResId(): Int = when (this) {
+    NotificationSettingType.ALL -> R.string.notification_setting_type_title_all
+    NotificationSettingType.CONTEST -> R.string.notification_setting_type_title_contest
+    NotificationSettingType.ACTIVITY -> R.string.notification_setting_type_title_activity
+    NotificationSettingType.NOTICE -> R.string.notification_setting_type_title_notice
+}
+
+@StringRes
+fun NotificationSettingType.getDescriptionResId(): Int = when (this) {
+    NotificationSettingType.ALL -> R.string.notification_setting_type_description_all
+    NotificationSettingType.CONTEST -> R.string.notification_setting_type_description_contest
+    NotificationSettingType.ACTIVITY -> R.string.notification_setting_type_description_activity
+    NotificationSettingType.NOTICE -> R.string.notification_setting_type_description_notice
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/utils/extension/NotificationType.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/utils/extension/NotificationType.kt
@@ -1,0 +1,12 @@
+package com.captures2024.soongan.presentation.feature.main.profile.utils.extension
+
+import androidx.annotation.StringRes
+import com.captures2024.soongan.core.model.utils.NotificationType
+import com.captures2024.soongan.presentation.feature.main.profile.R
+
+@StringRes
+internal fun NotificationType.getTabResId(): Int = when (this) {
+    NotificationType.CONTEST -> R.string.notification_tab_contest
+    NotificationType.ACTIVITY -> R.string.notification_tab_activity
+    NotificationType.NOTICE -> R.string.notification_tab_notice
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/utils/extension/ProfileBottomSheetMenuItem.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/utils/extension/ProfileBottomSheetMenuItem.kt
@@ -1,0 +1,35 @@
+package com.captures2024.soongan.presentation.feature.main.profile.utils.extension
+
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconArrowRightFromBracket
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconFillPersonRunning
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillCircleQuestion
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillFile
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillGear
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillUser
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.presentation.feature.main.profile.R
+import com.captures2024.soongan.presentation.viewmodel.model.ProfileBottomSheetMenuItem
+
+fun ProfileBottomSheetMenuItem.getStringResId() = when (this) {
+    ProfileBottomSheetMenuItem.EDIT -> R.string.profile_menu_item_edit_title
+    ProfileBottomSheetMenuItem.FAQ -> R.string.profile_menu_item_faq_title
+    ProfileBottomSheetMenuItem.PUSH -> R.string.profile_menu_item_notification_title
+    ProfileBottomSheetMenuItem.TERMS_AND_POLICY -> R.string.profile_menu_item_temp_and_policy_title
+    ProfileBottomSheetMenuItem.WITHDRAW -> R.string.profile_menu_item_withdraw_title
+    ProfileBottomSheetMenuItem.SIGN_OUT -> R.string.profile_menu_item_sign_out_title
+}
+
+fun ProfileBottomSheetMenuItem.getColor() = when (this) {
+    ProfileBottomSheetMenuItem.SIGN_OUT -> SGColor.negative
+    else -> SGColor.black
+}
+
+fun ProfileBottomSheetMenuItem.getIcon() = when (this) {
+    ProfileBottomSheetMenuItem.EDIT -> MyIconPack.IconNonFillUser
+    ProfileBottomSheetMenuItem.FAQ -> MyIconPack.IconNonFillCircleQuestion
+    ProfileBottomSheetMenuItem.PUSH -> MyIconPack.IconNonFillGear
+    ProfileBottomSheetMenuItem.TERMS_AND_POLICY -> MyIconPack.IconNonFillFile
+    ProfileBottomSheetMenuItem.WITHDRAW -> MyIconPack.IconFillPersonRunning
+    ProfileBottomSheetMenuItem.SIGN_OUT -> MyIconPack.IconArrowRightFromBracket
+}

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/utils/nonScaleAnnotatedTitle.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/utils/nonScaleAnnotatedTitle.kt
@@ -1,0 +1,47 @@
+package com.captures2024.soongan.presentation.feature.main.profile.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.ParagraphStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleSpanStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+
+@Composable
+internal fun nonScaleAnnotatedTitle(
+    title: String,
+    count: Int,
+) = buildAnnotatedString {
+    val commonParagraphStyle = ParagraphStyle(lineHeight = 24.sp)
+
+    pushStyle(style = commonParagraphStyle)
+    withStyle(
+        style = getSGNonScaleSpanStyle(
+            color = SGColor.Grayscale.black100,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = SGTypography.pretendard,
+            letterSpacing = (-5).em,
+        ),
+    ) {
+        append(title)
+    }
+
+    append(" ")
+
+    withStyle(
+        style = getSGNonScaleSpanStyle(
+            color = SGColor.Grayscale.black100,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = SGTypography.pretendard,
+            letterSpacing = (0).em,
+        ),
+    ) {
+        append("$count")
+    }
+}

--- a/presentation/feature/main-profile/src/main/res/values/strings.xml
+++ b/presentation/feature/main-profile/src/main/res/values/strings.xml
@@ -110,5 +110,9 @@
     <string name="profile_menu_withdraw_description">정말 회원탈퇴를 하실 건가요?\n\n회원탈퇴를 위해 아래 입력창에\n\'회원탈퇴\'를 입력해주세요</string>
     <string name="profile_menu_withdraw_placeholder">회원탈퇴</string>
 
+<!-- ProfileBodyComponent  -->
+    <string name="profile_gallery_post_empty_content">아직 참가한 작품이 없어요.</string>
+    <string name="profile_gallery_post_empty_button">참가하러 가기</string>
+    <string name="profile_gallery_post_error">참가 작품을 불러올 수 없어요.</string>
 
 </resources>

--- a/presentation/feature/main-profile/src/main/res/values/strings.xml
+++ b/presentation/feature/main-profile/src/main/res/values/strings.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="back_description">back</string>
+    <string name="delete_description">delete</string>
+    <string name="image_description">image</string>
+    <string name="notification_description">notification</string>
+    <string name="menu_description">menu</string>
+
+<!-- Button   -->
+    <string name="button_confirm">확인</string>
+    <string name="button_edit_confirm">수정완료</string>
+
+<!--  FaqCategory  -->
+    <string name="faq_tab_default">기본</string>
+    <string name="faq_tab_contest">대회 안내</string>
+    <string name="faq_tab_copy_right">저작권</string>
+
+    <!--  NotificationBody  -->
+    <string name="notification_tab_contest">대회 알림</string>
+    <string name="notification_tab_activity">활동 알림</string>
+    <string name="notification_tab_notice">공지 알림</string>
+
+<!--  FaqCategoryItems  -->
+    <string name="faq_data_default_q1">Q. ‘순간’이란 무엇인가요?</string>
+    <string name="faq_data_default_a1">‘순간’은 여러분의 특별한 찰나를 사진으로 기록하고, 이를 통해 사람들과 소통할 수 있는 사진 공유 플랫폼입니다.\n\n단순히 잘 찍힌 사진보다, 여러분이 느끼는 특별한 순간과 감정이 담긴 사진을 소중히 여깁니다. 서로의 행복한 순간을 공유하며, 다른 사람들의 시선을 이해하고 공감할 수 있는 공간이죠. ‘순간’에서 다양한 감정과 이야기를 사진으로 나누며 특별한 경험을 즐겨보세요!</string>
+    <string name="faq_data_default_q2">Q. 제가 이 콘테스트에 왜 참가해야 할까요?</string>
+    <string name="faq_data_default_a2">‘순간’ 콘테스트에 참가하는 이유는 사람마다 다를 수 있지만, 크게 세 가지 이유가 있습니다!\n\n• 전문적인 사진작가\n‘순간’은 다른 사람들이 내 사진을 어떻게 느끼는지 바로 알 수 있는 기회를 제공합니다. 콘테스트에서 받은 피드백과 반응은 사진 스타일을 발전시키는 데 큰 도움이 될 거예요.\n\n• 아마추어 사진가\n주어진 주제에 맞춰 사진을 찍으면서, 자신의 스타일과 시각을 찾아가는 과정을 경험할 수 있습니다.\n\n• 사진 감상자\n사진을 찍기보다는 감상하는 걸 좋아한다면? ‘순간’은 다양한 시선과 감성으로 가득한 사진들을 감상할 수 있는 곳이에요.</string>
+
+    <string name="faq_data_contest_q1">Q. 작품을 출품하고 싶어요. 어떻게 해야 하나요?</string>
+    <string name="faq_data_contest_a1">메인 화면 중앙에 있는 + 버튼을 눌러 출품할 수 있습니다. 이미 출품한 작품이 있더라도 + 버튼을 누르면 추가로 출품이 가능합니다. (참고로 작품 제목은 20자 미만으로 입력해야 한다는 점 기억해주세요!)</string>
+    <string name="faq_data_contest_q2">Q. 콘테스트 참가 작품을 보고 싶어요!</string>
+    <string name="faq_data_contest_a2">현재 진행 중인 콘테스트의 참가 작품은 메인 화면에서 우측 하단에 있는 참가 작품 아이콘을 눌러 확인할 수 있습니다. 역대 콘테스트 작품은 \'역대콘\' 탭에서 보고 싶은 회차를 선택해 감상할 수 있어요.</string>
+    <string name="faq_data_contest_q3">Q. 콘테스트 규칙을 알고 싶어요!</string>
+    <string name="faq_data_contest_a3"><![CDATA[• 출품 작품 개수 \n회차별로 최대 3개의 작품을 출품할 수 있습니다.\n\n• 동점자 처리 방식 \n동점일 경우, 1. 직전 회차 참가 여부 / 2. 1차 투표에서 받은 좋아요 수 / 3. 업로드 시간을 기준으로 처리됩니다.\n\n• TOP7 & 우승자 선정 방식 \n좋아요 개수로 결정되며, 제목 또한 많은 공감을 이끌어낼 수 있는 중요한 요소입니다!\n\n• 사진 변경 \n출품 후 사진 변경은 불가하지만, 제목은 언제든지 수정 가능합니다.]]></string>
+    <string name="faq_data_contest_q4">Q. AI로 만든 사진도 제출할 수 있나요?</string>
+    <string name="faq_data_contest_a4">아쉽지만 AI로 생성한 사진은 제출할 수 없습니다. 다만, 직접 찍은 사진에 필터나 작은 요소를 합성하는 정도의 편집은 가능합니다. AI 기반 이미지가 아닌, 여러분이 직접 찍은 사진이 기본이 되어야 합니다. 하지만 AI를 활용한 콘텐츠에 관심이 있다면 저희에게 알려주세요. \'순간\'의 다음 프로젝트로 발전할 수도 있거든요! ^^</string>
+    <string name="faq_data_contest_q5">Q. 우승하면 어떤 혜택이 있나요?</string>
+    <string name="faq_data_contest_a5">최종 1위 우승자는 앱을 켰을 때 등장하는 메인 화면에 우승 사진이 소개됩니다. 또한 역대 콘테스트를 소개하는 대표 사진으로도 사용되죠. 마지막으로, 나만의 팁이나 이야기를 공유할 수 있는 인터뷰 기회도 제공됩니다!</string>
+
+    <string name="faq_data_copyright_q1">Q. 사진의 저작권은 누구에게 있나요?</string>
+    <string name="faq_data_copyright_a1">모든 사진의 저작권은 촬영한 본인에게 있습니다. ‘순간’은 여러분이 자신의 작품을 자유롭게 공유하고, 시각과 감정을 표현할 수 있는 공간을 제공합니다. 다만, 콘테스트에 제출된 사진은 ‘순간’ 앱 내에서 홍보 및 전시 목적으로 사용될 수 있습니다.</string>
+    <string name="faq_data_copyright_q2">Q. 사진 업로드 시 저작권 관련 주의사항이 있나요?</string>
+    <string name="faq_data_copyright_a2">• 타인의 작품 사용 금지 다른 사람의 사진, 이미지, 그래픽 등을 무단으로 사용해서는 안 됩니다. 반드시 본인이 직접 촬영한 사진만 사용해주세요.\n\n• 초상권 \n다른 사람의 얼굴이나 신체가 포함된 사진은 당사자의 동의를 받아야 합니다. 이를 어길 경우 사진이 삭제되거나 법적 문제가 발생할 수 있어요.\n\n• 상업적 사용 금지 \n상표나 로고가 포함된 사진은 상업적 목적으로 사용할 수 없습니다. 주의해서 촬영해주세요!</string>
+    <string name="faq_data_copyright_q3">Q. TOP7 선정 후, 저작권 침해가 확인되면 어떻게 되나요?</string>
+    <string name="faq_data_copyright_a3">• 수상 취소 및 사진 삭제 해당 사진은 즉시 삭제되며 수상 자격도 박탈될 수 있습니다. 수상 혜택도 모두 회수될 수 있습니다.\n\n• 법적 책임 저작권 침해에 따른 법적 책임은 사진을 업로드한 사용자에게 있습니다. ‘순간’은 이런 분쟁에 관여하지 않지만, 피해자의 요청에 따라 필요한 조치를 취할 수 있습니다.\n\n• 계정 제한 저작권 침해 사례가 반복될 경우 사용자 계정이 일시적 혹은 영구적으로 제한될 수 있습니다. 이는 다른 사용자의 권리를 보호하기 위한 조치입니다.</string>
+
+    <!--  ProfileBottomSheetMenuItem  -->
+    <string name="profile_menu_item_edit_title">프로필 편집</string>
+    <string name="profile_menu_item_notification_title">푸시 알림 설정</string>
+    <string name="profile_menu_item_temp_and_policy_title">약관 및 정책</string>
+    <string name="profile_menu_item_faq_title">FAQ</string>
+    <string name="profile_menu_item_withdraw_title">회원탈퇴</string>
+    <string name="profile_menu_item_sign_out_title">로그아웃</string>
+
+<!--  NotificationSettingType  -->
+    <string name="notification_setting_type_title_all">전체 알림</string>
+    <string name="notification_setting_type_title_contest">대회 알림</string>
+    <string name="notification_setting_type_title_activity">활동 알림</string>
+    <string name="notification_setting_type_title_notice">공지 알림</string>
+
+    <string name="notification_setting_type_description_all" />
+    <string name="notification_setting_type_description_contest">대회 시작, 최종 투표 시작, 결과 발표 등</string>
+    <string name="notification_setting_type_description_activity">(대)댓글 작성, 신고 접수 및 결과 안내 등</string>
+    <string name="notification_setting_type_description_notice">공지사항 알림</string>
+
+<!--  FaqScreen  -->
+    <string name="faq_inquiry_question_message">추가적인 문의가 있으신가요 ?</string>
+    <string name="faq_inquiry_text">문의하기</string>
+
+<!--  FaqTopBarComponent  -->
+    <string name="faq_top_bar_title">FAQ</string>
+
+<!--  NotificationEmptyComponent  -->
+    <string name="notification_empty_description">표시할 알림이 없어요.</string>
+
+<!--  NotificationTopBarComponent  -->
+    <string name="notification_top_bar_title">알림</string>
+
+<!--  ProfileEditBodyComponent  -->
+    <string name="profile_edit_nickname_description">닉네임은 한글, 영문, 숫자만 입력해주세요</string>
+    <string name="profile_edit_nickname_placeholder">닉네임을 입력해주세요</string>
+    <string name="profile_edit_nickname_error_duplicated">닉네임이 중복되었습니다.</string>
+    <string name="profile_edit_nickname_error_regex">특수문자는 제거해주세요</string>
+    <string name="profile_edit_nickname_error_length">3–10자리 숫자, 영문, 한글로 입력해주세요</string>
+    <string name="profile_edit_introduction_description">자기소개를 입력해주세요</string>
+    <string name="profile_edit_introduction_placeholder">본인을 소개해주세요</string>
+    <string name="profile_edit_introduction_error_length">20자리 이하의 자기소개를 입력해주세요</string>
+
+<!-- ProfileEditImageBottomSheet   -->
+    <string name="profile_image_gallery">갤러리에서 사진 선택</string>
+    <string name="profile_image_default">기본 프로필로 돌아가기</string>
+
+<!--  ProfileMenuNotificationSettingScreen  -->
+    <string name="profile_menu_notification_setting_title">푸시 알림 정책</string>
+
+<!--  ProfileMenuSignOutDoneScreen  -->
+    <string name="profile_menu_sign_out_done_title">로그아웃</string>
+    <string name="profile_menu_sign_out_done_description">로그아웃이 완료됐습니다.\n또 만나길 바랄게요!</string>
+
+<!--  ProfileMenuSignOutScreen  -->
+    <string name="profile_menu_sign_out_title">로그아웃</string>
+    <string name="profile_menu_sign_out_description">정말 로그아웃 하실 건가요?</string>
+
+<!--  ProfileMenuWithdrawDoneScreen  -->
+    <string name="profile_menu_withdraw_done_title">회원 탈퇴</string>
+    <string name="profile_menu_withdraw_done_description">회원탈퇴가 완료되었습니다.</string>
+
+<!--  ProfileMenuWithdrawScreen  -->
+    <string name="profile_menu_withdraw_title">회원 탈퇴</string>
+    <string name="profile_menu_withdraw_description">정말 회원탈퇴를 하실 건가요?\n\n회원탈퇴를 위해 아래 입력창에\n\'회원탈퇴\'를 입력해주세요</string>
+    <string name="profile_menu_withdraw_placeholder">회원탈퇴</string>
+
+
+</resources>

--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/MainComponent.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/MainComponent.kt
@@ -1,12 +1,16 @@
 package com.captures2024.soongan.presentation.feature.main.component
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDestination
 import com.captures2024.soongan.presentation.feature.main.navigation.MainNavigationState
 import com.captures2024.soongan.presentation.feature.main.navigation.MainTopLevelDestination
@@ -25,14 +29,21 @@ internal fun MainComponent(
                 topLevelDestinations = navigationState.topLevelDestinations,
             )
 
-            if (!isNotViewBottomBar) {
-                SoonGanBottomBar(
-                    destinations = navigationState.topLevelDestinations,
-                    onNavigateToDestination = navigationState::navigateToTopLevelDestination,
-                    currentDestination = navigationState.currentDestination,
-                    modifier = Modifier.testTag("SoonGanBottomBar"),
-                )
-            }
+            SoonGanBottomBar(
+                isNotViewBottomBar = isNotViewBottomBar,
+                destinations = navigationState.topLevelDestinations,
+                onNavigateToDestination = navigationState::navigateToTopLevelDestination,
+                currentDestination = navigationState.currentDestination,
+                modifier = Modifier
+                    .let {
+                        return@let when (isNotViewBottomBar) {
+                            true -> it.height(0.dp)
+                            false -> it.wrapContentHeight()
+                        }
+                    }
+                    .animateContentSize()
+                    .testTag("SoonGanBottomBar"),
+            )
         },
         content = content,
     )

--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/SoonGanBottomBar.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/SoonGanBottomBar.kt
@@ -15,6 +15,7 @@ import kotlin.collections.forEach
 
 @Composable
 internal fun SoonGanBottomBar(
+    isNotViewBottomBar: Boolean,
     destinations: List<MainTopLevelDestination>,
     onNavigateToDestination: (MainTopLevelDestination) -> Unit,
     currentDestination: NavDestination?,
@@ -28,7 +29,11 @@ internal fun SoonGanBottomBar(
 
             SoonGanNavigationBarItem(
                 selected = selected,
-                onClick = { if (!selected) { onNavigateToDestination(destination) } },
+                onClick = {
+                    if (!isNotViewBottomBar && !selected) {
+                        onNavigateToDestination(destination)
+                    }
+                },
                 icon = {
                     Icon(
                         imageVector = destination.unselectedIcon,

--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
@@ -1,10 +1,5 @@
 package com.captures2024.soongan.presentation.feature.main.component.screen
 
-import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -66,10 +61,6 @@ internal fun MainScreen(navigationState: MainNavigationState) {
                 true -> HomeNavigator
                 false -> WelcomeNavigator
             },
-            enterTransition = { fadeIn() + scaleIn(initialScale = 0.9f) },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { fadeIn() + scaleIn(initialScale = 0.9f) },
-            popExitTransition = { fadeOut() + scaleOut(targetScale = 0.5f) },
         ) {
             welcome(
                 navigateToHome = navController::navigateToHome,

--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
@@ -21,8 +21,12 @@ import com.captures2024.soongan.core.navigator.screen.main.home.navigateToRegist
 import com.captures2024.soongan.core.navigator.screen.main.post.navigateToEditPost
 import com.captures2024.soongan.core.navigator.screen.main.post.navigateToImageViewer
 import com.captures2024.soongan.core.navigator.screen.main.post.navigateToPostInfo
+import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToEditProfile
+import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToFAQ
+import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToNotification
 import com.captures2024.soongan.core.navigator.screen.main.util.getHidedPostId
 import com.captures2024.soongan.core.navigator.screen.main.util.navigateToBackWithHidePost
+import com.captures2024.soongan.core.navigator.screen.main.util.navigateFromNotification
 import com.captures2024.soongan.core.navigator.screen.main.welcome.WelcomeNavigator
 import com.captures2024.soongan.presentation.feature.main.awards.navigation.mainAwards
 import com.captures2024.soongan.presentation.feature.main.component.MainComponent
@@ -86,7 +90,15 @@ internal fun MainScreen(navigationState: MainNavigationState) {
                 navigateToEditPost = navController::navigateToEditPost,
                 navigateToBackWithHidePost = navController::navigateToBackWithHidePost,
             )
-            mainProfile()
+            mainProfile(
+                navigateToBack = navigateToBack,
+                navigateToNotification = navController::navigateToNotification,
+                navigateToPostInfo = navController::navigateToPostInfo,
+                navigateToRegistrationPost = navController::navigateToRegistrationPost,
+                navigateToEditProfile = navController::navigateToEditProfile,
+                navigateToFAQ = navController::navigateToFAQ,
+                navigateFromNotification = navController::navigateFromNotification,
+            )
         }
     }
 }

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/FaqViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/FaqViewModel.kt
@@ -1,0 +1,92 @@
+package com.captures2024.soongan.presentation.viewmodel.main.profile
+
+import androidx.lifecycle.SavedStateHandle
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.FaqCategory
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class FaqViewModel
+@Inject
+constructor(
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle: SavedStateHandle,
+) : BaseViewModel<FaqViewModel.State, FaqViewModel.Effect, FaqViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle = savedStateHandle,
+) {
+
+    data class State(
+        val categories: List<FaqCategory>,
+        val selectedCategory: FaqCategory,
+    ) : UIState
+
+    sealed interface Effect : UISideEffect {
+        data object NavigateToBack : Effect
+    }
+
+    sealed interface Intent : UIIntent {
+        data object OnClickBack : Intent
+
+        data class OnClickCategory(
+            val category: FaqCategory,
+        ) : Intent
+
+        data object OnClickInquiry : Intent
+    }
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State {
+        return State(
+            categories = FaqCategory.entries,
+            selectedCategory = FaqCategory.DEFAULT,
+        )
+    }
+
+    override fun handleIntent(intent: Intent) {
+        when (intent) {
+            is Intent.OnClickBack -> handleOnClickBack()
+            is Intent.OnClickCategory -> handleOnClickCategory(intent)
+            is Intent.OnClickInquiry -> handleOnClickInquiry()
+        }
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        analyticsHelper.e(throwable) { "state: $currentState" }
+    }
+
+    private fun handleOnClickBack() {
+        postSideEffect(Effect.NavigateToBack)
+    }
+
+    private fun handleOnClickCategory(intent: Intent.OnClickCategory) {
+        reduce {
+            copy(
+                selectedCategory = intent.category,
+            )
+        }
+    }
+
+    private fun handleOnClickInquiry() {
+        // TODO()
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileBottomSheetViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileBottomSheetViewModel.kt
@@ -1,0 +1,85 @@
+package com.captures2024.soongan.presentation.viewmodel.main.profile
+
+import androidx.lifecycle.SavedStateHandle
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.ProfileBottomSheetMenuItem
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ProfileBottomSheetViewModel
+@Inject
+constructor(
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle: SavedStateHandle,
+) : BaseViewModel<ProfileBottomSheetViewModel.State, ProfileBottomSheetViewModel.Effect, ProfileBottomSheetViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle = savedStateHandle,
+) {
+    data object State : UIState
+
+    sealed interface Effect : UISideEffect {
+
+        data object NavigateToEdit : Effect
+
+        data object NavigateToPush : Effect
+
+        data object NavigateToTerms : Effect
+
+        data object NavigateToFaq : Effect
+
+        data object NavigateToWithdraw : Effect
+
+        data object NavigateToSignOut : Effect
+    }
+
+    sealed interface Intent : UIIntent {
+        data class OnClickMenuItem(
+            val item: ProfileBottomSheetMenuItem,
+        ) : Intent
+    }
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State = State
+
+    override fun handleIntent(intent: Intent) {
+        when (intent) {
+            is Intent.OnClickMenuItem -> handleOnClickMenuItem(intent)
+        }
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        analyticsHelper.e(throwable) { "state: $currentState" }
+    }
+
+    private fun handleOnClickMenuItem(intent: Intent.OnClickMenuItem) {
+        postSideEffect(
+            sideEffect = when (intent.item) {
+                ProfileBottomSheetMenuItem.EDIT -> Effect.NavigateToEdit
+                ProfileBottomSheetMenuItem.PUSH -> Effect.NavigateToPush
+                ProfileBottomSheetMenuItem.TERMS_AND_POLICY -> Effect.NavigateToTerms
+                ProfileBottomSheetMenuItem.FAQ -> Effect.NavigateToFaq
+                ProfileBottomSheetMenuItem.WITHDRAW -> Effect.NavigateToWithdraw
+                ProfileBottomSheetMenuItem.SIGN_OUT -> Effect.NavigateToSignOut
+            },
+        )
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileEditViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileEditViewModel.kt
@@ -1,0 +1,274 @@
+package com.captures2024.soongan.presentation.viewmodel.main.profile
+
+import androidx.lifecycle.SavedStateHandle
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.Validation
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.PostSingleButtonDialogUseCase
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetCurrentMemberFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.core.domain.usecase.members.PatchProfileUseCase
+import com.captures2024.soongan.core.model.AppConst
+import com.captures2024.soongan.core.model.enums.CommonDialogType
+import com.captures2024.soongan.core.model.exception.NetworkExceptionWrapper
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.UserProfile
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ProfileEditViewModel
+@Inject
+constructor(
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle: SavedStateHandle,
+    private val postSingleButtonDialogUseCase: PostSingleButtonDialogUseCase,
+    private val getCurrentMemberFlowUseCase: GetCurrentMemberFlowUseCase,
+    private val patchProfileUseCase: PatchProfileUseCase,
+) : BaseViewModel<ProfileEditViewModel.State, ProfileEditViewModel.Effect, ProfileEditViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle = savedStateHandle,
+) {
+
+    data class State(
+        val userProfile: UserProfile,
+        val editingState: EditingProfileState,
+        val isShowEditBottomSheet: Boolean,
+        val maxNicknameLength: Int = AppConst.Main.Profile.MAX_NICKNAME_LENGTH,
+        val maxIntroductionLength: Int = AppConst.Main.Profile.MAX_INTRODUCTION_LENGTH,
+    ) : UIState {
+        val isEditable: Boolean
+            get() = userProfile != editingState.editingProfile
+
+        data class EditingProfileState(
+            val editingProfile: UserProfile = UserProfile(),
+            val isDuplicatedNickname: Boolean = false,
+        ) {
+            val isValidNickname: Validation.NicknameValidState
+                get() = Validation.isValidNickname(editingProfile.nickname)
+
+            val isValidIntroduction: Validation.IntroductionValidState
+                get() = Validation.isValidSelfIntroduction(editingProfile.selfIntroduction)
+        }
+    }
+
+    sealed interface Effect : UISideEffect {
+
+        data object NavigateToBack : Effect
+
+        data object OpenMediaPicker : Effect
+    }
+
+    sealed interface Intent : UIIntent {
+        data object Init : Intent
+
+        data object OnClickBack : Intent
+
+        data object OnClickProfileImage : Intent
+
+        data object OnChangeDefaultProfileImage : Intent
+
+        data object OpenPhotoPicker : Intent
+
+        data object OnDismissRequestEditBottomSheet : Intent
+
+        data class OnProfileImageChanged(
+            val newProfileImage: String,
+        ) : Intent
+
+        data class OnNicknameValueChanged(
+            val newValue: String,
+        ) : Intent
+
+        data class OnIntroductionValueChanged(
+            val newValue: String,
+        ) : Intent
+
+        data object OnClickEditButton : Intent
+    }
+
+    init {
+        intent(Intent.Init)
+    }
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State {
+        return State(
+            userProfile = UserProfile(),
+            editingState = State.EditingProfileState(),
+            isShowEditBottomSheet = false,
+        )
+    }
+
+    override fun handleIntent(intent: Intent) {
+        when (intent) {
+            is Intent.Init -> handleInit()
+            is Intent.OnClickBack -> handleOnClickBack()
+            is Intent.OnClickProfileImage -> handleOnClickProfileImage()
+            is Intent.OnChangeDefaultProfileImage -> handleOnChangeDefaultProfileImage()
+            is Intent.OpenPhotoPicker -> handleOpenPhotoPicker()
+            is Intent.OnDismissRequestEditBottomSheet -> handleOnDismissRequestEditBottomSheet()
+            is Intent.OnProfileImageChanged -> handleOnProfileImageChanged(intent)
+            is Intent.OnNicknameValueChanged -> handleOnNicknameValueChanged(intent)
+            is Intent.OnIntroductionValueChanged -> handleOnIntroductionValueChanged(intent)
+            is Intent.OnClickEditButton -> loadingLaunch { handleOnClickEditButton() }
+        }
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        analyticsHelper.e(throwable) { "state: $currentState" }
+    }
+
+    private fun handleInit() {
+        launch { collectMemberInfo() }
+    }
+
+    private fun handleOnClickBack() {
+        postSideEffect(Effect.NavigateToBack)
+    }
+
+    private fun handleOnClickProfileImage() {
+        showEditBottomSheet()
+    }
+
+    private fun handleOnChangeDefaultProfileImage() {
+        reduce {
+            copy(
+                editingState = editingState.copy(
+                    editingProfile = editingState.editingProfile.copy(
+                        profileImageUrl = null,
+                    ),
+                ),
+            )
+        }
+
+        dismissEditBottomSheet()
+    }
+
+    private fun handleOpenPhotoPicker() {
+        postSideEffect(Effect.OpenMediaPicker)
+        dismissEditBottomSheet()
+    }
+
+    private fun handleOnDismissRequestEditBottomSheet() {
+        dismissEditBottomSheet()
+    }
+
+    private fun handleOnProfileImageChanged(intent: Intent.OnProfileImageChanged) {
+        reduce {
+            copy(
+                editingState = editingState.copy(
+                    editingProfile = editingState.editingProfile.copy(
+                        profileImageUrl = intent.newProfileImage,
+                    ),
+                ),
+            )
+        }
+    }
+
+    private fun handleOnNicknameValueChanged(intent: Intent.OnNicknameValueChanged) {
+        reduce {
+            copy(
+                editingState = editingState.copy(
+                    editingProfile = editingState.editingProfile.copy(
+                        nickname = intent.newValue,
+                    ),
+                    isDuplicatedNickname = false,
+                ),
+            )
+        }
+    }
+
+    private fun handleOnIntroductionValueChanged(intent: Intent.OnIntroductionValueChanged) {
+        reduce {
+            copy(
+                editingState = editingState.copy(
+                    editingProfile = editingState.editingProfile.copy(
+                        selfIntroduction = intent.newValue,
+                    ),
+                ),
+            )
+        }
+    }
+
+    private suspend fun handleOnClickEditButton() {
+        val editedProfile = currentState.editingState.editingProfile
+
+        try {
+            val isPatchedProfile = patchProfileUseCase(
+                nickname = editedProfile.nickname,
+                selfIntroduction = editedProfile.selfIntroduction,
+                profileImageUrl = editedProfile.profileImageUrl,
+                isDefaultProfileImage = (editedProfile.profileImageUrl == null),
+            ).getOrThrow()
+
+            analyticsHelper.d { "Patch Profile result : $isPatchedProfile" }
+
+            postSideEffect(Effect.NavigateToBack)
+        } catch (e: NetworkExceptionWrapper) {
+            when (e.statusCode) {
+                704 -> reduce {
+                    copy(
+                        editingState = editingState.copy(
+                            isDuplicatedNickname = true,
+                        ),
+                    )
+                }
+
+                else -> postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+            }
+        }
+    }
+
+    private suspend fun collectMemberInfo() {
+        getCurrentMemberFlowUseCase().collect { currentMember ->
+            analyticsHelper.d { "currentMember Update? - currentMember: $currentMember" }
+
+            currentMember?.let {
+                val userProfile = UserProfile(
+                    nickname = currentMember.nickname ?: "user1",
+                    selfIntroduction = currentMember.selfIntroduction ?: "본인을 소개해주세요",
+                    profileImageUrl = currentMember.profileImageUrl,
+                )
+
+                reduce {
+                    copy(
+                        userProfile = userProfile,
+                        editingState = editingState.copy(editingProfile = userProfile),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun showEditBottomSheet() {
+        reduce {
+            copy(
+                isShowEditBottomSheet = true,
+            )
+        }
+    }
+
+    private fun dismissEditBottomSheet() {
+        reduce {
+            copy(
+                isShowEditBottomSheet = false,
+            )
+        }
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileNotificationSettingViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileNotificationSettingViewModel.kt
@@ -1,0 +1,107 @@
+package com.captures2024.soongan.presentation.viewmodel.main.profile
+
+import androidx.lifecycle.SavedStateHandle
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.NotificationSettingType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ProfileNotificationSettingViewModel
+@Inject
+constructor(
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle: SavedStateHandle,
+) : BaseViewModel<ProfileNotificationSettingViewModel.State, ProfileNotificationSettingViewModel.Effect, ProfileNotificationSettingViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle = savedStateHandle,
+) {
+
+    data class State(
+        val notificationSettingState: NotificationSettingState,
+    ) : UIState {
+
+        data class NotificationSettingState(
+            val all: Boolean = false,
+            val contest: Boolean = false,
+            val activity: Boolean = false,
+            val notice: Boolean = false,
+        ) {
+            fun getStateByType(type: NotificationSettingType): Boolean = when (type) {
+                NotificationSettingType.ALL -> all
+                NotificationSettingType.CONTEST -> contest
+                NotificationSettingType.ACTIVITY -> activity
+                NotificationSettingType.NOTICE -> notice
+            }
+
+            fun switch(type: NotificationSettingType): NotificationSettingState = when (type) {
+                NotificationSettingType.ALL -> copy(all = !all)
+                NotificationSettingType.CONTEST -> copy(contest = !contest)
+                NotificationSettingType.ACTIVITY -> copy(activity = !activity)
+                NotificationSettingType.NOTICE -> copy(notice = !notice)
+            }
+        }
+    }
+
+    sealed interface Effect : UISideEffect {
+        data object NavigateToBack : Effect
+    }
+
+    sealed interface Intent : UIIntent {
+        data object OnClickBack : Intent
+
+        data class OnSwitchNotificationSettingType(
+            val type: NotificationSettingType,
+        ) : Intent
+    }
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State {
+        return State(
+            notificationSettingState = State.NotificationSettingState(),
+        )
+    }
+
+    override fun handleIntent(intent: Intent) {
+        when (intent) {
+            is Intent.OnClickBack -> handleOnClickBack()
+            is Intent.OnSwitchNotificationSettingType -> handleOnSwitchNotificationSettingType(intent)
+        }
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        analyticsHelper.e(throwable) { "state: $currentState" }
+    }
+
+    private fun handleOnClickBack() {
+        postSideEffect(Effect.NavigateToBack)
+    }
+
+    private fun handleOnSwitchNotificationSettingType(intent: Intent.OnSwitchNotificationSettingType) {
+        val notificationSettingState = currentState.notificationSettingState
+
+        reduce {
+            copy(
+                notificationSettingState = notificationSettingState.switch(intent.type),
+            )
+        }
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileNotificationViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileNotificationViewModel.kt
@@ -1,0 +1,251 @@
+package com.captures2024.soongan.presentation.viewmodel.main.profile
+
+import androidx.lifecycle.SavedStateHandle
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.PostSingleButtonDialogUseCase
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.core.domain.usecase.notifications.DeleteNotificationUseCase
+import com.captures2024.soongan.core.domain.usecase.notifications.GetNotificationsCountUseCase
+import com.captures2024.soongan.core.domain.usecase.notifications.GetNotificationsUseCase
+import com.captures2024.soongan.core.domain.usecase.notifications.PostNotificationReadUseCase
+import com.captures2024.soongan.core.model.dto.NotificationDto
+import com.captures2024.soongan.core.model.enums.CommonDialogType
+import com.captures2024.soongan.core.model.utils.NotificationSubType
+import com.captures2024.soongan.core.model.utils.NotificationType
+import com.captures2024.soongan.core.model.utils.NotificationsCountTable
+import com.captures2024.soongan.core.model.utils.NotificationsTable
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.EnumMap
+import javax.inject.Inject
+
+@HiltViewModel
+class ProfileNotificationViewModel
+@Inject
+constructor(
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle: SavedStateHandle,
+    private val postSingleButtonDialogUseCase: PostSingleButtonDialogUseCase,
+    private val getNotificationsUseCase: GetNotificationsUseCase,
+    private val getNotificationsCountUseCase: GetNotificationsCountUseCase,
+    private val postNotificationReadUseCase: PostNotificationReadUseCase,
+    private val deleteNotificationUseCase: DeleteNotificationUseCase,
+) : BaseViewModel<ProfileNotificationViewModel.State, ProfileNotificationViewModel.Effect, ProfileNotificationViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle = savedStateHandle,
+) {
+    data class State(
+        val notificationCategories: List<NotificationType>,
+        val selectedNotificationCategory: NotificationType,
+        val notifications: NotificationsTable,
+        val notificationsCount: NotificationsCountTable,
+    ) : UIState
+
+    sealed interface Effect : UISideEffect {
+
+        data object NavigateToBack : Effect
+
+        data class NavigateFromNotification(
+            val subType: NotificationSubType,
+            val url: String?, // redirectUrl
+        ) : Effect
+    }
+
+    sealed interface Intent : UIIntent {
+
+        data object Init : Intent
+
+        data object OnClickBack : Intent
+
+        data class OnClickCategory(
+            val type: NotificationType,
+        ) : Intent
+
+        data class OnClickNotification(
+            val key: Int,
+        ) : Intent
+
+        data class OnDeleteNotification(
+            val key: Int,
+        ) : Intent
+    }
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State {
+        return State(
+            notificationCategories = NotificationType.entries,
+            selectedNotificationCategory = NotificationType.CONTEST,
+            notifications = emptyMap(),
+            notificationsCount = emptyMap(),
+        )
+    }
+
+    init {
+        intent(Intent.Init)
+    }
+
+    override fun handleIntent(intent: Intent) {
+        when (intent) {
+            is Intent.Init -> loadingLaunch { handleInit() }
+            is Intent.OnClickBack -> handleOnClickBack()
+            is Intent.OnClickCategory -> handleOnClickCategory(intent)
+            is Intent.OnClickNotification -> loadingLaunch { handleOnClickNotification(intent) }
+            is Intent.OnDeleteNotification -> loadingLaunch { handleOnDeleteNotification(intent) }
+        }
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        analyticsHelper.e(throwable) { "state: $currentState" }
+    }
+
+    private suspend fun handleInit() {
+        initSetNotificationsCount()
+        initSetNotifications()
+    }
+
+    private fun handleOnClickBack() {
+        postSideEffect(Effect.NavigateToBack)
+    }
+
+    private fun handleOnClickCategory(intent: Intent.OnClickCategory) {
+        reduce {
+            copy(
+                selectedNotificationCategory = intent.type,
+            )
+        }
+    }
+
+    private suspend fun handleOnClickNotification(intent: Intent.OnClickNotification) {
+        val state = currentState
+        val targetNotificationMap = state.notifications[state.selectedNotificationCategory] ?: return
+        val targetNotification = targetNotificationMap[intent.key] ?: return
+
+        val result = postNotificationReadUseCase(notificationId = targetNotification.id).getOrNull()
+
+        if (result == null) {
+            postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+            return
+        }
+
+        if (result) {
+            val updatedMap = targetNotificationMap.toMutableMap()
+                .apply {
+                    put(
+                        intent.key,
+                        targetNotification.copy(
+                            isRead = true,
+                        ),
+                    )
+                }
+                .toMap()
+
+            reduce {
+                copy(
+                    notifications = notifications.toMutableMap()
+                        .apply {
+                            put(
+                                state.selectedNotificationCategory,
+                                updatedMap,
+                            )
+                        }
+                        .toMap(),
+                )
+            }
+
+            postSideEffect(
+                Effect.NavigateFromNotification(
+                    subType = targetNotification.subType,
+                    url = targetNotification.redirectUrl,
+                ),
+            )
+        }
+    }
+
+    private suspend fun handleOnDeleteNotification(intent: Intent.OnDeleteNotification) {
+        val state = currentState
+        val targetNotificationMap = state.notifications[state.selectedNotificationCategory] ?: return
+        val targetNotification = targetNotificationMap[intent.key] ?: return
+
+        val result = deleteNotificationUseCase(notificationId = targetNotification.id).getOrNull()
+
+        if (result == null) {
+            postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+            return
+        }
+
+        val updatedMap = targetNotificationMap.toMutableMap().apply {
+            remove(intent.key)
+        }.toMap()
+
+        reduce {
+            copy(
+                notifications = state.notifications.toMutableMap().apply {
+                    put(state.selectedNotificationCategory, updatedMap)
+                }.toMap(),
+            )
+        }
+    }
+
+    private suspend fun initSetNotificationsCount() {
+        val notificationsCountDto = getNotificationsCountUseCase().getOrNull()
+
+        if (notificationsCountDto == null) {
+            postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+            return
+        }
+
+        analyticsHelper.d { "Init Set NotificationsCountDto: $notificationsCountDto" }
+
+        reduce {
+            copy(
+                notificationsCount = EnumMap<NotificationType, Int>(NotificationType::class.java).apply {
+                    notificationsCountDto.notificationCountItems
+                        .forEach { item -> put(item.type, item.count) }
+                }.toMap(),
+            )
+        }
+    }
+
+    private suspend fun initSetNotifications() {
+        val tempNotificationsTable = EnumMap<NotificationType, Map<Int, NotificationDto>>(NotificationType::class.java)
+
+        NotificationType.entries.forEach { type ->
+            val notificationsDto = getNotificationsUseCase(type = type).getOrNull()
+
+            if (notificationsDto == null) {
+                postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+                return
+            }
+
+            analyticsHelper.d { "Init Set NotificationsDto: $notificationsDto" }
+
+            val tempNotificationMap: Map<Int, NotificationDto> = notificationsDto.notifications
+                .mapIndexed { index, notification -> index to notification }
+                .toMap()
+
+            tempNotificationsTable.put(notificationsDto.type, tempNotificationMap)
+        }
+
+        reduce {
+            copy(
+                notifications = tempNotificationsTable.toMap(),
+            )
+        }
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileSignOutViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileSignOutViewModel.kt
@@ -1,0 +1,107 @@
+package com.captures2024.soongan.presentation.viewmodel.main.profile
+
+import androidx.lifecycle.SavedStateHandle
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.auth.SignOutSocialPlatformUseCase
+import com.captures2024.soongan.core.domain.usecase.dialog.PostSingleButtonDialogUseCase
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.ClearCurrentMemberUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.core.model.enums.CommonDialogType
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ProfileSignOutViewModel
+@Inject
+constructor(
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle: SavedStateHandle,
+    private val postSingleButtonDialogUseCase: PostSingleButtonDialogUseCase,
+    private val signOutSocialPlatformUseCase: SignOutSocialPlatformUseCase,
+    private val clearCurrentMemberUseCase: ClearCurrentMemberUseCase,
+) : BaseViewModel<ProfileSignOutViewModel.State, ProfileSignOutViewModel.Effect, ProfileSignOutViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle = savedStateHandle,
+) {
+
+    data class State(
+        val isSuccess: Boolean,
+    ) : UIState
+
+    sealed interface Effect : UISideEffect {
+
+        data object NavigateToBack : Effect
+
+        data object NavigateToDone : Effect
+    }
+
+    sealed interface Intent : UIIntent {
+
+        data object OnClickBack : Intent
+
+        data object OnClickConfirmSignOut : Intent
+
+        data object OnClickDoneSignOut : Intent
+    }
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State {
+        return State(
+            isSuccess = false,
+        )
+    }
+
+    override fun handleIntent(intent: Intent) {
+        when (intent) {
+            is Intent.OnClickBack -> handleOnClickBack()
+            is Intent.OnClickConfirmSignOut -> loadingLaunch { handleOnClickConfirmSignOut() }
+            is Intent.OnClickDoneSignOut -> launch { handleOnClickDoneSignOut() }
+        }
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        analyticsHelper.e(throwable) { "state: $currentState" }
+    }
+
+    private fun handleOnClickBack() {
+        postSideEffect(Effect.NavigateToBack)
+    }
+
+    private suspend fun handleOnClickConfirmSignOut() {
+        val result = signOutSocialPlatformUseCase().getOrNull()
+
+        if (result != true) {
+            postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+            return
+        }
+
+        reduce {
+            copy(
+                isSuccess = true,
+            )
+        }
+    }
+
+    private suspend fun handleOnClickDoneSignOut() {
+        postSideEffect(Effect.NavigateToDone)
+
+        clearCurrentMemberUseCase()
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileViewModel.kt
@@ -1,0 +1,165 @@
+package com.captures2024.soongan.presentation.viewmodel.main.profile
+
+import androidx.lifecycle.SavedStateHandle
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetCurrentMemberFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.core.domain.usecase.system.LaunchTermsUseCase
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.UserProfile
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ProfileViewModel
+@Inject
+constructor(
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle: SavedStateHandle,
+    private val getCurrentMemberFlowUseCase: GetCurrentMemberFlowUseCase,
+    private val launchTermsUseCase: LaunchTermsUseCase,
+) : BaseViewModel<ProfileViewModel.State, ProfileViewModel.Effect, ProfileViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle = savedStateHandle,
+) {
+
+    data class State(
+        val userProfile: UserProfile,
+        val isShowMenuBottomSheet: Boolean,
+    ) : UIState
+
+    sealed interface Effect : UISideEffect {
+
+        data object NavigateToNotification : Effect
+
+        data class NavigateToPostInfo(
+            val postId: Long,
+        ) : Effect
+
+        data object NavigateToRegistrationPost : Effect
+
+        data object NavigateToEditProfile : Effect
+
+        data object NavigateToFAQ : Effect
+    }
+
+    sealed interface Intent : UIIntent {
+        data object Init : Intent
+
+        data object OnClickMenu : Intent
+
+        data object OnClickNotification : Intent
+
+        data object OnDismissRequestMenuBottomSheet : Intent
+
+        data object OnClickEditProfile : Intent
+
+        data object OnClickFaq : Intent
+
+        data object OnClickTerms : Intent
+    }
+
+    init {
+        intent(Intent.Init)
+    }
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State {
+        return State(
+            userProfile = UserProfile(),
+            isShowMenuBottomSheet = false,
+        )
+    }
+
+    override fun handleIntent(intent: Intent) {
+        when (intent) {
+            is Intent.Init -> handleInit()
+            is Intent.OnClickMenu -> handleOnClickMenu()
+            is Intent.OnClickNotification -> handleOnClickNotification()
+            is Intent.OnDismissRequestMenuBottomSheet -> handleOnDismissRequestMenuBottomSheet()
+            is Intent.OnClickEditProfile -> handleOnClickEditProfile()
+            is Intent.OnClickFaq -> handleOnClickFaq()
+            is Intent.OnClickTerms -> loadingLaunch { handleOnClickTerms() }
+        }
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        analyticsHelper.e(throwable) { "state: $currentState" }
+    }
+
+    private fun handleInit() {
+        launch { collectUserProfile() }
+    }
+
+    private fun handleOnClickMenu() {
+        showMenuBottomSheet()
+    }
+
+    private fun handleOnClickNotification() {
+        postSideEffect(Effect.NavigateToNotification)
+    }
+
+    private fun handleOnDismissRequestMenuBottomSheet() {
+        dismissMenuBottomSheet()
+    }
+
+    private fun handleOnClickEditProfile() {
+        postSideEffect(Effect.NavigateToEditProfile)
+    }
+
+    private fun handleOnClickFaq() {
+        postSideEffect(Effect.NavigateToFAQ)
+    }
+
+    private suspend fun handleOnClickTerms() {
+        launchTermsUseCase()
+    }
+
+    private suspend fun collectUserProfile() {
+        getCurrentMemberFlowUseCase().collect { currentMember ->
+            currentMember?.let {
+                reduce {
+                    copy(
+                        userProfile = UserProfile(
+                            nickname = currentMember.nickname ?: "user1",
+                            selfIntroduction = currentMember.selfIntroduction ?: "본인을 소개해주세요",
+                            profileImageUrl = currentMember.profileImageUrl,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun showMenuBottomSheet() {
+        reduce {
+            copy(
+                isShowMenuBottomSheet = true,
+            )
+        }
+    }
+
+    private fun dismissMenuBottomSheet() {
+        reduce {
+            copy(
+                isShowMenuBottomSheet = false,
+            )
+        }
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileViewModel.kt
@@ -12,7 +12,10 @@ import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetCurrentMemberFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.domain.usecase.system.LaunchTermsUseCase
+import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetMyGalleryUseCase
+import com.captures2024.soongan.core.model.dto.GalleryPostDto
 import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.PaginationStatus
 import com.captures2024.soongan.presentation.viewmodel.model.UserProfile
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -30,6 +33,7 @@ constructor(
     savedStateHandle: SavedStateHandle,
     private val getCurrentMemberFlowUseCase: GetCurrentMemberFlowUseCase,
     private val launchTermsUseCase: LaunchTermsUseCase,
+    private val getMyGalleryUseCase: GetMyGalleryUseCase,
 ) : BaseViewModel<ProfileViewModel.State, ProfileViewModel.Effect, ProfileViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
@@ -42,8 +46,22 @@ constructor(
 
     data class State(
         val userProfile: UserProfile,
+        val myGalleryState: MyGalleryState,
         val isShowMenuBottomSheet: Boolean,
-    ) : UIState
+    ) : UIState {
+
+        data class MyGalleryState(
+            val isRefreshing: Boolean,
+            val posts: List<GalleryPostDto>,
+            val paginationStatus: PaginationStatus,
+            val loadPage: Int,
+            val loadPageSize: Int,
+            val hasNextPage: Boolean,
+        ) {
+            val isInitPage: Boolean
+                get() = loadPage == 0
+        }
+    }
 
     sealed interface Effect : UISideEffect {
 
@@ -74,6 +92,16 @@ constructor(
         data object OnClickFaq : Intent
 
         data object OnClickTerms : Intent
+
+        data object OnRefresh : Intent
+
+        data object OnLoadNextPage : Intent
+
+        data object OnClickRegisterPost : Intent
+
+        data class OnClickPost(
+            val postId: Long,
+        ) : Intent
     }
 
     init {
@@ -83,19 +111,31 @@ constructor(
     override fun createInitialState(savedStateHandle: SavedStateHandle): State {
         return State(
             userProfile = UserProfile(),
+            myGalleryState = State.MyGalleryState(
+                isRefreshing = false,
+                posts = emptyList(),
+                paginationStatus = PaginationStatus.DEFAULT,
+                loadPage = 0,
+                loadPageSize = 50,
+                hasNextPage = false,
+            ),
             isShowMenuBottomSheet = false,
         )
     }
 
     override fun handleIntent(intent: Intent) {
         when (intent) {
-            is Intent.Init -> handleInit()
+            is Intent.Init -> loadingLaunch { handleInit() }
             is Intent.OnClickMenu -> handleOnClickMenu()
             is Intent.OnClickNotification -> handleOnClickNotification()
             is Intent.OnDismissRequestMenuBottomSheet -> handleOnDismissRequestMenuBottomSheet()
             is Intent.OnClickEditProfile -> handleOnClickEditProfile()
             is Intent.OnClickFaq -> handleOnClickFaq()
             is Intent.OnClickTerms -> loadingLaunch { handleOnClickTerms() }
+            is Intent.OnRefresh -> launch { handleOnRefresh() }
+            is Intent.OnLoadNextPage -> launch { handleOnLoadNextPage() }
+            is Intent.OnClickRegisterPost -> handleOnClickRegisterPost()
+            is Intent.OnClickPost -> handleOnClickPost(intent)
         }
     }
 
@@ -103,8 +143,21 @@ constructor(
         analyticsHelper.e(throwable) { "state: $currentState" }
     }
 
-    private fun handleInit() {
+    private suspend fun handleInit() {
         launch { collectUserProfile() }
+
+        val status = getRemotePost(
+            page = 0,
+            isRefreshing = true,
+        )
+
+        reduce {
+            copy(
+                myGalleryState = myGalleryState.copy(
+                    paginationStatus = status,
+                ),
+            )
+        }
     }
 
     private fun handleOnClickMenu() {
@@ -129,6 +182,54 @@ constructor(
 
     private suspend fun handleOnClickTerms() {
         launchTermsUseCase()
+    }
+
+    private suspend fun handleOnRefresh() {
+        reduce {
+            copy(
+                myGalleryState = myGalleryState.copy(
+                    isRefreshing = true,
+                ),
+            )
+        }
+
+        val status = getRemotePost(
+            page = 0,
+            isRefreshing = true,
+        )
+
+        reduce {
+            copy(
+                myGalleryState = myGalleryState.copy(
+                    isRefreshing = false,
+                    paginationStatus = status,
+                ),
+            )
+        }
+    }
+
+    private suspend fun handleOnLoadNextPage() {
+        val status = getRemotePost(page = currentState.myGalleryState.loadPage)
+
+        reduce {
+            copy(
+                myGalleryState = myGalleryState.copy(
+                    paginationStatus = status,
+                ),
+            )
+        }
+    }
+
+    private fun handleOnClickRegisterPost() {
+        postSideEffect(Effect.NavigateToRegistrationPost)
+    }
+
+    private fun handleOnClickPost(intent: Intent.OnClickPost) {
+        postSideEffect(
+            sideEffect = Effect.NavigateToPostInfo(
+                postId = intent.postId,
+            )
+        )
     }
 
     private suspend fun collectUserProfile() {
@@ -161,5 +262,57 @@ constructor(
                 isShowMenuBottomSheet = false,
             )
         }
+    }
+
+    private suspend fun getRemotePost(
+        page: Int,
+        isRefreshing: Boolean = false,
+    ): PaginationStatus {
+        val state = currentState
+
+        when (state.myGalleryState.paginationStatus) {
+            PaginationStatus.REFRESH_LOAD,
+            PaginationStatus.PAGING_LOAD,
+                -> return state.myGalleryState.paginationStatus
+
+            else -> Unit
+        }
+
+        reduce {
+            copy(
+                myGalleryState = myGalleryState.copy(
+                    paginationStatus = when (isRefreshing) {
+                        true -> PaginationStatus.REFRESH_LOAD
+                        false -> PaginationStatus.PAGING_LOAD
+                    },
+                ),
+            )
+        }
+
+        val galleryDto = getMyGalleryUseCase(
+            params = GetMyGalleryUseCase.Params(
+                page = page,
+                pageSize = state.myGalleryState.loadPageSize,
+            ),
+        ).getOrNull()
+
+        if (galleryDto == null) {
+            return PaginationStatus.FAILED
+        }
+
+        reduce {
+            copy(
+                myGalleryState = myGalleryState.copy(
+                    posts = when (isRefreshing) {
+                        true -> galleryDto.posts
+                        false -> myGalleryState.posts + galleryDto.posts
+                    },
+                    loadPage = page + 1,
+                    hasNextPage = galleryDto.hasNext,
+                ),
+            )
+        }
+
+        return PaginationStatus.SUCCESS
     }
 }

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileWithdrawViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileWithdrawViewModel.kt
@@ -1,0 +1,122 @@
+package com.captures2024.soongan.presentation.viewmodel.main.profile
+
+import androidx.lifecycle.SavedStateHandle
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.auth.WithdrawMemberUseCase
+import com.captures2024.soongan.core.domain.usecase.dialog.PostSingleButtonDialogUseCase
+import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
+import com.captures2024.soongan.core.domain.usecase.members.ClearCurrentMemberUseCase
+import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.core.model.AppConst
+import com.captures2024.soongan.core.model.enums.CommonDialogType
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ProfileWithdrawViewModel
+@Inject
+constructor(
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle: SavedStateHandle,
+    private val postSingleButtonDialogUseCase: PostSingleButtonDialogUseCase,
+    private val withdrawMemberUseCase: WithdrawMemberUseCase,
+    private val clearCurrentMemberUseCase: ClearCurrentMemberUseCase,
+) : BaseViewModel<ProfileWithdrawViewModel.State, ProfileWithdrawViewModel.Effect, ProfileWithdrawViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle = savedStateHandle,
+) {
+
+    data class State(
+        val input: String,
+        val isSuccessWithdraw: Boolean,
+    ) : UIState
+
+    sealed interface Effect : UISideEffect {
+
+        data object NavigateToBack : Effect
+
+        data object NavigateToDone : Effect
+    }
+
+    sealed interface Intent : UIIntent {
+
+        data object OnClickBack : Intent
+
+        data class OnInputValueChanged(
+            val newValue: String,
+        ) : Intent
+
+        data object OnClickConfirmWithdraw : Intent
+
+        data object OnClickDoneWithdraw : Intent
+    }
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State {
+        return State(
+            input = AppConst.EMPTY_STRING,
+            isSuccessWithdraw = false,
+        )
+    }
+
+    override fun handleIntent(intent: Intent) {
+        when (intent) {
+            is Intent.OnClickBack -> handleOnClickBack()
+            is Intent.OnInputValueChanged -> handleOnInputValueChanged(intent)
+            is Intent.OnClickConfirmWithdraw -> loadingLaunch { handleOnClickConfirmWithdraw() }
+            is Intent.OnClickDoneWithdraw -> launch { handleOnClickDoneWithdraw() }
+        }
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        analyticsHelper.e(throwable) { "state: $currentState" }
+    }
+
+    private fun handleOnClickBack() {
+        postSideEffect(Effect.NavigateToBack)
+    }
+
+    private fun handleOnInputValueChanged(intent: Intent.OnInputValueChanged) {
+        reduce {
+            copy(
+                input = intent.newValue,
+            )
+        }
+    }
+
+    private suspend fun handleOnClickConfirmWithdraw() {
+        val result = withdrawMemberUseCase().getOrNull()
+
+        if (result != true) {
+            postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+            return
+        }
+
+        reduce {
+            copy(
+                isSuccessWithdraw = true,
+            )
+        }
+    }
+
+    private suspend fun handleOnClickDoneWithdraw() {
+        postSideEffect(Effect.NavigateToDone)
+        clearCurrentMemberUseCase()
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/FaqCategory.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/FaqCategory.kt
@@ -1,0 +1,27 @@
+package com.captures2024.soongan.presentation.viewmodel.model
+
+enum class FaqCategory {
+    DEFAULT,
+    CONTEST,
+    COPYRIGHT,
+    ;
+
+    fun getCategoryItems(): List<FaqCategoryItem> = when (this) {
+        DEFAULT -> listOf(
+            FaqCategoryItem.Default.First,
+            FaqCategoryItem.Default.Second,
+        )
+        CONTEST -> listOf(
+            FaqCategoryItem.Contest.First,
+            FaqCategoryItem.Contest.Second,
+            FaqCategoryItem.Contest.Third,
+            FaqCategoryItem.Contest.Fourth,
+            FaqCategoryItem.Contest.Fifth,
+        )
+        COPYRIGHT -> listOf(
+            FaqCategoryItem.Copyright.First,
+            FaqCategoryItem.Copyright.Second,
+            FaqCategoryItem.Copyright.Third,
+        )
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/FaqCategoryItem.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/FaqCategoryItem.kt
@@ -1,0 +1,23 @@
+package com.captures2024.soongan.presentation.viewmodel.model
+
+sealed interface FaqCategoryItem {
+
+    sealed interface Default : FaqCategoryItem {
+        data object First : Default
+        data object Second : Default
+    }
+
+    sealed interface Contest : FaqCategoryItem {
+        data object First : Default
+        data object Second : Default
+        data object Third : Default
+        data object Fourth : Default
+        data object Fifth : Default
+    }
+
+    sealed interface Copyright : FaqCategoryItem {
+        data object First : Default
+        data object Second : Default
+        data object Third : Default
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/FaqCategoryItem.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/FaqCategoryItem.kt
@@ -8,16 +8,16 @@ sealed interface FaqCategoryItem {
     }
 
     sealed interface Contest : FaqCategoryItem {
-        data object First : Default
-        data object Second : Default
-        data object Third : Default
-        data object Fourth : Default
-        data object Fifth : Default
+        data object First : Contest
+        data object Second : Contest
+        data object Third : Contest
+        data object Fourth : Contest
+        data object Fifth : Contest
     }
 
     sealed interface Copyright : FaqCategoryItem {
-        data object First : Default
-        data object Second : Default
-        data object Third : Default
+        data object First : Copyright
+        data object Second : Copyright
+        data object Third : Copyright
     }
 }

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/NotificationSettingType.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/NotificationSettingType.kt
@@ -1,0 +1,8 @@
+package com.captures2024.soongan.presentation.viewmodel.model
+
+enum class NotificationSettingType {
+    ALL,
+    CONTEST,
+    ACTIVITY,
+    NOTICE,
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/ProfileBottomSheetMenuItem.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/ProfileBottomSheetMenuItem.kt
@@ -1,0 +1,10 @@
+package com.captures2024.soongan.presentation.viewmodel.model
+
+enum class ProfileBottomSheetMenuItem {
+    EDIT,
+    PUSH,
+    TERMS_AND_POLICY,
+    FAQ,
+    WITHDRAW,
+    SIGN_OUT,
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/UserProfile.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/UserProfile.kt
@@ -1,0 +1,7 @@
+package com.captures2024.soongan.presentation.viewmodel.model
+
+data class UserProfile(
+    val nickname: String = "user1",
+    val selfIntroduction: String = "본인을 소개해주세요",
+    val profileImageUrl: String? = null,
+)


### PR DESCRIPTION
# [SG-135] refactor profile

## 변경 사항
- 기존 profile 모듈 로직 refactor
- 기존 바텀시트에 navHost 사용하지 않던 부분 사용하도록 수정

## 비고
- _현재 프로필에서 내 게시글 갤러리쪽은 구현하지 않은 상태입니다 참고 부탁드립니다_
    - 현재 갤러리까지 구현한 커밋이 올라갔습니다

[SG-135]: https://captures2024.atlassian.net/browse/SG-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ