### PR TITLE
[SG-133] refactor main-feed

### DIFF
--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/AppConst.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/AppConst.kt
@@ -47,4 +47,8 @@ object AppConst {
         const val ACCESS_TOKEN_ALLOW = "$AUTH_HEADER: true"
         const val REFRESH_TOKEN_ALLOW = "$AUTH_HEADER: false"
     }
+
+    object SavedStateHandle {
+        const val UGC_HIDE_KEY = "ugc-hide-key"
+    }
 }

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/AppConst.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/AppConst.kt
@@ -24,4 +24,8 @@ object AppConst {
         const val ACCESS_TOKEN_ALLOW = "$AUTH_HEADER: true"
         const val REFRESH_TOKEN_ALLOW = "$AUTH_HEADER: false"
     }
+
+    object Gallery {
+        const val PAGE_SIZE = 20
+    }
 }

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/AppConst.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/AppConst.kt
@@ -28,6 +28,10 @@ object AppConst {
 
             const val IMAGE_DEFAULT_DURATION: Long = 1L * 1L * 1000L
         }
+
+        object Gallery {
+            const val PAGE_SIZE = 50
+        }
     }
 
     object Notification {
@@ -42,9 +46,5 @@ object AppConst {
 
         const val ACCESS_TOKEN_ALLOW = "$AUTH_HEADER: true"
         const val REFRESH_TOKEN_ALLOW = "$AUTH_HEADER: false"
-    }
-
-    object Gallery {
-        const val PAGE_SIZE = 20
     }
 }

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/mock/MockUpData.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/mock/MockUpData.kt
@@ -8,7 +8,7 @@ import com.captures2024.soongan.core.model.utils.NotificationsTable
 import java.util.EnumMap
 
 val mockFeedTitleOptions by lazy {
-    listOf(1 to "평화", 2 to "즐거움", 3 to "따듯함", 4 to "행복")
+    listOf(1 to "평화", 2 to "즐거움", 3 to "따듯함", 4 to "주제", 5 to "주제", 6 to "주제", 7 to "주제", 8 to "주제", 9 to "주제", 10 to "주제")
 }
 
 val mockPosts: List<GalleryPostDto> by lazy {

--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/util/NavCotrollerExt.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/util/NavCotrollerExt.kt
@@ -4,35 +4,53 @@ import androidx.navigation.NavController
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.navOptions
 import com.captures2024.soongan.core.model.utils.NotificationSubType
+import com.captures2024.soongan.core.navigator.screen.main.feed.FeedNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.HomeGalleryNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.HomeNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHome
 
-private const val SAVED_STATE_HANDLE_KEY = "hide_post_id"
+private const val UGC_HIDE_KEY = "ugc-hide-key"
+
+private enum class HideTargetScreen(val navigator: Any) {
+    HOME_GALLERY(HomeGalleryNavigator),
+    FEED(FeedNavigator),
+}
 
 /**
- * 갤러리 화면에서 접근한 게시물이 삭제/신고 되었을 경우 popBackStack + hidePost
+ *  직전 화면에 즉시 숨겨야 할 콘텐츠가 있는 경우, target ID를 직전 화면 스택에 저장 후 뒤로 가기
+ *  save hideTargetContentId in previousBackStackEntry (HomeGallery || Feed) + popBackStack
  *
- * @param postId
+ *  ps. 직전 화면에서 NavController.getHideTargetContentId()를 통해 targetId를 획득 가능
+ *
+ * @param targetId
  */
-fun NavController.navigateToBackWithHidePost(postId: Long) {
-    this.previousBackStackEntry?.destination?.hasRoute<HomeGalleryNavigator>()
-        ?.let { isGalleryRoute ->
-            when (isGalleryRoute) {
-                true -> setHidedPostId(postId)
-                false -> popBackStack()
-            }
-        }
+fun NavController.navigateToBackWithHideTargetContentId(targetId: Long) {
+    val prevDestination = this.previousBackStackEntry?.destination ?: return
+
+    val hideTargetScreen = HideTargetScreen.entries.find { screen ->
+        prevDestination.hasRoute(screen.navigator::class)
+    }
+
+    if(hideTargetScreen == null) {
+        popBackStack()
+
+        return
+    }
+
+    setHideTargetContentId(targetId)
+
+    when(hideTargetScreen) {
+        HideTargetScreen.HOME_GALLERY -> popBackStack<HomeGalleryNavigator>(inclusive = false)
+
+        HideTargetScreen.FEED -> popBackStack<FeedNavigator>(inclusive = false)
+    }
 }
 
-private fun NavController.setHidedPostId(postId: Long) {
-    this.previousBackStackEntry?.savedStateHandle?.set(SAVED_STATE_HANDLE_KEY, postId)
+private fun NavController.setHideTargetContentId(targetId: Long) =
+    this.previousBackStackEntry?.savedStateHandle?.set(UGC_HIDE_KEY, targetId)
 
-    popBackStack<HomeGalleryNavigator>(inclusive = false)
-}
-
-fun NavController.getHidedPostId(): Long =
-    this.currentBackStackEntry?.savedStateHandle?.get(SAVED_STATE_HANDLE_KEY) ?: -1L
+fun NavController.getHideTargetContentId(): Long =
+    this.currentBackStackEntry?.savedStateHandle?.get(UGC_HIDE_KEY) ?: -1L
 
 /**
  * 알림 하위 타입에 따른 타겟 화면으로 전환.

--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/util/NavCotrollerExt.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/util/NavCotrollerExt.kt
@@ -3,13 +3,12 @@ package com.captures2024.soongan.core.navigator.screen.main.util
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.navOptions
+import com.captures2024.soongan.core.model.AppConst
 import com.captures2024.soongan.core.model.utils.NotificationSubType
 import com.captures2024.soongan.core.navigator.screen.main.feed.FeedNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.HomeGalleryNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.HomeNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHome
-
-private const val UGC_HIDE_KEY = "ugc-hide-key"
 
 private enum class HideTargetScreen(val navigator: Any) {
     HOME_GALLERY(HomeGalleryNavigator),
@@ -47,10 +46,10 @@ fun NavController.navigateToBackWithHideTargetContentId(targetId: Long) {
 }
 
 private fun NavController.setHideTargetContentId(targetId: Long) =
-    this.previousBackStackEntry?.savedStateHandle?.set(UGC_HIDE_KEY, targetId)
+    this.previousBackStackEntry?.savedStateHandle?.set(AppConst.SavedStateHandle.UGC_HIDE_KEY, targetId)
 
 fun NavController.getHideTargetContentId(): Long =
-    this.currentBackStackEntry?.savedStateHandle?.get(UGC_HIDE_KEY) ?: -1L
+    this.currentBackStackEntry?.savedStateHandle?.get(AppConst.SavedStateHandle.UGC_HIDE_KEY) ?: -1L
 
 /**
  * 알림 하위 타입에 따른 타겟 화면으로 전환.

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/feed/FeedViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/feed/FeedViewModel.kt
@@ -10,13 +10,14 @@ import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetFilteredGalleryByReportTargetIdsUseCase
+import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetWeeklyContestInfoListUseCase
+import com.captures2024.soongan.core.model.AppConst
 import com.captures2024.soongan.core.model.dto.GalleryPostDto
-import com.captures2024.soongan.core.model.mock.mockFeedTitleOptions
-import com.captures2024.soongan.core.model.mock.mockPosts
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
+import com.captures2024.soongan.core.viewmodel.model.PaginationStatus
 import com.captures2024.soongan.core.viewmodel.model.PostOrderType
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import javax.inject.Inject
 
 @HiltViewModel
@@ -30,6 +31,8 @@ constructor(
     getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
     setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
+    private val getWeeklyContestInfoListUseCase: GetWeeklyContestInfoListUseCase,
+    private val getFilteredGalleryByReportTargetIdsUseCase: GetFilteredGalleryByReportTargetIdsUseCase,
 ) : NewBaseViewModel<FeedViewModel.State, FeedViewModel.Effect, FeedViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
@@ -43,22 +46,28 @@ constructor(
     data class State(
         val isLoading: Boolean = false,
         val isRefreshing: Boolean = false,
-        val isShowDropDown: Boolean = false, /* cmp: FeedDropDown */
-        val isShowBottomSheet: Boolean = false, /* cmp: FeedFilterBottomSheet  */
+        val isOpenDropDown: Boolean = false,
+        val isOpenFilterBottomSheet: Boolean = false,
         val postOrderType: PostOrderType = PostOrderType.MOST_LIKED,
-        val currentRound: Int = 1,
+        val paginationStatus: PaginationStatus = PaginationStatus.INACTIVE,
         val titleOptions: List<Pair<Int, String>> = emptyList(), /* string value : "${round}회차 | title" */
+        val currentRound: Int = 1,
+        internal val nextPage: Int = 0,
+        internal val hasNextPage: Boolean = false,
         internal val feed: Map<Int, List<GalleryPostDto>> = emptyMap(),
     ) : UIState {
 
         val currentTitleOption: Pair<Int, String>
             get() = titleOptions[currentRound - 1]
 
+        val isFirstPage: Boolean
+            get() = (nextPage == 0)
+
         val currentRoundGallery: List<GalleryPostDto>
             get() = feed[currentRound] ?: emptyList()
 
         override fun toString(): String {
-            return "State(isLoading=$isLoading, isRefreshing = $isRefreshing, isShowDropDown = $isShowDropDown, isShowBottomSheet=$isShowBottomSheet, titleItems:$titleOptions, postOrderType:$postOrderType, feeds:$feed)"
+            return "State(isLoading=$isLoading, isRefreshing = $isRefreshing, isShowDropDown = $isOpenDropDown, isShowBottomSheet=$isOpenFilterBottomSheet, titleItems:$titleOptions, postOrderType:$postOrderType, currentRound:$currentRound, titleOptions:$titleOptions, feeds:$feed, currentTitleOption:$currentTitleOption, currentRoundGallery:$currentRoundGallery)"
         }
     }
 
@@ -73,9 +82,7 @@ constructor(
 
         data object Init : Intent
 
-        data class RefreshFeed(
-            val round: Int,
-        ) : Intent
+        data object RefreshFeed : Intent
 
         data class OnClickRound(
             val newRound: Int,
@@ -86,16 +93,16 @@ constructor(
         data object OnFilterDismissRequest : Intent
 
         data class OnClickSortFilter(
-            val round: Int,
             val postOrderType: PostOrderType,
         ) : Intent
+
+        data object LoadNextPage : Intent
 
         data class OnClickPost(
             val postId: Long,
         ) : Intent
 
         data class HidePost(
-            val round: Int,
             val postId: Long,
         ) : Intent
     }
@@ -116,7 +123,7 @@ constructor(
         when (intent) {
             is Intent.Init -> loadingLaunch { handleInit() }
 
-            is Intent.RefreshFeed -> launch { handleRefreshFeed(intent) }
+            is Intent.RefreshFeed -> launch { handleRefreshFeed() }
 
             is Intent.OnClickRound -> launch { handleOnClickRound(intent) }
 
@@ -126,6 +133,8 @@ constructor(
 
             is Intent.OnClickSortFilter -> launch { handleOnClickSortFilter(intent) }
 
+            is Intent.LoadNextPage -> launch { handleLoadNextPage() }
+
             is Intent.OnClickPost -> handleOnClickPost(intent)
 
             is Intent.HidePost -> handleOnReportedPost(intent)
@@ -133,33 +142,41 @@ constructor(
     }
 
     private suspend fun handleInit() {
-        getTitleOptions()
-        fetchFeedPage()
+        syncFeedInfo()
     }
 
-    private suspend fun handleRefreshFeed(intent: Intent.RefreshFeed) {
+    private suspend fun handleRefreshFeed() {
         reduce {
             copy(
                 isRefreshing = true,
+                nextPage = 0,
             )
         }
 
-        val round = intent.round
-        val orderType = currentState.postOrderType
+        fetchFeedPage()
 
-        fetchFeedPage(round = round, orderType = orderType)
+        reduce {
+            copy(
+                isRefreshing = false,
+            )
+        }
     }
 
     private suspend fun handleOnClickRound(intent: Intent.OnClickRound) {
-        val round = intent.newRound
+        reduce {
+            copy(
+                currentRound = intent.newRound,
+                nextPage = 0,
+            )
+        }
 
-        fetchFeedPage(round = round, orderType = currentState.postOrderType)
+        fetchFeedPage()
     }
 
     private fun handleOnClickFilter() {
         reduce {
             copy(
-                isShowBottomSheet = true,
+                isOpenFilterBottomSheet = true,
             )
         }
     }
@@ -167,23 +184,30 @@ constructor(
     private fun handleOnFilterDismissRequest() {
         reduce {
             copy(
-                isShowBottomSheet = false,
+                isOpenFilterBottomSheet = false,
             )
         }
     }
 
     private suspend fun handleOnClickSortFilter(intent: Intent.OnClickSortFilter) {
-        val round = intent.round
-        val orderType = intent.postOrderType
-
         reduce {
             copy(
-                isShowBottomSheet = false,
+                isOpenFilterBottomSheet = false,
                 postOrderType = intent.postOrderType,
             )
         }
 
-        fetchFeedPage(round = round, orderType = orderType)
+        fetchFeedPage()
+    }
+
+    private suspend fun handleLoadNextPage() {
+        reduce {
+            copy(
+                nextPage = nextPage + 1,
+            )
+        }
+
+        fetchFeedPage()
     }
 
     private fun handleOnClickPost(intent: Intent.OnClickPost) {
@@ -191,8 +215,8 @@ constructor(
     }
 
     private fun handleOnReportedPost(intent: Intent.HidePost) {
-        val round = intent.round
         val postId = intent.postId
+        val round = currentState.currentRound
 
         val tempPosts = currentState.feed[round]?.toMutableList() ?: mutableListOf()
 
@@ -205,34 +229,99 @@ constructor(
         analyticsHelper.d { "reported post, postId : $postId" }
     }
 
-    private fun getTitleOptions() {
-        val mockTitleOptions = mockFeedTitleOptions
+    private suspend fun syncFeedInfo() {
+        getTitleOptions()
+        fetchFeedPage()
+    }
+
+    private suspend fun getTitleOptions() {
+        val weeklyContestInfoListDto = getWeeklyContestInfoListUseCase().getOrNull()
+
+        if (weeklyContestInfoListDto == null) {
+            analyticsHelper.d { "getTitleOptions - weeklyContestInfoListDto is null" }
+
+            return
+        }
+
+        val titleOptions: List<Pair<Int, String>> =
+            weeklyContestInfoListDto.weeklyContestInfoList.map { it.round to it.subject }
 
         reduce {
             copy(
-                titleOptions = mockTitleOptions,
+                titleOptions = titleOptions,
             )
         }
     }
 
-    private suspend fun fetchFeedPage(
-        round: Int = 1,
-        orderType: PostOrderType = PostOrderType.MOST_LIKED,
-    ) {
-        val mockFeed = buildMap { put(round, mockPosts) }
-        // val feed = getFeedUseCase(round, orderType, + page | cursor)
+    private fun setUpPaginationStatus() {
+        if (currentState.isFirstPage) {
+            reduce {
+                copy(
+                    paginationStatus = PaginationStatus.LOADING,
+                    feed = emptyMap(),
+                )
+            }
+        } else {
+            reduce {
+                copy(
+                    paginationStatus = PaginationStatus.PAGINATING,
+                )
+            }
+        }
+    }
 
-        delay(1000) // 임시 로딩용
+    private suspend fun fetchFeedPage() {
+        when (currentState.paginationStatus) {
+            PaginationStatus.LOADING,
+            PaginationStatus.PAGINATING,
+            -> return
 
-        analyticsHelper.d { "fetchFeedPage - round: $round, orderType: $orderType, feed: $mockFeed" }
+            else -> Unit
+        }
+
+        setUpPaginationStatus()
+
+        val galleryDto = getFilteredGalleryByReportTargetIdsUseCase(
+            params = GetFilteredGalleryByReportTargetIdsUseCase.Params(
+                round = currentState.currentRound,
+                orderType = currentState.postOrderType.name,
+                page = currentState.nextPage,
+                pageSize = AppConst.Gallery.PAGE_SIZE,
+            ),
+        ).getOrNull()
+
+        if (galleryDto == null) {
+            analyticsHelper.d { "fetchFeedPage - galleryDto is null" }
+
+            reduce {
+                copy(
+                    paginationStatus = PaginationStatus.ERROR,
+                )
+            }
+
+            return
+        }
+
+        val round = galleryDto.round ?: currentState.currentRound
+
+        val currentPosts = currentState.feed[round].orEmpty()
+        val updatedPosts = currentPosts + galleryDto.posts
+
+        val updatedFeed = currentState.feed.toMutableMap().apply {
+            put(round, updatedPosts)
+        }.toMap()
 
         reduce {
             copy(
-//                isLoading | paginationStatus.Loading = false
-                isRefreshing = false,
-                currentRound = round,
-                postOrderType = orderType,
-                feed = mockFeed,
+                paginationStatus = when {
+                    !galleryDto.hasNext -> PaginationStatus.EXHAUST
+
+                    galleryDto.posts.isEmpty() -> PaginationStatus.EMPTY
+
+                    else -> PaginationStatus.INACTIVE
+                },
+                hasNextPage = galleryDto.hasNext,
+                feed = updatedFeed,
             )
         }
     }

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/feed/FeedViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/feed/FeedViewModel.kt
@@ -46,8 +46,8 @@ constructor(
     data class State(
         val isLoading: Boolean = false,
         val isRefreshing: Boolean = false,
-        val isOpenDropDown: Boolean = false,
-        val isOpenFilterBottomSheet: Boolean = false,
+        val isOpenTitlePickerBottomSheet: Boolean = false, /* cmp: FeedDropDown */
+        val isOpenFilterBottomSheet: Boolean = false, /* cmp: FeedFilterBottomSheet  */
         val postOrderType: PostOrderType = PostOrderType.MOST_LIKED,
         val paginationStatus: PaginationStatus = PaginationStatus.INACTIVE,
         val titleOptions: List<Pair<Int, String>> = emptyList(), /* string value : "${round}회차 | title" */
@@ -58,7 +58,7 @@ constructor(
     ) : UIState {
 
         val currentTitleOption: Pair<Int, String>
-            get() = titleOptions[currentRound - 1]
+            get() = titleOptions.getOrNull(currentRound - 1) ?: (0 to "")
 
         val isFirstPage: Boolean
             get() = (nextPage == 0)
@@ -67,7 +67,7 @@ constructor(
             get() = feed[currentRound] ?: emptyList()
 
         override fun toString(): String {
-            return "State(isLoading=$isLoading, isRefreshing = $isRefreshing, isShowDropDown = $isOpenDropDown, isShowBottomSheet=$isOpenFilterBottomSheet, titleItems:$titleOptions, postOrderType:$postOrderType, currentRound:$currentRound, titleOptions:$titleOptions, feeds:$feed, currentTitleOption:$currentTitleOption, currentRoundGallery:$currentRoundGallery)"
+            return "State(isLoading=$isLoading, isRefreshing = $isRefreshing, isOpenTitlePickerBottomSheet = $isOpenTitlePickerBottomSheet, isOpenFilterBottomSheet=$isOpenFilterBottomSheet, titleItems:$titleOptions, postOrderType:$postOrderType, feeds:$feed)"
         }
     }
 
@@ -82,11 +82,15 @@ constructor(
 
         data object Init : Intent
 
-        data object RefreshFeed : Intent
+        data object RefreshFeed: Intent
 
-        data class OnClickRound(
-            val newRound: Int,
-        ) : Intent
+        data object OnClickTitle: Intent
+
+        data object OnTitlePickerDismissRequest : Intent
+
+        data class OnSelectTitle(
+            val round: Int,
+        ): Intent
 
         data object OnClickFilter : Intent
 
@@ -103,7 +107,7 @@ constructor(
         ) : Intent
 
         data class HidePost(
-            val targetId: Long,
+            val postId: Long,
         ) : Intent
     }
 
@@ -125,7 +129,11 @@ constructor(
 
             is Intent.RefreshFeed -> launch { handleRefreshFeed() }
 
-            is Intent.OnClickRound -> launch { handleOnClickRound(intent) }
+            is Intent.OnClickTitle -> launch { handleOnClickTitle() }
+
+            is Intent.OnTitlePickerDismissRequest -> launch { handleOnTitlePickerDismissRequest() }
+
+            is Intent.OnSelectTitle -> launch { handleOnSelectTitle(intent) }
 
             is Intent.OnClickFilter -> handleOnClickFilter()
 
@@ -154,23 +162,32 @@ constructor(
         }
 
         fetchFeedPage()
+    }
 
+    private fun handleOnClickTitle() {
         reduce {
             copy(
-                isRefreshing = false,
+                isOpenTitlePickerBottomSheet = true,
             )
         }
     }
 
-    private suspend fun handleOnClickRound(intent: Intent.OnClickRound) {
+    private fun handleOnTitlePickerDismissRequest() {
         reduce {
             copy(
-                currentRound = intent.newRound,
-                nextPage = 0,
+                isOpenTitlePickerBottomSheet = false,
             )
         }
+    }
 
-        fetchFeedPage()
+    private suspend fun handleOnSelectTitle(intent: Intent.OnSelectTitle) {
+        val round = intent.round
+
+        if(round != currentState.currentRound) {
+            fetchFeedPage(round = round)
+        }
+
+        handleOnTitlePickerDismissRequest()
     }
 
     private fun handleOnClickFilter() {
@@ -190,14 +207,8 @@ constructor(
     }
 
     private suspend fun handleOnClickSortFilter(intent: Intent.OnClickSortFilter) {
-        reduce {
-            copy(
-                isOpenFilterBottomSheet = false,
-                postOrderType = intent.postOrderType,
-            )
-        }
-
-        fetchFeedPage()
+        handleOnFilterDismissRequest()
+        fetchFeedPage(postOrderType = intent.postOrderType)
     }
 
     private suspend fun handleLoadNextPage() {
@@ -215,18 +226,18 @@ constructor(
     }
 
     private fun handleOnReportedPost(intent: Intent.HidePost) {
-        val targetId = intent.targetId
         val round = currentState.currentRound
+        val postId = intent.postId
 
         val tempPosts = currentState.feed[round]?.toMutableList() ?: mutableListOf()
 
-        tempPosts.removeAll { it.postId == targetId }
+        tempPosts.removeAll { it.postId == postId }
 
         reduce {
             copy(feed = feed.toMutableMap().apply { put(round, tempPosts) }.toMap())
         }
 
-        analyticsHelper.d { "reported post, postId : $targetId" }
+        analyticsHelper.d { "reported post, postId : $postId" }
     }
 
     private suspend fun syncFeedInfo() {
@@ -270,7 +281,10 @@ constructor(
         }
     }
 
-    private suspend fun fetchFeedPage() {
+    private suspend fun fetchFeedPage(
+        round: Int = currentState.currentRound,
+        postOrderType: PostOrderType = currentState.postOrderType,
+    ) {
         when (currentState.paginationStatus) {
             PaginationStatus.LOADING,
             PaginationStatus.PAGINATING,
@@ -283,8 +297,8 @@ constructor(
 
         val galleryDto = getFilteredGalleryByReportTargetIdsUseCase(
             params = GetFilteredGalleryByReportTargetIdsUseCase.Params(
-                round = currentState.currentRound,
-                orderType = currentState.postOrderType.name,
+                round = round,
+                orderType = postOrderType.name,
                 page = currentState.nextPage,
                 pageSize = AppConst.Gallery.PAGE_SIZE,
             ),
@@ -302,8 +316,6 @@ constructor(
             return
         }
 
-        val round = galleryDto.round ?: currentState.currentRound
-
         val currentPosts = currentState.feed[round].orEmpty()
         val updatedPosts = currentPosts + galleryDto.posts
 
@@ -320,6 +332,7 @@ constructor(
 
                     else -> PaginationStatus.INACTIVE
                 },
+                currentRound = round,
                 hasNextPage = galleryDto.hasNext,
                 feed = updatedFeed,
             )

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/feed/FeedViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/feed/FeedViewModel.kt
@@ -103,7 +103,7 @@ constructor(
         ) : Intent
 
         data class HidePost(
-            val postId: Long,
+            val targetId: Long,
         ) : Intent
     }
 
@@ -215,18 +215,18 @@ constructor(
     }
 
     private fun handleOnReportedPost(intent: Intent.HidePost) {
-        val postId = intent.postId
+        val targetId = intent.targetId
         val round = currentState.currentRound
 
         val tempPosts = currentState.feed[round]?.toMutableList() ?: mutableListOf()
 
-        tempPosts.removeAll { it.postId == intent.postId }
+        tempPosts.removeAll { it.postId == targetId }
 
         reduce {
             copy(feed = feed.toMutableMap().apply { put(round, tempPosts) }.toMap())
         }
 
-        analyticsHelper.d { "reported post, postId : $postId" }
+        analyticsHelper.d { "reported post, postId : $targetId" }
     }
 
     private suspend fun syncFeedInfo() {

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
@@ -226,7 +226,7 @@ constructor(
                 round = null,
                 orderType = currentState.postOrderType.name,
                 page = currentState.nextPage,
-                pageSize = AppConst.Gallery.PAGE_SIZE,
+                pageSize = AppConst.Main.Gallery.PAGE_SIZE,
             ),
         ).getOrNull()
 

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
@@ -92,7 +92,7 @@ constructor(
         data object OnClickRegistrationText : Intent
 
         data class HidePost(
-            val postId: Long,
+            val targetId: Long,
         ) : Intent
     }
 
@@ -264,12 +264,12 @@ constructor(
     private fun handleHidePost(intent: Intent.HidePost) {
         val tempPosts = currentState.posts.toMutableList()
 
-        tempPosts.removeAll { it.postId == intent.postId }
+        tempPosts.removeAll { it.postId == intent.targetId }
 
         reduce {
             copy(posts = tempPosts.toList())
         }
 
-        analyticsHelper.d { "reported post, postId : ${intent.postId}" }
+        analyticsHelper.d { "reported post, postId : ${intent.targetId}" }
     }
 }

--- a/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
+++ b/core/viewmodel/src/main/kotlin/com/captures2024/soongan/core/viewmodel/home/HomeGalleryViewModel.kt
@@ -11,6 +11,7 @@ import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ShowLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.members.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetFilteredGalleryByReportTargetIdsUseCase
+import com.captures2024.soongan.core.model.AppConst
 import com.captures2024.soongan.core.model.dto.GalleryPostDto
 import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
 import com.captures2024.soongan.core.viewmodel.model.PaginationStatus
@@ -22,7 +23,6 @@ import javax.inject.Inject
 class HomeGalleryViewModel
 @Inject
 constructor(
-    private val getFilteredGalleryByReportTargetIdsUseCase: GetFilteredGalleryByReportTargetIdsUseCase,
     analyticsHelper: AnalyticsHelper,
     showLoadingUseCase: ShowLoadingUseCase,
     hideLoadingUseCase: HideLoadingUseCase,
@@ -30,6 +30,7 @@ constructor(
     getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
     setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
+    private val getFilteredGalleryByReportTargetIdsUseCase: GetFilteredGalleryByReportTargetIdsUseCase,
 ) : NewBaseViewModel<HomeGalleryViewModel.State, HomeGalleryViewModel.Effect, HomeGalleryViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
@@ -42,17 +43,20 @@ constructor(
 
     data class State(
         val isLoading: Boolean = false,
-        val isShowBottomSheet: Boolean = false,
         val isRefreshing: Boolean = false,
+        val isOpenFilterBottomSheet: Boolean = false,
         val postOrderType: PostOrderType = PostOrderType.MOST_LIKED,
         val paginationStatus: PaginationStatus = PaginationStatus.INACTIVE,
         val posts: List<GalleryPostDto> = emptyList(),
-        val nextPage: Int = 0,
-        val hasNextPage: Boolean = false,
+        internal val nextPage: Int = 0,
+        internal val hasNextPage: Boolean = false,
     ) : UIState {
 
+        val isFirstPage: Boolean
+            get() = (nextPage == 0)
+
         override fun toString(): String {
-            return "State(isLoading=$isLoading, isShowBottomSheet=$isShowBottomSheet, isRefreshing=$isRefreshing, postOrderType=$postOrderType, paginationStatus=$paginationStatus, posts=$posts, nextPage=$nextPage, hasNextPage=$hasNextPage)"
+            return "State(isLoading=$isLoading, isShowBottomSheet=$isOpenFilterBottomSheet, isRefreshing=$isRefreshing, postOrderType=$postOrderType, paginationStatus=$paginationStatus, posts=$posts, nextPage=$nextPage, hasNextPage=$hasNextPage)"
         }
     }
 
@@ -71,19 +75,19 @@ constructor(
 
         data object RefreshGallery : Intent
 
-        data object LoadNextPage : Intent
-
-        data class OnClickPost(
-            val postId: Long,
-        ) : Intent
-
         data object OnClickFilter : Intent
+
+        data object OnFilterDismissRequest : Intent
 
         data class OnClickSortFilter(
             val postOrderType: PostOrderType,
         ) : Intent
 
-        data object OnBottomModalDismissRequest : Intent
+        data object LoadNextPage : Intent
+
+        data class OnClickPost(
+            val postId: Long,
+        ) : Intent
 
         data object OnClickRegistrationText : Intent
 
@@ -110,15 +114,15 @@ constructor(
 
             is Intent.RefreshGallery -> launch { handleRefreshGallery() }
 
-            is Intent.LoadNextPage -> launch { handleLoadNextPage() }
-
-            is Intent.OnBottomModalDismissRequest -> handleOnBottomModalDismissRequest()
-
             is Intent.OnClickFilter -> handleOnClickFilter()
 
-            is Intent.OnClickPost -> handleOnClickPost(intent)
+            is Intent.OnFilterDismissRequest -> handleOnFilterDismissRequest()
 
             is Intent.OnClickSortFilter -> loadingLaunch { handleOnClickSortFilter(intent) }
+
+            is Intent.LoadNextPage -> launch { handleLoadNextPage() }
+
+            is Intent.OnClickPost -> handleOnClickPost(intent)
 
             is Intent.OnClickRegistrationText -> handleOnClickRegistrationText()
 
@@ -127,24 +131,40 @@ constructor(
     }
 
     private suspend fun handleInit() {
-        fetchPostPage(page = 0)
+        fetchPostPage()
     }
 
     private suspend fun handleRefreshGallery() {
-        fetchPostPage(
-            page = 0,
-            isRefreshing = true,
-        )
+        reduce {
+            copy(
+                isRefreshing = true,
+                nextPage = 0,
+            )
+        }
+
+        fetchPostPage()
+
+        reduce {
+            copy(
+                isRefreshing = false,
+            )
+        }
     }
 
     private suspend fun handleLoadNextPage() {
-        fetchPostPage(page = currentState.nextPage)
-    }
-
-    private fun handleOnBottomModalDismissRequest() {
         reduce {
             copy(
-                isShowBottomSheet = false,
+                nextPage = currentState.nextPage + 1,
+            )
+        }
+
+        fetchPostPage()
+    }
+
+    private fun handleOnFilterDismissRequest() {
+        reduce {
+            copy(
+                isOpenFilterBottomSheet = false,
             )
         }
     }
@@ -152,7 +172,7 @@ constructor(
     private fun handleOnClickFilter() {
         reduce {
             copy(
-                isShowBottomSheet = true,
+                isOpenFilterBottomSheet = true,
             )
         }
     }
@@ -164,22 +184,19 @@ constructor(
     private suspend fun handleOnClickSortFilter(intent: Intent.OnClickSortFilter) {
         reduce {
             copy(
-                isShowBottomSheet = false,
+                isOpenFilterBottomSheet = false,
                 postOrderType = intent.postOrderType,
+                nextPage = 0,
             )
         }
 
-        fetchPostPage(page = 0)
+        fetchPostPage()
     }
 
-    private fun setUpLoading(
-        isInitPage: Boolean,
-        isRefreshing: Boolean,
-    ) {
-        if (isInitPage) {
+    private fun setUpPaginationStatus() {
+        if (currentState.isFirstPage) {
             reduce {
                 copy(
-                    isRefreshing = isRefreshing,
                     paginationStatus = PaginationStatus.LOADING,
                     posts = emptyList(),
                 )
@@ -193,10 +210,7 @@ constructor(
         }
     }
 
-    private suspend fun fetchPostPage(
-        page: Int = 0,
-        isRefreshing: Boolean = false,
-    ) {
+    private suspend fun fetchPostPage() {
         when (currentState.paginationStatus) {
             PaginationStatus.LOADING,
             PaginationStatus.PAGINATING,
@@ -205,25 +219,22 @@ constructor(
             else -> Unit
         }
 
-        val isInitPage = (page == 0)
-
-        setUpLoading(isInitPage = isInitPage, isRefreshing = isRefreshing)
+        setUpPaginationStatus()
 
         val galleryDto = getFilteredGalleryByReportTargetIdsUseCase(
             params = GetFilteredGalleryByReportTargetIdsUseCase.Params(
                 round = null,
                 orderType = currentState.postOrderType.name,
-                page = page,
-                pageSize = PAGE_SIZE,
+                page = currentState.nextPage,
+                pageSize = AppConst.Gallery.PAGE_SIZE,
             ),
         ).getOrNull()
 
         if (galleryDto == null) {
-            analyticsHelper.d { "galleryDto is null" }
+            analyticsHelper.d { "fetchPostPage - galleryDto is null" }
 
             reduce {
                 copy(
-                    isRefreshing = false,
                     paginationStatus = PaginationStatus.ERROR,
                 )
             }
@@ -233,7 +244,6 @@ constructor(
 
         reduce {
             copy(
-                isRefreshing = false,
                 paginationStatus = when {
                     !galleryDto.hasNext -> PaginationStatus.EXHAUST
 
@@ -242,7 +252,6 @@ constructor(
                     else -> PaginationStatus.INACTIVE
                 },
                 posts = posts + galleryDto.posts,
-                nextPage = page + 1,
                 hasNextPage = galleryDto.hasNext,
             )
         }
@@ -262,9 +271,5 @@ constructor(
         }
 
         analyticsHelper.d { "reported post, postId : ${intent.postId}" }
-    }
-
-    companion object {
-        private const val PAGE_SIZE = 20
     }
 }

--- a/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/navigation/FeedNavigation.kt
+++ b/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/navigation/FeedNavigation.kt
@@ -8,12 +8,12 @@ import com.captures2024.soongan.feature.feed.route.FeedRoute
 
 fun NavGraphBuilder.feed(
     navigateToPost: (Long, NavOptions?) -> Unit,
-    getHidedPostId: () -> Long,
+    getHideTargetContentId: () -> Long,
 ) {
     composable<FeedNavigator> {
         FeedRoute(
             navigateToPost = navigateToPost,
-            getReportedPostId = getHidedPostId,
+            getHideTargetContentId = getHideTargetContentId,
         )
     }
 }

--- a/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/route/FeedRoute.kt
+++ b/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/route/FeedRoute.kt
@@ -21,7 +21,7 @@ import com.captures2024.soongan.feature.feed.ui.FeedScreen
 @Composable
 internal fun FeedRoute(
     navigateToPost: (Long, NavOptions?) -> Unit,
-    getReportedPostId: () -> Long,
+    getHideTargetContentId: () -> Long,
     feedViewModel: FeedViewModel = hiltViewModel(),
 ) {
     val uiState by feedViewModel.state.collectAsStateWithLifecycle()
@@ -35,10 +35,10 @@ internal fun FeedRoute(
     }
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-        val postId = getReportedPostId()
+        val targetId = getHideTargetContentId()
 
-        if (postId != -1L) {
-            feedViewModel.intent(Intent.HidePost(postId))
+        if (targetId != -1L) {
+            feedViewModel.intent(Intent.HidePost(targetId))
         }
     }
 

--- a/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/route/FeedRoute.kt
+++ b/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/route/FeedRoute.kt
@@ -16,6 +16,7 @@ import com.captures2024.soongan.core.viewmodel.feed.FeedViewModel
 import com.captures2024.soongan.core.viewmodel.feed.FeedViewModel.Intent
 import com.captures2024.soongan.feature.feed.ui.FeedFilterBottomSheet
 import com.captures2024.soongan.feature.feed.ui.FeedScreen
+import com.captures2024.soongan.feature.feed.ui.FeedTitlePickerBottomSheet
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -44,9 +45,11 @@ internal fun FeedRoute(
 
     FeedScreen(
         uiState = uiState,
-        modifier = Modifier.fillMaxSize().sgBottomBarPadding(),
+        modifier = Modifier
+            .fillMaxSize()
+            .sgBottomBarPadding(),
         onRefresh = { feedViewModel.intent(Intent.RefreshFeed) },
-        onClickRound = { feedViewModel.intent(Intent.OnClickRound(it)) },
+        onClickTitle = { feedViewModel.intent(Intent.OnClickTitle) },
         onClickFilter = { feedViewModel.intent(Intent.OnClickFilter) },
         onClickPost = { feedViewModel.intent(Intent.OnClickPost(it)) },
     )
@@ -56,6 +59,15 @@ internal fun FeedRoute(
             orderType = uiState.postOrderType,
             onDismissRequest = { feedViewModel.intent(Intent.OnFilterDismissRequest) },
             onClickItem = { feedViewModel.intent(Intent.OnClickSortFilter(it)) },
+        )
+    }
+
+    if (uiState.isOpenTitlePickerBottomSheet) {
+        FeedTitlePickerBottomSheet(
+            selectedOption = uiState.currentTitleOption,
+            options = uiState.titleOptions,
+            onSelectTitle = { feedViewModel.intent(Intent.OnSelectTitle(it)) },
+            onDismissRequest = { feedViewModel.intent(Intent.OnTitlePickerDismissRequest) },
         )
     }
 }

--- a/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/route/FeedRoute.kt
+++ b/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/route/FeedRoute.kt
@@ -25,7 +25,6 @@ internal fun FeedRoute(
     feedViewModel: FeedViewModel = hiltViewModel(),
 ) {
     val uiState by feedViewModel.state.collectAsStateWithLifecycle()
-    val round = uiState.currentRound
 
     LaunchedEffect(key1 = Unit) {
         feedViewModel.sideEffect.collect { effect ->
@@ -39,24 +38,24 @@ internal fun FeedRoute(
         val postId = getReportedPostId()
 
         if (postId != -1L) {
-            feedViewModel.intent(Intent.HidePost(round, postId))
+            feedViewModel.intent(Intent.HidePost(postId))
         }
     }
 
     FeedScreen(
         uiState = uiState,
         modifier = Modifier.fillMaxSize().sgBottomBarPadding(),
-        onRefresh = { feedViewModel.intent(Intent.RefreshFeed(round)) },
+        onRefresh = { feedViewModel.intent(Intent.RefreshFeed) },
         onClickRound = { feedViewModel.intent(Intent.OnClickRound(it)) },
         onClickFilter = { feedViewModel.intent(Intent.OnClickFilter) },
         onClickPost = { feedViewModel.intent(Intent.OnClickPost(it)) },
     )
 
-    if (uiState.isShowBottomSheet) {
+    if (uiState.isOpenFilterBottomSheet) {
         FeedFilterBottomSheet(
             orderType = uiState.postOrderType,
             onDismissRequest = { feedViewModel.intent(Intent.OnFilterDismissRequest) },
-            onClickItem = { feedViewModel.intent(Intent.OnClickSortFilter(round, it)) },
+            onClickItem = { feedViewModel.intent(Intent.OnClickSortFilter(it)) },
         )
     }
 }

--- a/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/ui/FeedDropDownTitle.kt
+++ b/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/ui/FeedDropDownTitle.kt
@@ -1,0 +1,101 @@
+package com.captures2024.soongan.feature.feed.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGalleryHeaderTitle
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun FeedDropDownTitle(
+    selectedOption: Pair<Int, String>,
+    options: List<Pair<Int, String>>,
+    modifier: Modifier = Modifier,
+    onClickTitle: (round: Int) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded },
+        modifier = modifier,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(fraction = 0.45f)
+                .menuAnchor(MenuAnchorType.PrimaryEditable),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceAround,
+        ) {
+            SGGalleryHeaderTitle(
+                prefix = "${selectedOption.first}회차",
+                suffix = selectedOption.second,
+            )
+
+            Icon(
+                imageVector = if (expanded) Icons.Filled.KeyboardArrowUp else Icons.Filled.KeyboardArrowDown,
+                contentDescription = null,
+            )
+        }
+
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            for ((round, title) in options) {
+                DropdownMenuItem(
+                    text = {
+                        SGText(
+                            text = "${round}회차 | $title",
+                            style = getSGNonScaleTextStyle(
+                                color = SGColor.primaryA,
+                                fontSize = 20.sp,
+                                fontWeight = FontWeight.Bold,
+                                lineHeight = 20.sp,
+                                fontFamily = SGTypography.nanumSquareNeo,
+                                letterSpacing = (-5).em,
+                            ),
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onClickTitle(round)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun FeedDropDownMenuPreview() {
+    FeedDropDownTitle(
+        selectedOption = 1 to "평화",
+        options = listOf(1 to "평화", 2 to "행복", 3 to "즐거움"),
+        onClickTitle = {}
+    )
+}

--- a/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/ui/FeedGalleryHeader.kt
+++ b/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/ui/FeedGalleryHeader.kt
@@ -1,44 +1,33 @@
 package com.captures2024.soongan.feature.feed.ui
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.em
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.dp
 import com.captures2024.soongan.core.designsystem.icon.MyIconPack
 import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillFillter
+import com.captures2024.soongan.core.designsystem.ui.component.WidthSpacer
 import com.captures2024.soongan.core.designsystem.ui.component.button.SGIconCircleButton
 import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGalleryHeader
 import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGalleryHeaderTitle
-import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
-import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
 import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
-import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
 import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
 import com.captures2024.soongan.core.viewmodel.feed.FeedViewModel
 
 @Composable
 internal fun FeedGalleryHeader(
     selectedOption: Pair<Int, String>,
-    options: List<Pair<Int, String>>,
     modifier: Modifier = Modifier,
-    onClickRound: (Int) -> Unit = {},
+    onClickTitle: () -> Unit = {},
     onClickFilter: () -> Unit = {},
 ) {
     SGGalleryHeader(
@@ -51,73 +40,40 @@ internal fun FeedGalleryHeader(
             )
         },
     ) {
-        FeedDropDownMenu(
-            selectedOption = selectedOption,
-            options = options,
-            onClickRound = onClickRound,
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun FeedDropDownMenu(
-    selectedOption: Pair<Int, String>,
-    options: List<Pair<Int, String>>,
-    modifier: Modifier = Modifier,
-    onClickRound: (Int) -> Unit,
-) {
-    var expanded by remember { mutableStateOf(false) }
-
-    ExposedDropdownMenuBox(
-        expanded = expanded,
-        onExpandedChange = { expanded = !expanded },
-        modifier = modifier,
-    ) {
+        // open scroll picker
         Row(
-            modifier = Modifier
-                .fillMaxWidth(fraction = 0.45f)
-                .menuAnchor(MenuAnchorType.PrimaryEditable),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceAround,
+            modifier = Modifier.clickable(onClick = onClickTitle),
         ) {
             SGGalleryHeaderTitle(
                 prefix = "${selectedOption.first}회차",
                 suffix = selectedOption.second,
             )
-
-            Icon(
-                imageVector = if (expanded) Icons.Filled.KeyboardArrowUp else Icons.Filled.KeyboardArrowDown,
-                contentDescription = null,
-            )
+            WidthSpacer(26.dp)
+            TempArrowDownIcon()
         }
 
-        ExposedDropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false },
-        ) {
-            for ((round, title) in options) {
-                DropdownMenuItem(
-                    text = {
-                        SGText(
-                            text = "${round}회차 | $title",
-                            style = getSGNonScaleTextStyle(
-                                color = SGColor.primaryA,
-                                fontSize = 20.sp,
-                                fontWeight = FontWeight.Bold,
-                                lineHeight = 20.sp,
-                                fontFamily = SGTypography.nanumSquareNeo,
-                                letterSpacing = (-5).em,
-                            ),
-                        )
-                    },
-                    onClick = {
-                        expanded = false
-                        onClickRound(round)
-                    },
-                )
-            }
-        }
+        // drop down menu
+//        FeedDropDownMenu(
+//            selectedOption = selectedOption,
+//            options = options,
+//            onClickRound = onClickRound,
+//        )
+    }
+}
+
+@Composable
+private fun TempArrowDownIcon(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .background(color = SGColor.black40, shape = CircleShape)
+            .size(20.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Default.KeyboardArrowDown,
+            contentDescription = null,
+            tint = SGColor.black100,
+        )
     }
 }
 
@@ -128,7 +84,6 @@ private fun FeedHeaderPreview() {
 
     FeedGalleryHeader(
         selectedOption = state.currentTitleOption,
-        options = state.titleOptions,
-        onClickRound = {},
+        onClickTitle = {},
     )
 }

--- a/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/ui/FeedScreen.kt
+++ b/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/ui/FeedScreen.kt
@@ -24,7 +24,7 @@ internal fun FeedScreen(
     uiState: FeedViewModel.State,
     modifier: Modifier = Modifier,
     onRefresh: () -> Unit,
-    onClickRound: (Int) -> Unit,
+    onClickTitle: () -> Unit,
     onClickFilter: () -> Unit,
     onClickPost: (Long) -> Unit,
 ) {
@@ -47,7 +47,7 @@ internal fun FeedScreen(
     ) {
         FeedScreen(
             uiState = uiState,
-            onClickRound = onClickRound,
+            onClickTitle = onClickTitle,
             onClickFilter = onClickFilter,
             onClickPost = onClickPost,
         )
@@ -58,7 +58,7 @@ internal fun FeedScreen(
 private fun FeedScreen(
     uiState: FeedViewModel.State,
     modifier: Modifier = Modifier,
-    onClickRound: (Int) -> Unit = {},
+    onClickTitle: () -> Unit = {},
     onClickFilter: () -> Unit = {},
     onClickPost: (Long) -> Unit = {},
     /* temp SGGallery params */
@@ -80,8 +80,7 @@ private fun FeedScreen(
             header = {
                 FeedGalleryHeader(
                     selectedOption = uiState.currentTitleOption,
-                    options = uiState.titleOptions,
-                    onClickRound = onClickRound,
+                    onClickTitle = onClickTitle,
                     onClickFilter = onClickFilter,
                 )
             },

--- a/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/ui/FeedScrollTitlePicker.kt
+++ b/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/ui/FeedScrollTitlePicker.kt
@@ -1,0 +1,264 @@
+package com.captures2024.soongan.feature.feed.ui
+
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.WidthSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.model.mock.mockFeedTitleOptions
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+
+@Composable
+internal fun FeedScrollTitlePicker(
+    selectedOption: Pair<Int, String>,
+    options: List<Pair<Int, String>>,
+    modifier: Modifier = Modifier,
+    onChangedOption: (Int) -> Unit,
+    onSelectTitle: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        SGText(
+            text = "회차 선택",
+            modifier = Modifier
+                .align(Alignment.Start)
+                .padding(start = 24.dp),
+            style = getSGNonScaleTextStyle(
+                color = SGColor.Grayscale.black100,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.SemiBold,
+                lineHeight = 20.sp,
+                fontFamily = SGTypography.pretendard,
+            )
+        )
+
+        ScrollPicker(
+            selectedOption = selectedOption,
+            options = options,
+            onChangedOption = onChangedOption,
+        )
+
+        Row(
+            modifier = Modifier.padding(bottom = 136.dp)
+        ) {
+            TempPickerButton(
+                text = "취소",
+                textColor = SGColor.black,
+                containerColor = SGColor.transparent,
+                onClick = onDismissRequest,
+            )
+            WidthSpacer(54.dp)
+            TempPickerButton(
+                text = "확인",
+                textColor = SGColor.white,
+                containerColor = SGColor.black100,
+                onClick = onSelectTitle,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScrollPicker(
+    selectedOption: Pair<Int, String>,
+    options: List<Pair<Int, String>>,
+    modifier: Modifier = Modifier,
+    visibleOptionCount: Int = 7,
+    onChangedOption: (Int) -> Unit,
+) {
+    val median = visibleOptionCount / 2
+    val spaceOptions = List(median) { null }
+    val adjustedOptions = spaceOptions + options + spaceOptions
+    val listCount = adjustedOptions.size
+
+    fun getOptionTitle(index: Int): String = adjustedOptions.getOrNull(index)?.let {
+        "${it.first}회차 | ${it.second}"
+    } ?: ""
+
+    val listState =
+        rememberLazyListState(initialFirstVisibleItemIndex = selectedOption.first - 1)
+    val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
+
+    val currentCenterIndex = remember {
+        derivedStateOf {
+            listState.firstVisibleItemIndex + median
+        }
+    }
+
+    val fadingEdgeGradient = Brush.verticalGradient(
+        0f to Color.Transparent,
+        0.5f to Color.Black,
+        1f to Color.Transparent
+    )
+
+    val boxHeight = 264.dp
+    val itemSize = 28.dp
+
+    val upperDividerYOffset = boxHeight / 2 - itemSize / 2
+    val underDividerYOffset = boxHeight / 2 + itemSize / 2
+
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.firstVisibleItemIndex }
+            .filter { it in options.indices }
+            .distinctUntilChanged()
+            .collect { round -> onChangedOption(round) }
+    }
+
+    HorizontalDivider(
+        modifier = Modifier.offset(y = upperDividerYOffset),
+        thickness = 0.5.dp,
+        color = Color(0xFFCCCCCC)
+    )
+    HorizontalDivider(
+        modifier = Modifier.offset(y = underDividerYOffset),
+        thickness = 0.5.dp,
+        color = Color(0xFFCCCCCC)
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(height = boxHeight)
+            .nestedScroll(object : NestedScrollConnection {
+                override fun onPostScroll(
+                    consumed: Offset,
+                    available: Offset,
+                    source: NestedScrollSource
+                ): Offset = available
+            }),
+    ) {
+        LazyColumn(
+            state = listState,
+            flingBehavior = flingBehavior,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .wrapContentSize()
+                .height(itemSize * visibleOptionCount)
+                .fadingEdge(fadingEdgeGradient)
+        ) {
+            items(
+                count = listCount,
+                key = { it },
+            ) { index ->
+                val distanceFromCenter = kotlin.math.abs(index - currentCenterIndex.value)
+                val fontSize = when (distanceFromCenter) {
+                    0 -> 23.sp
+                    1 -> 18.sp
+                    2 -> 14.sp
+                    else -> 12.sp
+                }
+
+                Box(
+                    modifier = Modifier.height(itemSize),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    SGText(
+                        text = getOptionTitle(index = index),
+                        style = getSGNonScaleTextStyle(
+                            color = SGColor.Grayscale.black100,
+                            fontSize = fontSize,
+                            fontWeight = FontWeight.Normal,
+                            lineHeight = 20.sp,
+                            fontFamily = SGTypography.pretendard,
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun Modifier.fadingEdge(brush: Brush) = this
+    .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+    .drawWithContent {
+        drawContent()
+        drawRect(brush = brush, blendMode = BlendMode.DstIn)
+    }
+
+//private fun Modifier.scalingEdge(scale: Float) = this
+//    .graphicsLayer(scaleX = scale, scaleY = scale)
+
+@Composable
+private fun TempPickerButton(
+    text: String,
+    textColor: Color,
+    containerColor: Color,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = modifier
+            .height(48.dp)
+            .width(120.dp),
+        shape = RoundedCornerShape(20.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = containerColor,
+        )
+    ) {
+        SGText(
+            text = text,
+            style = getSGNonScaleTextStyle(
+                color = textColor,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+                lineHeight = 20.sp,
+                fontFamily = SGTypography.pretendard,
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun FeedScrollTitlePicker_Preview() {
+    FeedScrollTitlePicker(
+        selectedOption = mockFeedTitleOptions.first(),
+        options = mockFeedTitleOptions,
+        onChangedOption = {},
+        onSelectTitle = {},
+        onDismissRequest = {},
+    )
+}

--- a/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/ui/FeedTitlePickerBottomSheet.kt
+++ b/feature/feed/src/main/kotlin/com/captures2024/soongan/feature/feed/ui/FeedTitlePickerBottomSheet.kt
@@ -1,0 +1,73 @@
+package com.captures2024.soongan.feature.feed.ui
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.mock.mockFeedTitleOptions
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun FeedTitlePickerBottomSheet(
+    selectedOption: Pair<Int, String>,
+    options: List<Pair<Int, String>>,
+    modifier: Modifier = Modifier,
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    onSelectTitle: (Int) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    var currentSelectedOption by remember { mutableStateOf(selectedOption) }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        sheetState = sheetState,
+        containerColor = Color.White,
+    ) {
+        // scroll title picker
+        FeedScrollTitlePicker(
+            selectedOption = currentSelectedOption,
+            options = options,
+            onChangedOption = { idx -> currentSelectedOption = options[idx] },
+            onSelectTitle = { onSelectTitle(currentSelectedOption.first) },
+            onDismissRequest = onDismissRequest
+        )
+
+        // drop down title
+//        FeedDropDownTitle(
+//            selectedOption = selectedOption,
+//            options = options,
+//            onClickTitle = onSelectTitle,
+//        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@DevicePreviews
+@Composable
+private fun FeedScrollTitlePickerBottomSheet_Preview() {
+    val sheetState = SheetState(
+        skipPartiallyExpanded = true,
+        initialValue = SheetValue.Expanded,
+        density = LocalDensity.current,
+        skipHiddenState = false,
+    )
+
+    FeedTitlePickerBottomSheet(
+        selectedOption = mockFeedTitleOptions.first(),
+        options = mockFeedTitleOptions,
+        sheetState = sheetState,
+        onSelectTitle = {},
+        onDismissRequest = {},
+    )
+}

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/navigation/HomeNavigation.kt
@@ -3,9 +3,9 @@ package com.captures2024.soongan.feature.home.navigation
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.captures2024.soongan.core.navigator.screen.main.home.EditPostNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.HomeGalleryNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.HomeNavigator
-import com.captures2024.soongan.core.navigator.screen.main.home.EditPostNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.HomePostNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.HomePostPhotoNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.RegistrationPostNavigator
@@ -23,8 +23,8 @@ fun NavGraphBuilder.home(
     navigateToPost: (Long, NavOptions?) -> Unit,
     navigateToEditPost: (Long, String, String) -> Unit,
     navigateToPostPhoto: (String) -> Unit,
-    navigateToBackWithHidePost: (Long) -> Unit,
-    getHidedPostId: () -> Long,
+    navigateToBackWithHideTargetContentId: (Long) -> Unit,
+    getHideTargetContentId: () -> Long,
 ) {
     composable<HomeNavigator> {
         HomeRoute(
@@ -44,7 +44,7 @@ fun NavGraphBuilder.home(
             navigateToBack = navigateToBack,
             navigateToPost = navigateToPost,
             navigateToRegistrationPost = navigateToRegistrationPost,
-            getReportedPostId = getHidedPostId,
+            getHideTargetContentId = getHideTargetContentId,
         )
     }
     composable<HomePostNavigator> {
@@ -52,7 +52,7 @@ fun NavGraphBuilder.home(
             navigateToBack = navigateToBack,
             navigateToEditPost = navigateToEditPost,
             navigateToHomePostPhoto = navigateToPostPhoto,
-            navigateToBackWithHidePost = navigateToBackWithHidePost,
+            navigateToBackWithHideTargetContentId = navigateToBackWithHideTargetContentId,
         )
     }
     composable<EditPostNavigator> {

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomeGalleryRoute.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomeGalleryRoute.kt
@@ -54,10 +54,10 @@ internal fun HomeGalleryRoute(
         onClickRegistrationText = { homeGalleryViewModel.intent(Intent.OnClickRegistrationText) },
     )
 
-    if (uiState.isShowBottomSheet) {
+    if (uiState.isOpenFilterBottomSheet) {
         HomeGalleryBottomSheet(
             uiState = uiState,
-            onDismissRequest = { homeGalleryViewModel.intent(Intent.OnBottomModalDismissRequest) },
+            onDismissRequest = { homeGalleryViewModel.intent(Intent.OnFilterDismissRequest) },
             onClickItem = { homeGalleryViewModel.intent(Intent.OnClickSortFilter(it)) },
         )
     }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomeGalleryRoute.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomeGalleryRoute.kt
@@ -21,7 +21,7 @@ internal fun HomeGalleryRoute(
     navigateToBack: () -> Unit,
     navigateToPost: (Long, NavOptions?) -> Unit,
     navigateToRegistrationPost: () -> Unit,
-    getReportedPostId: () -> Long,
+    getHideTargetContentId: () -> Long,
     homeGalleryViewModel: HomeGalleryViewModel = hiltViewModel(),
 ) {
     val uiState by homeGalleryViewModel.state.collectAsStateWithLifecycle()
@@ -37,10 +37,10 @@ internal fun HomeGalleryRoute(
     }
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-        val postId = getReportedPostId()
+        val targetId = getHideTargetContentId()
 
-        if (postId != -1L) {
-            homeGalleryViewModel.intent(Intent.HidePost(postId))
+        if (targetId != -1L) {
+            homeGalleryViewModel.intent(Intent.HidePost(targetId))
         }
     }
 

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomePostRoute.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/route/HomePostRoute.kt
@@ -27,7 +27,7 @@ internal fun HomePostRoute(
     navigateToBack: () -> Unit,
     navigateToEditPost: (Long, String, String) -> Unit,
     navigateToHomePostPhoto: (String) -> Unit,
-    navigateToBackWithHidePost: (Long) -> Unit,
+    navigateToBackWithHideTargetContentId: (Long) -> Unit,
     homePostViewModel: HomePostViewModel = hiltViewModel(),
 ) {
     val uiState by homePostViewModel.state.collectAsStateWithLifecycle()
@@ -50,7 +50,7 @@ internal fun HomePostRoute(
 
                 is Effect.NavigateToHomePostPhoto -> navigateToHomePostPhoto(effect.url)
 
-                is Effect.NavigateToBackWithHidePost -> navigateToBackWithHidePost(effect.postId)
+                is Effect.NavigateToBackWithHidePost -> navigateToBackWithHideTargetContentId(effect.postId)
             }
         }
     }

--- a/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/gallery/HomeGalleryScreen.kt
+++ b/feature/home/src/main/kotlin/com/captures2024/soongan/feature/home/ui/gallery/HomeGalleryScreen.kt
@@ -24,10 +24,10 @@ import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGallery
 import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
 import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
 import com.captures2024.soongan.core.model.dto.GalleryPostDto
-import com.captures2024.soongan.feature.home.R
 import com.captures2024.soongan.core.viewmodel.home.HomeGalleryViewModel
-import com.captures2024.soongan.feature.home.ui.gallery.component.HomeGalleryHeader
 import com.captures2024.soongan.core.viewmodel.model.PaginationStatus
+import com.captures2024.soongan.feature.home.R
+import com.captures2024.soongan.feature.home.ui.gallery.component.HomeGalleryHeader
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -61,7 +61,7 @@ internal fun HomeGalleryScreen(
         HomeGalleryScreen(
             posts = uiState.posts,
             paginationStatus = uiState.paginationStatus,
-            isInitPage = (uiState.nextPage == 0),
+            isInitPage = uiState.isFirstPage,
             onBackPressed = onBackPressed,
             onLoadNextPage = onLoadNextPage,
             onClickPost = onClickPost,

--- a/feature/main/src/main/kotlin/com/captures2024/soongan/feature/main/navigation/MainRouteNavHost.kt
+++ b/feature/main/src/main/kotlin/com/captures2024/soongan/feature/main/navigation/MainRouteNavHost.kt
@@ -20,9 +20,9 @@ import com.captures2024.soongan.core.navigator.screen.main.home.navigateToRegist
 import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToEditProfile
 import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToFAQ
 import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToNotification
-import com.captures2024.soongan.core.navigator.screen.main.util.getHidedPostId
+import com.captures2024.soongan.core.navigator.screen.main.util.getHideTargetContentId
 import com.captures2024.soongan.core.navigator.screen.main.util.navigateFromNotification
-import com.captures2024.soongan.core.navigator.screen.main.util.navigateToBackWithHidePost
+import com.captures2024.soongan.core.navigator.screen.main.util.navigateToBackWithHideTargetContentId
 import com.captures2024.soongan.core.navigator.screen.main.welcome.WelcomeNavigator
 import com.captures2024.soongan.feature.awards.navigation.awards
 import com.captures2024.soongan.feature.feed.navigation.feed
@@ -70,12 +70,12 @@ internal fun MainRouteNavHost(
             navigateToPost = navController::navigateToHomePost,
             navigateToEditPost = navController::navigateToEditPost,
             navigateToPostPhoto = navController::navigateToHomePostPhoto,
-            navigateToBackWithHidePost = navController::navigateToBackWithHidePost,
-            getHidedPostId = navController::getHidedPostId,
+            navigateToBackWithHideTargetContentId = navController::navigateToBackWithHideTargetContentId,
+            getHideTargetContentId = navController::getHideTargetContentId,
         )
         feed(
             navigateToPost = navController::navigateToHomePost,
-            getHidedPostId = navController::getHidedPostId,
+            getHideTargetContentId = navController::getHideTargetContentId,
         )
         awards()
         profile(

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedFilterBottomSheetComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedFilterBottomSheetComponent.kt
@@ -1,0 +1,155 @@
+package com.captures2024.soongan.presentation.feature.main.feed.component.feed
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconFilterLike
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.feed.utils.extensions.getIcon
+import com.captures2024.soongan.presentation.feature.main.feed.utils.extensions.getStringResId
+import com.captures2024.soongan.presentation.viewmodel.model.PostOrderType
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun FeedFilterBottomSheetComponent(
+    orderType: PostOrderType,
+    modifier: Modifier = Modifier,
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    onDismissRequest: () -> Unit,
+    onClickItem: (PostOrderType) -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        sheetState = sheetState,
+        containerColor = Color.White,
+    ) {
+        Column(
+            modifier = Modifier.padding(
+                horizontal = 20.dp,
+                vertical = 20.dp,
+            ),
+        ) {
+            PostOrderType.entries.forEachIndexed { idx, postOrderType ->
+                if (idx != 0) HorizontalDivider(color = SGColor.primaryA.copy(alpha = 0.3f))
+
+                FeedGalleryFilterItem(
+                    text = stringResource(id = postOrderType.getStringResId()),
+                    icon = postOrderType.getIcon(),
+                    selected = (orderType == postOrderType),
+                    onClickItem = { onClickItem(postOrderType) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FeedGalleryFilterItem(
+    text: String,
+    icon: ImageVector,
+    selected: Boolean,
+    modifier: Modifier = Modifier,
+    onClickItem: () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .clickable { onClickItem() },
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 56.dp)
+                .padding(horizontal = 20.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            SGText(
+                text = text,
+                style = getSGNonScaleTextStyle(
+                    color = when (selected) {
+                        true -> SGColor.primaryA
+
+                        false -> SGColor.primaryA.copy(alpha = 0.3f)
+                    },
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 24.sp,
+                    fontFamily = SGTypography.nanumSquareNeo,
+                ),
+            )
+
+            Icon(
+                modifier = Modifier.size(24.dp),
+                imageVector = icon,
+                contentDescription = text,
+                tint = when (selected) {
+                    true -> SGColor.primaryA
+
+                    false -> SGColor.primaryA.copy(alpha = 0.3f)
+                },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@DevicePreviews
+@Composable
+private fun FeedFilterBottomSheet_Preview() {
+    val sheetState = SheetState(
+        skipPartiallyExpanded = true,
+        initialValue = SheetValue.Expanded,
+        density = LocalDensity.current,
+        skipHiddenState = false,
+    )
+
+    FeedFilterBottomSheetComponent(
+        orderType = PostOrderType.MOST_LIKED,
+        sheetState = sheetState,
+        onClickItem = {},
+        onDismissRequest = {},
+    )
+}
+
+@DevicePreviews
+@Composable
+private fun FeedGalleryFilterItem_Preview() {
+    FeedGalleryFilterItem(
+        text = "좋아요 순",
+        icon = MyIconPack.IconFilterLike,
+        selected = true,
+        onClickItem = {},
+    )
+}

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedGalleryHeaderComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedGalleryHeaderComponent.kt
@@ -1,0 +1,87 @@
+package com.captures2024.soongan.presentation.feature.main.feed.component.feed
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconNonFillFillter
+import com.captures2024.soongan.core.designsystem.ui.component.WidthSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.button.SGIconCircleButton
+import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGalleryHeader
+import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGalleryHeaderTitle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.feed.R
+import com.captures2024.soongan.presentation.viewmodel.main.feed.TitleOption
+
+@Composable
+internal fun FeedGalleryHeaderComponent(
+    selectedOption: TitleOption,
+    modifier: Modifier = Modifier,
+    onClickTitle: () -> Unit,
+    onClickFilter: () -> Unit,
+) {
+    val (round, subject) = selectedOption
+
+    SGGalleryHeader(
+        modifier = modifier,
+        trailingIcon = {
+            SGIconCircleButton(
+                imageVector = MyIconPack.IconNonFillFillter,
+                contentDescription = "filter",
+                onClick = onClickFilter,
+            )
+        },
+    ) {
+        Row(
+            modifier = Modifier.clickable(
+                onClick = onClickTitle,
+                enabled = subject.isNotBlank(),
+            ),
+        ) {
+            SGGalleryHeaderTitle(
+                prefix = stringResource(R.string.feed_gallery_header_title_round_unit, round),
+                suffix = subject,
+            )
+            WidthSpacer(26.dp)
+            TempArrowDownIcon()
+        }
+    }
+}
+
+@Composable
+private fun TempArrowDownIcon(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .background(color = SGColor.black40, shape = CircleShape)
+            .size(20.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Default.KeyboardArrowDown,
+            contentDescription = null,
+            tint = SGColor.black100,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun FeedGalleryHeaderComponent_Preview() {
+    FeedGalleryHeaderComponent(
+        selectedOption = (1 to "test"),
+        onClickTitle = {},
+        onClickFilter = {},
+    )
+}

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedGalleryHeaderComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedGalleryHeaderComponent.kt
@@ -23,7 +23,7 @@ import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGallery
 import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
 import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
 import com.captures2024.soongan.presentation.feature.main.feed.R
-import com.captures2024.soongan.presentation.viewmodel.model.feed.TitleOption
+import com.captures2024.soongan.presentation.viewmodel.model.TitleOption
 
 @Composable
 internal fun FeedGalleryHeaderComponent(

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedGalleryHeaderComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedGalleryHeaderComponent.kt
@@ -23,7 +23,7 @@ import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGallery
 import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
 import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
 import com.captures2024.soongan.presentation.feature.main.feed.R
-import com.captures2024.soongan.presentation.viewmodel.main.feed.TitleOption
+import com.captures2024.soongan.presentation.viewmodel.model.feed.TitleOption
 
 @Composable
 internal fun FeedGalleryHeaderComponent(
@@ -32,8 +32,6 @@ internal fun FeedGalleryHeaderComponent(
     onClickTitle: () -> Unit,
     onClickFilter: () -> Unit,
 ) {
-    val (round, subject) = selectedOption
-
     SGGalleryHeader(
         modifier = modifier,
         trailingIcon = {
@@ -47,12 +45,12 @@ internal fun FeedGalleryHeaderComponent(
         Row(
             modifier = Modifier.clickable(
                 onClick = onClickTitle,
-                enabled = subject.isNotBlank(),
+                enabled = selectedOption.hasValidSubject,
             ),
         ) {
             SGGalleryHeaderTitle(
-                prefix = stringResource(R.string.feed_gallery_header_title_round_unit, round),
-                suffix = subject,
+                prefix = stringResource(R.string.feed_gallery_header_title_round_unit, selectedOption.round),
+                suffix = selectedOption.subject,
             )
             WidthSpacer(26.dp)
             TempArrowDownIcon()
@@ -80,7 +78,7 @@ private fun TempArrowDownIcon(modifier: Modifier = Modifier) {
 @Composable
 private fun FeedGalleryHeaderComponent_Preview() {
     FeedGalleryHeaderComponent(
-        selectedOption = (1 to "test"),
+        selectedOption = TitleOption(round = 1, subject = "주제"),
         onClickTitle = {},
         onClickFilter = {},
     )

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedScrollPickerComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedScrollPickerComponent.kt
@@ -49,7 +49,7 @@ import com.captures2024.soongan.core.designsystem.ui.theme.innerShadow
 import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
 import com.captures2024.soongan.core.model.AppConst
 import com.captures2024.soongan.presentation.feature.main.feed.R
-import com.captures2024.soongan.presentation.viewmodel.model.feed.TitleOption
+import com.captures2024.soongan.presentation.viewmodel.model.TitleOption
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedScrollPickerComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedScrollPickerComponent.kt
@@ -1,0 +1,295 @@
+package com.captures2024.soongan.presentation.feature.main.feed.component.feed
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.captures2024.soongan.core.designsystem.ui.component.HeightSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.WidthSpacer
+import com.captures2024.soongan.core.designsystem.ui.component.text.SGText
+import com.captures2024.soongan.core.designsystem.ui.component.text.getSGNonScaleTextStyle
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
+import com.captures2024.soongan.core.designsystem.ui.theme.innerShadow
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.AppConst
+import com.captures2024.soongan.core.model.mock.mockFeedTitleOptions
+import com.captures2024.soongan.presentation.feature.main.feed.R
+import com.captures2024.soongan.presentation.viewmodel.main.feed.TitleOption
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+
+@Composable
+internal fun FeedScrollTitlePickerComponent(
+    selectedOption: TitleOption,
+    options: List<TitleOption>,
+    modifier: Modifier = Modifier,
+    onChangedOption: (Int) -> Unit,
+    onSelectTitle: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        SGText(
+            text = stringResource(R.string.feed_scroll_title_picker_header_text),
+            modifier = Modifier
+                .align(Alignment.Start)
+                .padding(start = 24.dp),
+            style = getSGNonScaleTextStyle(
+                color = SGColor.Grayscale.black100,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.SemiBold,
+                lineHeight = 20.sp,
+                fontFamily = SGTypography.pretendard,
+            )
+        )
+
+        ScrollPicker(
+            selectedOption = selectedOption,
+            options = options,
+            modifier = Modifier.padding(horizontal = 10.dp),
+            onChangedOption = onChangedOption,
+        )
+
+        HeightSpacer(32.dp)
+
+        Row(
+            modifier = Modifier.padding(bottom = 60.dp)
+        ) {
+            TempPickerButton(
+                text = stringResource(R.string.feed_scroll_title_picker_dismiss_text),
+                textColor = SGColor.black,
+                containerColor = SGColor.transparent,
+                onClick = onDismissRequest,
+            )
+            WidthSpacer(54.dp)
+            TempPickerButton(
+                text = stringResource(R.string.feed_scroll_title_picker_confirm_text),
+                textColor = SGColor.white,
+                containerColor = SGColor.black100,
+                onClick = onSelectTitle,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScrollPicker(
+    selectedOption: TitleOption,
+    options: List<TitleOption>,
+    modifier: Modifier = Modifier,
+    visibleOptionCount: Int = 5,
+    onChangedOption: (Int) -> Unit,
+) {
+    val median = visibleOptionCount / 2
+    val spaceOptions = List(median) { null }
+    val adjustedOptions = spaceOptions + options + spaceOptions
+    val listCount = adjustedOptions.size
+
+    @Composable
+    fun getTitleText(index: Int): String =
+        adjustedOptions.getOrNull(index)?.let { (round, subject) ->
+            "$round" + stringResource(R.string.scroll_picker_title_infix_text) + subject
+        } ?: AppConst.EMPTY_STRING
+
+    val listState =
+        rememberLazyListState(initialFirstVisibleItemIndex = selectedOption.first - 1)
+    val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
+
+    val currentCenterIndex = remember {
+        derivedStateOf {
+            listState.firstVisibleItemIndex + median
+        }
+    }
+
+    val fadingEdgeGradient = Brush.verticalGradient(
+        0f to Color.Transparent,
+        0.5f to Color.Black,
+        1f to Color.Transparent
+    )
+
+    val boxHeight = 264.dp
+    val itemSize = 28.dp
+
+    val upperDividerYOffset = boxHeight / 2 - itemSize / 2
+    val underDividerYOffset = boxHeight / 2 + itemSize / 2
+
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.firstVisibleItemIndex }
+            .filter { it in options.indices }
+            .distinctUntilChanged()
+            .collect { round -> onChangedOption(round) }
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(height = boxHeight)
+            .innerShadow(
+                shape = RectangleShape,
+                blur = 0.dp,
+                offsetX = 0.dp,
+                offsetY = (-0.5).dp,
+            )
+            .nestedScroll(object : NestedScrollConnection {
+                override fun onPostScroll(
+                    consumed: Offset,
+                    available: Offset,
+                    source: NestedScrollSource,
+                ): Offset = available
+            }),
+    ) {
+        HorizontalDivider(
+            modifier = Modifier.offset(y = upperDividerYOffset),
+            thickness = 0.5.dp,
+            color = Color(0xFFCCCCCC)
+        )
+
+        HorizontalDivider(
+            modifier = Modifier.offset(y = underDividerYOffset),
+            thickness = 0.5.dp,
+            color = Color(0xFFCCCCCC)
+        )
+
+        LazyColumn(
+            state = listState,
+            flingBehavior = flingBehavior,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .wrapContentSize()
+                .height(itemSize * visibleOptionCount)
+                .fadingEdge(fadingEdgeGradient)
+        ) {
+            items(
+                count = listCount,
+                key = { it },
+            ) { index ->
+                val distanceFromCenter = kotlin.math.abs(index - currentCenterIndex.value)
+                val fontSize = when (distanceFromCenter) {
+                    0 -> 23.sp
+                    1 -> 18.sp
+                    2 -> 14.sp
+                    else -> 12.sp
+                }
+
+                Box(
+                    modifier = Modifier.height(itemSize),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    SGText(
+                        text = getTitleText(index = index),
+                        style = getSGNonScaleTextStyle(
+                            color = SGColor.Grayscale.black100,
+                            fontSize = fontSize,
+                            fontWeight = FontWeight.Normal,
+                            lineHeight = 20.sp,
+                            fontFamily = SGTypography.pretendard,
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun Modifier.fadingEdge(brush: Brush) = this
+    .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+    .drawWithContent {
+        drawContent()
+        drawRect(brush = brush, blendMode = BlendMode.DstIn)
+    }
+
+@Composable
+private fun TempPickerButton(
+    text: String,
+    textColor: Color,
+    containerColor: Color,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(20.dp)
+
+    TextButton(
+        onClick = onClick,
+        modifier = modifier
+            .height(48.dp)
+            .width(120.dp)
+            .border(width = 1.dp, color = SGColor.black100, shape = shape),
+        shape = shape,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = containerColor,
+        )
+    ) {
+        SGText(
+            text = text,
+            style = getSGNonScaleTextStyle(
+                color = textColor,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+                lineHeight = 20.sp,
+                fontFamily = SGTypography.pretendard,
+            )
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun FeedScrollTitlePicker_Preview() {
+    FeedScrollTitlePickerComponent(
+        selectedOption = mockFeedTitleOptions.first(),
+        options = mockFeedTitleOptions,
+        onChangedOption = {},
+        onSelectTitle = {},
+        onDismissRequest = {},
+    )
+}
+
+@DevicePreviews
+@Composable
+private fun ScrollPicker_Preview() {
+    ScrollPicker(
+        selectedOption = mockFeedTitleOptions.first(),
+        options = mockFeedTitleOptions,
+        visibleOptionCount = 5,
+        onChangedOption = {},
+    )
+}

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedScrollPickerComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedScrollPickerComponent.kt
@@ -48,9 +48,8 @@ import com.captures2024.soongan.core.designsystem.ui.theme.SGTypography
 import com.captures2024.soongan.core.designsystem.ui.theme.innerShadow
 import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
 import com.captures2024.soongan.core.model.AppConst
-import com.captures2024.soongan.core.model.mock.mockFeedTitleOptions
 import com.captures2024.soongan.presentation.feature.main.feed.R
-import com.captures2024.soongan.presentation.viewmodel.main.feed.TitleOption
+import com.captures2024.soongan.presentation.viewmodel.model.feed.TitleOption
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 
@@ -60,7 +59,7 @@ internal fun FeedScrollTitlePickerComponent(
     options: List<TitleOption>,
     modifier: Modifier = Modifier,
     onChangedOption: (Int) -> Unit,
-    onSelectTitle: () -> Unit,
+    onSelectOption: () -> Unit,
     onDismissRequest: () -> Unit,
 ) {
     Column(
@@ -97,14 +96,16 @@ internal fun FeedScrollTitlePickerComponent(
                 text = stringResource(R.string.feed_scroll_title_picker_dismiss_text),
                 textColor = SGColor.black,
                 containerColor = SGColor.transparent,
+                borderColor = SGColor.black,
                 onClick = onDismissRequest,
             )
             WidthSpacer(54.dp)
             TempPickerButton(
                 text = stringResource(R.string.feed_scroll_title_picker_confirm_text),
-                textColor = SGColor.white,
-                containerColor = SGColor.black100,
-                onClick = onSelectTitle,
+                textColor = SGColor.Grayscale.white,
+                containerColor = SGColor.Main.primary,
+                borderColor = SGColor.Main.primary,
+                onClick = onSelectOption,
             )
         }
     }
@@ -130,7 +131,7 @@ private fun ScrollPicker(
         } ?: AppConst.EMPTY_STRING
 
     val listState =
-        rememberLazyListState(initialFirstVisibleItemIndex = selectedOption.first - 1)
+        rememberLazyListState(initialFirstVisibleItemIndex = selectedOption.round - 1)
     val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
 
     val currentCenterIndex = remember {
@@ -242,6 +243,7 @@ private fun TempPickerButton(
     text: String,
     textColor: Color,
     containerColor: Color,
+    borderColor: Color,
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
 ) {
@@ -252,7 +254,7 @@ private fun TempPickerButton(
         modifier = modifier
             .height(48.dp)
             .width(120.dp)
-            .border(width = 1.dp, color = SGColor.black100, shape = shape),
+            .border(width = 1.dp, color = borderColor, shape = shape),
         shape = shape,
         colors = ButtonDefaults.buttonColors(
             containerColor = containerColor,
@@ -274,11 +276,16 @@ private fun TempPickerButton(
 @DevicePreviews
 @Composable
 private fun FeedScrollTitlePicker_Preview() {
+    val options = listOf(
+        TitleOption(round = 1, subject = "주제"),
+        TitleOption(round = 2, subject = "주제"),
+        TitleOption(round = 3, subject = "주제"),
+    )
     FeedScrollTitlePickerComponent(
-        selectedOption = mockFeedTitleOptions.first(),
-        options = mockFeedTitleOptions,
+        selectedOption = options[0],
+        options = options,
         onChangedOption = {},
-        onSelectTitle = {},
+        onSelectOption = {},
         onDismissRequest = {},
     )
 }
@@ -286,9 +293,14 @@ private fun FeedScrollTitlePicker_Preview() {
 @DevicePreviews
 @Composable
 private fun ScrollPicker_Preview() {
+    val options = listOf(
+        TitleOption(round = 1, subject = "주제"),
+        TitleOption(round = 2, subject = "주제"),
+        TitleOption(round = 3, subject = "주제"),
+    )
     ScrollPicker(
-        selectedOption = mockFeedTitleOptions.first(),
-        options = mockFeedTitleOptions,
+        selectedOption = options[0],
+        options = options,
         visibleOptionCount = 5,
         onChangedOption = {},
     )

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedTitlePickerBottomSheetComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedTitlePickerBottomSheetComponent.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
-import com.captures2024.soongan.presentation.viewmodel.model.feed.TitleOption
+import com.captures2024.soongan.presentation.viewmodel.model.TitleOption
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedTitlePickerBottomSheetComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedTitlePickerBottomSheetComponent.kt
@@ -14,8 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
-import com.captures2024.soongan.core.model.mock.mockFeedTitleOptions
-import com.captures2024.soongan.presentation.viewmodel.main.feed.TitleOption
+import com.captures2024.soongan.presentation.viewmodel.model.feed.TitleOption
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -24,11 +23,10 @@ internal fun FeedTitlePickerBottomSheetComponent(
     options: List<TitleOption>,
     modifier: Modifier = Modifier,
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-    onSelectTitle: (round: Int) -> Unit,
+    onSelectOption: (round: Int) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
     var currentSelectedOption by remember { mutableStateOf(selectedOption) }
-    val round = currentSelectedOption.first
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
@@ -40,7 +38,7 @@ internal fun FeedTitlePickerBottomSheetComponent(
             selectedOption = currentSelectedOption,
             options = options,
             onChangedOption = { idx -> currentSelectedOption = options[idx] },
-            onSelectTitle = { onSelectTitle(round) },
+            onSelectOption = { onSelectOption(currentSelectedOption.round) },
             onDismissRequest = onDismissRequest
         )
     }
@@ -50,6 +48,11 @@ internal fun FeedTitlePickerBottomSheetComponent(
 @DevicePreviews
 @Composable
 private fun FeedScrollTitlePickerBottomSheet_Preview() {
+    val options = listOf(
+        TitleOption(round = 1, subject = "주제"),
+        TitleOption(round = 2, subject = "주제"),
+        TitleOption(round = 3, subject = "주제"),
+    )
     val sheetState = SheetState(
         skipPartiallyExpanded = true,
         initialValue = SheetValue.Expanded,
@@ -58,10 +61,10 @@ private fun FeedScrollTitlePickerBottomSheet_Preview() {
     )
 
     FeedTitlePickerBottomSheetComponent(
-        selectedOption = mockFeedTitleOptions.first(),
-        options = mockFeedTitleOptions,
+        selectedOption = options[0],
+        options = options,
         sheetState = sheetState,
-        onSelectTitle = {},
+        onSelectOption = {},
         onDismissRequest = {},
     )
 }

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedTitlePickerBottomSheetComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedTitlePickerBottomSheetComponent.kt
@@ -1,0 +1,67 @@
+package com.captures2024.soongan.presentation.feature.main.feed.component.feed
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.core.model.mock.mockFeedTitleOptions
+import com.captures2024.soongan.presentation.viewmodel.main.feed.TitleOption
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun FeedTitlePickerBottomSheetComponent(
+    selectedOption: TitleOption,
+    options: List<TitleOption>,
+    modifier: Modifier = Modifier,
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    onSelectTitle: (round: Int) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    var currentSelectedOption by remember { mutableStateOf(selectedOption) }
+    val round = currentSelectedOption.first
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        sheetState = sheetState,
+        containerColor = Color.White,
+    ) {
+        FeedScrollTitlePickerComponent(
+            selectedOption = currentSelectedOption,
+            options = options,
+            onChangedOption = { idx -> currentSelectedOption = options[idx] },
+            onSelectTitle = { onSelectTitle(round) },
+            onDismissRequest = onDismissRequest
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@DevicePreviews
+@Composable
+private fun FeedScrollTitlePickerBottomSheet_Preview() {
+    val sheetState = SheetState(
+        skipPartiallyExpanded = true,
+        initialValue = SheetValue.Expanded,
+        density = LocalDensity.current,
+        skipHiddenState = false,
+    )
+
+    FeedTitlePickerBottomSheetComponent(
+        selectedOption = mockFeedTitleOptions.first(),
+        options = mockFeedTitleOptions,
+        sheetState = sheetState,
+        onSelectTitle = {},
+        onDismissRequest = {},
+    )
+}

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/screen/FeedScreen.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/screen/FeedScreen.kt
@@ -31,6 +31,7 @@ import com.captures2024.soongan.presentation.feature.main.feed.component.feed.Fe
 import com.captures2024.soongan.presentation.viewmodel.main.feed.FeedViewModel
 import com.captures2024.soongan.presentation.viewmodel.model.PaginationStatus
 import com.captures2024.soongan.presentation.viewmodel.model.PostOrderType
+import com.captures2024.soongan.presentation.viewmodel.model.feed.TitleOption
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -40,7 +41,7 @@ internal fun FeedScreen(
     onRefresh: () -> Unit,
     onLoadNextPage: () -> Unit,
     onClickTitle: () -> Unit,
-    onSelectTitle: (round: Int) -> Unit,
+    onSelectTitleOption: (round: Int) -> Unit,
     onClickFilter: () -> Unit,
     onClickFilterItem: (PostOrderType) -> Unit,
     onClickPost: (Long) -> Unit,
@@ -138,7 +139,7 @@ internal fun FeedScreen(
         FeedTitlePickerBottomSheetComponent(
             selectedOption = feedState.currentTitleOption,
             options = feedState.titleOptions,
-            onSelectTitle = onSelectTitle,
+            onSelectOption = onSelectTitleOption,
             onDismissRequest = onTitlePickerDismissRequest,
         )
     }
@@ -160,7 +161,7 @@ private fun FeedScreenPreview() {
             isRefreshing = false,
             postOrderType = PostOrderType.MOST_LIKED,
             paginationStatus = PaginationStatus.DEFAULT,
-            titleOptions = listOf(1 to "test"),
+            titleOptions = listOf(TitleOption()),
             currentRound = 1,
             loadPage = 0,
             hasNextPage = true,
@@ -175,7 +176,7 @@ private fun FeedScreenPreview() {
         onRefresh = {},
         onLoadNextPage = {},
         onClickTitle = {},
-        onSelectTitle = {},
+        onSelectTitleOption = {},
         onClickFilter = {},
         onClickFilterItem = {},
         onClickPost = {},

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/screen/FeedScreen.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/screen/FeedScreen.kt
@@ -1,0 +1,185 @@
+package com.captures2024.soongan.presentation.feature.main.feed.component.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
+import androidx.compose.foundation.lazy.staggeredgrid.items
+import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGallery
+import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGalleryEmptyItem
+import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGalleryErrorItem
+import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGalleryImageItem
+import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGalleryPaginatingItem
+import com.captures2024.soongan.core.designsystem.ui.component.gallery.SGGallerySkeletonItem
+import com.captures2024.soongan.core.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.core.designsystem.ui.util.DevicePreviews
+import com.captures2024.soongan.presentation.feature.main.feed.R
+import com.captures2024.soongan.presentation.feature.main.feed.component.feed.FeedFilterBottomSheetComponent
+import com.captures2024.soongan.presentation.feature.main.feed.component.feed.FeedGalleryHeaderComponent
+import com.captures2024.soongan.presentation.feature.main.feed.component.feed.FeedTitlePickerBottomSheetComponent
+import com.captures2024.soongan.presentation.viewmodel.main.feed.FeedViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.PaginationStatus
+import com.captures2024.soongan.presentation.viewmodel.model.PostOrderType
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun FeedScreen(
+    uiState: FeedViewModel.State,
+    modifier: Modifier = Modifier,
+    onRefresh: () -> Unit,
+    onLoadNextPage: () -> Unit,
+    onClickTitle: () -> Unit,
+    onSelectTitle: (round: Int) -> Unit,
+    onClickFilter: () -> Unit,
+    onClickFilterItem: (PostOrderType) -> Unit,
+    onClickPost: (Long) -> Unit,
+    onTitlePickerDismissRequest: () -> Unit,
+    onFilterDismissRequest: () -> Unit,
+) {
+    val feedState = uiState.feedState
+
+    val pullToRefreshState = rememberPullToRefreshState()
+    val lazyStaggeredGridState = rememberLazyStaggeredGridState()
+    val rememberSkeletonItemHeight = remember { List(16) { (150..300).random() } }
+
+    PullToRefreshBox(
+        isRefreshing = feedState.isRefreshing,
+        onRefresh = onRefresh,
+        modifier = modifier,
+        state = pullToRefreshState,
+        indicator = {
+            Indicator(
+                modifier = Modifier.align(Alignment.TopCenter),
+                isRefreshing = feedState.isRefreshing,
+                containerColor = SGColor.white,
+                color = SGColor.black,
+                state = pullToRefreshState,
+            )
+        },
+    ) {
+        Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            SGGallery(
+                lazyStaggeredGridState = lazyStaggeredGridState,
+                isInitPage = feedState.isInitPage,
+                hasNextPage = feedState.hasNextPage,
+                onLoadNextPage = onLoadNextPage,
+                header = @Composable {
+                    FeedGalleryHeaderComponent(
+                        selectedOption = feedState.currentTitleOption,
+                        onClickTitle = onClickTitle,
+                        onClickFilter = onClickFilter,
+                    )
+                },
+            ) {
+                when {
+                    feedState.currentRoundGallery.isEmpty() -> when (feedState.paginationStatus) {
+                        PaginationStatus.DEFAULT,
+                        PaginationStatus.REFRESH_LOAD,
+                        PaginationStatus.PAGING_LOAD,
+                        -> items(
+                            items = rememberSkeletonItemHeight,
+                        ) { height ->
+                            SGGallerySkeletonItem(height = height)
+                        }
+
+                        PaginationStatus.SUCCESS -> {
+                            item(span = StaggeredGridItemSpan.FullLine) {
+                                SGGalleryEmptyItem(
+                                    emptyText = stringResource(R.string.feed_gallery_post_empty_content),
+                                    modifier = modifier.padding(top = 100.dp),
+                                )
+                            }
+                        }
+
+                        PaginationStatus.FAILED -> {
+                            item(span = StaggeredGridItemSpan.FullLine) {
+                                SGGalleryErrorItem(
+                                    errorText = stringResource(R.string.feed_gallery_post_error_content),
+                                )
+                            }
+                        }
+                    }
+
+                    else -> items(
+                        items = feedState.currentRoundGallery,
+                        key = { it.postId },
+                    ) {
+                        SGGalleryImageItem(
+                            imageUrl = it.imageUrl,
+                            onClick = { onClickPost(it.postId) },
+                        )
+                    }
+                }
+
+                if (feedState.paginationStatus == PaginationStatus.PAGING_LOAD) {
+                    item(span = StaggeredGridItemSpan.FullLine) {
+                        SGGalleryPaginatingItem()
+                    }
+                }
+            }
+        }
+    }
+
+    if (uiState.isOpenTitlePickerBottomSheet) {
+        FeedTitlePickerBottomSheetComponent(
+            selectedOption = feedState.currentTitleOption,
+            options = feedState.titleOptions,
+            onSelectTitle = onSelectTitle,
+            onDismissRequest = onTitlePickerDismissRequest,
+        )
+    }
+
+    if (uiState.isOpenFilterBottomSheet) {
+        FeedFilterBottomSheetComponent(
+            orderType = feedState.postOrderType,
+            onClickItem = onClickFilterItem,
+            onDismissRequest = onFilterDismissRequest,
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun FeedScreenPreview() {
+    val uiState = FeedViewModel.State(
+        feedState = FeedViewModel.State.FeedState(
+            isRefreshing = false,
+            postOrderType = PostOrderType.MOST_LIKED,
+            paginationStatus = PaginationStatus.DEFAULT,
+            titleOptions = listOf(1 to "test"),
+            currentRound = 1,
+            loadPage = 0,
+            hasNextPage = true,
+            feed = emptyMap(),
+        ),
+        isOpenTitlePickerBottomSheet = false,
+        isOpenFilterBottomSheet = false,
+    )
+
+    FeedScreen(
+        uiState = uiState,
+        onRefresh = {},
+        onLoadNextPage = {},
+        onClickTitle = {},
+        onSelectTitle = {},
+        onClickFilter = {},
+        onClickFilterItem = {},
+        onClickPost = {},
+        onTitlePickerDismissRequest = {},
+        onFilterDismissRequest = {},
+    )
+}

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/screen/FeedScreen.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/screen/FeedScreen.kt
@@ -31,7 +31,7 @@ import com.captures2024.soongan.presentation.feature.main.feed.component.feed.Fe
 import com.captures2024.soongan.presentation.viewmodel.main.feed.FeedViewModel
 import com.captures2024.soongan.presentation.viewmodel.model.PaginationStatus
 import com.captures2024.soongan.presentation.viewmodel.model.PostOrderType
-import com.captures2024.soongan.presentation.viewmodel.model.feed.TitleOption
+import com.captures2024.soongan.presentation.viewmodel.model.TitleOption
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -87,7 +87,7 @@ internal fun FeedScreen(
                 },
             ) {
                 when {
-                    feedState.currentRoundGallery.isEmpty() -> when (feedState.paginationStatus) {
+                    feedState.posts.isEmpty() -> when (feedState.paginationStatus) {
                         PaginationStatus.DEFAULT,
                         PaginationStatus.REFRESH_LOAD,
                         PaginationStatus.PAGING_LOAD,
@@ -116,7 +116,7 @@ internal fun FeedScreen(
                     }
 
                     else -> items(
-                        items = feedState.currentRoundGallery,
+                        items = feedState.posts,
                         key = { it.postId },
                     ) {
                         SGGalleryImageItem(
@@ -162,10 +162,10 @@ private fun FeedScreenPreview() {
             postOrderType = PostOrderType.MOST_LIKED,
             paginationStatus = PaginationStatus.DEFAULT,
             titleOptions = listOf(TitleOption()),
+            hasNextPage = true,
+            posts = emptyList(),
             currentRound = 1,
             loadPage = 0,
-            hasNextPage = true,
-            feed = emptyMap(),
         ),
         isOpenTitlePickerBottomSheet = false,
         isOpenFilterBottomSheet = false,

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/navigation/MainFeedNavigation.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/navigation/MainFeedNavigation.kt
@@ -1,11 +1,19 @@
 package com.captures2024.soongan.presentation.feature.main.feed.navigation
 
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.captures2024.soongan.core.navigator.screen.main.feed.FeedNavigator
+import com.captures2024.soongan.presentation.feature.main.feed.route.FeedRoute
 
-fun NavGraphBuilder.mainFeed() {
+fun NavGraphBuilder.mainFeed(
+    navigateToPost: (Long, NavOptions?) -> Unit,
+    getHideTargetContentId: () -> Long,
+) {
     composable<FeedNavigator> {
-        // TODO
+        FeedRoute(
+            navigateToPost = navigateToPost,
+            getHideTargetContentId = getHideTargetContentId,
+        )
     }
 }

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/route/FeedRoute.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/route/FeedRoute.kt
@@ -41,7 +41,7 @@ internal fun FeedRoute(
         onRefresh = { feedViewModel.intent(Intent.RefreshFeed) },
         onLoadNextPage = { feedViewModel.intent(Intent.LoadNextPage) },
         onClickTitle = { feedViewModel.intent(Intent.OnClickTitle) },
-        onSelectTitle = { feedViewModel.intent(Intent.OnSelectTitle(it)) },
+        onSelectTitleOption = { feedViewModel.intent(Intent.OnSelectTitleOption(it)) },
         onClickFilter = { feedViewModel.intent(Intent.OnClickFilter) },
         onClickFilterItem = { feedViewModel.intent(Intent.OnClickFilterItem(it)) },
         onClickPost = { feedViewModel.intent(Intent.OnClickPost(it)) },

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/route/FeedRoute.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/route/FeedRoute.kt
@@ -1,0 +1,51 @@
+package com.captures2024.soongan.presentation.feature.main.feed.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavOptions
+import com.captures2024.soongan.presentation.feature.main.feed.component.screen.FeedScreen
+import com.captures2024.soongan.presentation.viewmodel.main.feed.FeedViewModel
+import com.captures2024.soongan.presentation.viewmodel.main.feed.FeedViewModel.Intent
+
+@Composable
+internal fun FeedRoute(
+    navigateToPost: (Long, NavOptions?) -> Unit,
+    getHideTargetContentId: () -> Long,
+    feedViewModel: FeedViewModel = hiltViewModel(),
+) {
+    val uiState by feedViewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(key1 = Unit) {
+        feedViewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is FeedViewModel.Effect.NavigateToHomePost -> navigateToPost(effect.postId, null)
+            }
+        }
+    }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        val postId = getHideTargetContentId()
+
+        if (postId != -1L) {
+            feedViewModel.intent(Intent.HidePost(postId))
+        }
+    }
+
+    FeedScreen(
+        uiState = uiState,
+        onRefresh = { feedViewModel.intent(Intent.RefreshFeed) },
+        onLoadNextPage = { feedViewModel.intent(Intent.LoadNextPage) },
+        onClickTitle = { feedViewModel.intent(Intent.OnClickTitle) },
+        onSelectTitle = { feedViewModel.intent(Intent.OnSelectTitle(it)) },
+        onClickFilter = { feedViewModel.intent(Intent.OnClickFilter) },
+        onClickFilterItem = { feedViewModel.intent(Intent.OnClickFilterItem(it)) },
+        onClickPost = { feedViewModel.intent(Intent.OnClickPost(it)) },
+        onTitlePickerDismissRequest = { feedViewModel.intent(Intent.OnTitlePickerDismissRequest) },
+        onFilterDismissRequest = { feedViewModel.intent(Intent.OnFilterDismissRequest) },
+    )
+}

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/utils/extensions/PostOrderType.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/utils/extensions/PostOrderType.kt
@@ -1,0 +1,25 @@
+package com.captures2024.soongan.presentation.feature.main.feed.utils.extensions
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.captures2024.soongan.core.designsystem.icon.MyIconPack
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconFilterLike
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconFilterNew
+import com.captures2024.soongan.core.designsystem.icon.myiconpack.IconFilterOld
+import com.captures2024.soongan.presentation.feature.main.feed.R
+import com.captures2024.soongan.presentation.viewmodel.model.PostOrderType
+
+internal fun PostOrderType.getStringResId(): Int = when (this) {
+    PostOrderType.MOST_LIKED -> R.string.filter_likes
+
+    PostOrderType.OLDEST -> R.string.filter_oldest
+
+    PostOrderType.LATEST -> R.string.filter_newest
+}
+
+internal fun PostOrderType.getIcon(): ImageVector = when (this) {
+    PostOrderType.MOST_LIKED -> MyIconPack.IconFilterLike
+
+    PostOrderType.OLDEST -> MyIconPack.IconFilterOld
+
+    PostOrderType.LATEST -> MyIconPack.IconFilterNew
+}

--- a/presentation/feature/main-feed/src/main/res/values/strings.xml
+++ b/presentation/feature/main-feed/src/main/res/values/strings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="filter_likes">좋아요 순</string>
+    <string name="filter_oldest">오래된 순</string>
+    <string name="filter_newest">최신 등록 순</string>
+
+<!--  FeedScreen  -->
+    <string name="feed_gallery_post_empty_content">해당 회차에 참가한 작품이 없어요.</string>
+    <string name="feed_gallery_post_error_content">해당 회차 참가 작품을 불러올 수 없어요.</string>
+
+<!--  FeedGalleryHeaderComponent  -->
+    <string name="feed_gallery_header_title_round_unit">%1$s회차</string>
+
+    <!--  FeedScrollPickerComponent  -->
+    <string name="feed_scroll_title_picker_header_text">회차 선택</string>
+    <string name="feed_scroll_title_picker_dismiss_text">취소</string>
+    <string name="feed_scroll_title_picker_confirm_text">확인</string>
+    <string name="scroll_picker_title_infix_text">"회차 | "</string>
+</resources>

--- a/presentation/feature/main-feed/src/main/res/values/strings.xml
+++ b/presentation/feature/main-feed/src/main/res/values/strings.xml
@@ -15,5 +15,5 @@
     <string name="feed_scroll_title_picker_header_text">회차 선택</string>
     <string name="feed_scroll_title_picker_dismiss_text">취소</string>
     <string name="feed_scroll_title_picker_confirm_text">확인</string>
-    <string name="scroll_picker_title_infix_text">"회차 | "</string>
+    <string name="scroll_picker_title_infix_text">"회차  "</string>
 </resources>

--- a/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/navigation/MainHomeNavigation.kt
+++ b/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/navigation/MainHomeNavigation.kt
@@ -12,7 +12,7 @@ import com.captures2024.soongan.presentation.feature.main.home.route.HomeRoute
 import com.captures2024.soongan.presentation.feature.main.home.route.RegistrationPostRoute
 
 fun NavGraphBuilder.mainHome(
-    getHidedPostId: () -> Long,
+    getHideTargetContentId: () -> Long,
     navigateToBack: () -> Unit,
     navigateToRegistrationPost: () -> Unit,
     navigateToGallery: () -> Unit,
@@ -41,7 +41,7 @@ fun NavGraphBuilder.mainHome(
 
     composable<HomeGalleryNavigator> {
         HomeGalleryRoute(
-            getHidePostId = getHidedPostId,
+            getHideTargetContentId = getHideTargetContentId,
             navigateToBack = navigateToBack,
             navigateToPost = { navigateToPost(it, null) },
             navigateToRegistrationPost = navigateToRegistrationPost,

--- a/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/route/HomeGalleryRoute.kt
+++ b/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/route/HomeGalleryRoute.kt
@@ -12,7 +12,7 @@ import com.captures2024.soongan.presentation.viewmodel.main.home.HomeGalleryView
 
 @Composable
 internal fun HomeGalleryRoute(
-    getHidePostId: () -> Long,
+    getHideTargetContentId: () -> Long,
     navigateToBack: () -> Unit,
     navigateToPost: (Long) -> Unit,
     navigateToRegistrationPost: () -> Unit,
@@ -31,7 +31,7 @@ internal fun HomeGalleryRoute(
     }
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-        val postId = getHidePostId()
+        val postId = getHideTargetContentId()
 
         if (postId != -1L) {
             viewModel.intent(HomeGalleryViewModel.Intent.HidePost(postId))

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/navigation/MainPostNavigation.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/navigation/MainPostNavigation.kt
@@ -13,14 +13,14 @@ fun NavGraphBuilder.mainPost(
     navigateToBack: () -> Unit,
     navigateToImageViewer: (String) -> Unit,
     navigateToEditPost: (Long, String, String) -> Unit,
-    navigateToBackWithHidePost: (Long) -> Unit,
+    navigateToBackWithHideTargetContentId: (Long) -> Unit,
 ) {
     composable<PostInfoNavigator> {
         PostInfoRoute(
             navigateToBack = navigateToBack,
             navigateToImageViewer = navigateToImageViewer,
             navigateToEditPost = navigateToEditPost,
-            navigateToBackWithHidePost = navigateToBackWithHidePost,
+            navigateToBackWithHideTargetContentId = navigateToBackWithHideTargetContentId,
         )
     }
 

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/PostInfoRoute.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/PostInfoRoute.kt
@@ -13,7 +13,7 @@ internal fun PostInfoRoute(
     navigateToBack: () -> Unit,
     navigateToEditPost: (Long, String, String) -> Unit,
     navigateToImageViewer: (String) -> Unit,
-    navigateToBackWithHidePost: (Long) -> Unit,
+    navigateToBackWithHideTargetContentId: (Long) -> Unit,
     viewModel: PostInfoViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
@@ -24,7 +24,7 @@ internal fun PostInfoRoute(
                 is PostInfoViewModel.Effect.NavigateToBack -> navigateToBack()
                 is PostInfoViewModel.Effect.NavigateToEditPost -> navigateToEditPost(effect.postId, effect.url, effect.title)
                 is PostInfoViewModel.Effect.NavigateToImageViewer -> navigateToImageViewer(effect.url)
-                is PostInfoViewModel.Effect.NavigateToBackWithHidePost -> navigateToBackWithHidePost(effect.postId)
+                is PostInfoViewModel.Effect.NavigateToBackWithHidePost -> navigateToBackWithHideTargetContentId(effect.postId)
             }
         }
     }

--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
@@ -12,7 +12,6 @@ import androidx.navigation.compose.NavHost
 import com.captures2024.soongan.core.navigator.screen.main.home.HomeNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHome
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHomeGallery
-import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHomePost
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToRegistrationPost
 import com.captures2024.soongan.core.navigator.screen.main.post.navigateToEditPost
 import com.captures2024.soongan.core.navigator.screen.main.post.navigateToImageViewer
@@ -68,7 +67,7 @@ internal fun MainScreen(navigationState: MainNavigationState) {
             )
             mainAwards()
             mainFeed(
-                navigateToPost = navController::navigateToHomePost,
+                navigateToPost = navController::navigateToPostInfo,
                 getHideTargetContentId = navController::getHideTargetContentId,
             )
             mainHome(

--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
@@ -12,6 +12,7 @@ import androidx.navigation.compose.NavHost
 import com.captures2024.soongan.core.navigator.screen.main.home.HomeNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHome
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHomeGallery
+import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHomePost
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToRegistrationPost
 import com.captures2024.soongan.core.navigator.screen.main.post.navigateToEditPost
 import com.captures2024.soongan.core.navigator.screen.main.post.navigateToImageViewer
@@ -19,9 +20,9 @@ import com.captures2024.soongan.core.navigator.screen.main.post.navigateToPostIn
 import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToEditProfile
 import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToFAQ
 import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToNotification
-import com.captures2024.soongan.core.navigator.screen.main.util.getHidedPostId
-import com.captures2024.soongan.core.navigator.screen.main.util.navigateToBackWithHidePost
+import com.captures2024.soongan.core.navigator.screen.main.util.getHideTargetContentId
 import com.captures2024.soongan.core.navigator.screen.main.util.navigateFromNotification
+import com.captures2024.soongan.core.navigator.screen.main.util.navigateToBackWithHideTargetContentId
 import com.captures2024.soongan.core.navigator.screen.main.welcome.WelcomeNavigator
 import com.captures2024.soongan.presentation.feature.main.awards.navigation.mainAwards
 import com.captures2024.soongan.presentation.feature.main.component.MainComponent
@@ -65,21 +66,23 @@ internal fun MainScreen(navigationState: MainNavigationState) {
             welcome(
                 navigateToHome = navController::navigateToHome,
             )
-
             mainAwards()
-            mainFeed()
+            mainFeed(
+                navigateToPost = navController::navigateToHomePost,
+                getHideTargetContentId = navController::getHideTargetContentId,
+            )
             mainHome(
                 navigateToBack = navigateToBack,
                 navigateToRegistrationPost = navController::navigateToRegistrationPost,
                 navigateToGallery = navController::navigateToHomeGallery,
                 navigateToPost = navController::navigateToPostInfo,
-                getHidedPostId = navController::getHidedPostId,
+                getHideTargetContentId = navController::getHideTargetContentId,
             )
             mainPost(
                 navigateToBack = navigateToBack,
                 navigateToImageViewer = navController::navigateToImageViewer,
                 navigateToEditPost = navController::navigateToEditPost,
-                navigateToBackWithHidePost = navController::navigateToBackWithHidePost,
+                navigateToBackWithHideTargetContentId = navController::navigateToBackWithHideTargetContentId,
             )
             mainProfile(
                 navigateToBack = navigateToBack,

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/feed/FeedViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/feed/FeedViewModel.kt
@@ -19,7 +19,7 @@ import com.captures2024.soongan.core.model.enums.CommonDialogType
 import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
 import com.captures2024.soongan.presentation.viewmodel.model.PaginationStatus
 import com.captures2024.soongan.presentation.viewmodel.model.PostOrderType
-import com.captures2024.soongan.presentation.viewmodel.model.feed.TitleOption
+import com.captures2024.soongan.presentation.viewmodel.model.TitleOption
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -59,18 +59,15 @@ constructor(
             val paginationStatus: PaginationStatus,
             val titleOptions: List<TitleOption>,
             val hasNextPage: Boolean,
+            val posts: List<GalleryPostDto>,
             internal val currentRound: Int,
             internal val loadPage: Int,
-            internal val feed: Map<Int, List<GalleryPostDto>>,
         ) {
             val isInitPage: Boolean
                 get() = (loadPage == 0)
 
             val currentTitleOption: TitleOption
                 get() = titleOptions.getOrNull(currentRound - 1) ?: TitleOption()
-
-            val currentRoundGallery: List<GalleryPostDto>
-                get() = feed[currentRound] ?: emptyList()
         }
     }
 
@@ -125,10 +122,10 @@ constructor(
                 postOrderType = PostOrderType.MOST_LIKED,
                 paginationStatus = PaginationStatus.DEFAULT,
                 titleOptions = emptyList(),
+                hasNextPage = false,
+                posts = emptyList(),
                 currentRound = 1,
                 loadPage = 0,
-                hasNextPage = false,
-                feed = emptyMap(),
             ),
             isOpenTitlePickerBottomSheet = false,
             isOpenFilterBottomSheet = false,
@@ -175,11 +172,12 @@ constructor(
                 feedState = feedState.copy(
                     isRefreshing = true,
                     loadPage = 0,
+                    posts = emptyList(),
                 )
             )
         }
 
-        val paginationStatus = getRemoteGalleryPage()
+        val paginationStatus = getRemoteGalleryPost()
 
         reduce {
             copy(
@@ -210,8 +208,19 @@ constructor(
     private suspend fun handleOnSelectTitleOption(intent: Intent.OnSelectTitleOption) {
         val round = intent.round
 
+        handleOnTitlePickerDismissRequest()
+
         if (round != currentState.feedState.currentRound) {
-            val paginationStatus = getRemoteGalleryPage(round = round)
+            reduce {
+                copy(
+                    feedState = feedState.copy(
+                        currentRound = round,
+                        posts = emptyList(),
+                    )
+                )
+            }
+
+            val paginationStatus = getRemoteGalleryPost()
 
             reduce {
                 copy(
@@ -221,8 +230,6 @@ constructor(
                 )
             }
         }
-
-        handleOnTitlePickerDismissRequest()
     }
 
     private fun handleOnClickFilter() {
@@ -247,12 +254,20 @@ constructor(
         handleOnFilterDismissRequest()
 
         if (postOrderType != currentState.feedState.postOrderType) {
-            val paginationStatus = getRemoteGalleryPage(postOrderType = intent.postOrderType)
-
             reduce {
                 copy(
                     feedState = feedState.copy(
                         postOrderType = postOrderType,
+                        posts = emptyList(),
+                    )
+                )
+            }
+
+            val paginationStatus = getRemoteGalleryPost()
+
+            reduce {
+                copy(
+                    feedState = feedState.copy(
                         paginationStatus = paginationStatus,
                     )
                 )
@@ -269,7 +284,7 @@ constructor(
             )
         }
 
-        val paginationStatus = getRemoteGalleryPage()
+        val paginationStatus = getRemoteGalleryPost()
 
         reduce {
             copy(
@@ -285,17 +300,12 @@ constructor(
     }
 
     private fun handleOnReportedPost(intent: Intent.HidePost) {
-        val currentRound = currentState.feedState.currentRound
         val postId = intent.postId
 
         reduce {
             copy(
                 feedState = feedState.copy(
-                    feed = feedState.feed.mapValues { (round, gallery) ->
-                        if (round == currentRound) {
-                            gallery.filter { it.postId != postId }
-                        } else gallery
-                    }
+                    posts = feedState.posts.filter { it.postId != postId },
                 )
             )
         }
@@ -304,7 +314,7 @@ constructor(
     private suspend fun syncFeedInfo() {
         getTitleOptions()
 
-        val paginationStatus = getRemoteGalleryPage()
+        val paginationStatus = getRemoteGalleryPost()
 
         reduce {
             copy(
@@ -341,10 +351,7 @@ constructor(
         }
     }
 
-    private suspend fun getRemoteGalleryPage(
-        round: Int = currentState.feedState.currentRound,
-        postOrderType: PostOrderType = currentState.feedState.postOrderType,
-    ): PaginationStatus {
+    private suspend fun getRemoteGalleryPost(): PaginationStatus {
         val state = currentState.feedState
 
         when (state.paginationStatus) {
@@ -368,21 +375,18 @@ constructor(
 
         val galleryDto = getFilteredGalleryByReportTargetIdsUseCase(
             params = GetFilteredGalleryByReportTargetIdsUseCase.Params(
-                round = round,
-                orderType = postOrderType.name,
+                round = state.currentRound,
+                orderType = state.postOrderType.name,
                 page = state.loadPage,
                 pageSize = AppConst.Main.Gallery.PAGE_SIZE,
             ),
         ).getOrNull() ?: return PaginationStatus.FAILED
 
-        val updatedPosts = state.feed[round].orEmpty() + galleryDto.posts
-
         reduce {
             copy(
                 feedState = feedState.copy(
-                    currentRound = galleryDto.round ?: 1,
                     hasNextPage = galleryDto.hasNext,
-                    feed = feedState.feed + (round to updatedPosts),
+                    posts = feedState.posts + galleryDto.posts,
                 )
             )
         }

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/feed/FeedViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/feed/FeedViewModel.kt
@@ -1,10 +1,11 @@
-package com.captures2024.soongan.core.viewmodel.feed
+package com.captures2024.soongan.presentation.viewmodel.main.feed
 
 import androidx.lifecycle.SavedStateHandle
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.domain.usecase.dialog.PostSingleButtonDialogUseCase
 import com.captures2024.soongan.core.domain.usecase.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.ClearLoadingUseCase
 import com.captures2024.soongan.core.domain.usecase.loading.HideLoadingUseCase
@@ -14,11 +15,15 @@ import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetFilteredG
 import com.captures2024.soongan.core.domain.usecase.weekly.contests.GetWeeklyContestInfoListUseCase
 import com.captures2024.soongan.core.model.AppConst
 import com.captures2024.soongan.core.model.dto.GalleryPostDto
-import com.captures2024.soongan.core.viewmodel.NewBaseViewModel
-import com.captures2024.soongan.core.viewmodel.model.PaginationStatus
-import com.captures2024.soongan.core.viewmodel.model.PostOrderType
+import com.captures2024.soongan.core.model.enums.CommonDialogType
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import com.captures2024.soongan.presentation.viewmodel.model.PaginationStatus
+import com.captures2024.soongan.presentation.viewmodel.model.PostOrderType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+
+typealias TitleOption = Pair<Int, String> // round, subject
+typealias Feed = Map<Int, List<GalleryPostDto>> // round, gallery
 
 @HiltViewModel
 class FeedViewModel
@@ -31,9 +36,10 @@ constructor(
     getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
     setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
+    private val postSingleButtonDialogUseCase: PostSingleButtonDialogUseCase,
     private val getWeeklyContestInfoListUseCase: GetWeeklyContestInfoListUseCase,
     private val getFilteredGalleryByReportTargetIdsUseCase: GetFilteredGalleryByReportTargetIdsUseCase,
-) : NewBaseViewModel<FeedViewModel.State, FeedViewModel.Effect, FeedViewModel.Intent>(
+) : BaseViewModel<FeedViewModel.State, FeedViewModel.Effect, FeedViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
     hideLoadingUseCase = hideLoadingUseCase,
@@ -44,30 +50,29 @@ constructor(
 ) {
 
     data class State(
-        val isLoading: Boolean = false,
-        val isRefreshing: Boolean = false,
-        val isOpenTitlePickerBottomSheet: Boolean = false, /* cmp: FeedDropDown */
-        val isOpenFilterBottomSheet: Boolean = false, /* cmp: FeedFilterBottomSheet  */
-        val postOrderType: PostOrderType = PostOrderType.MOST_LIKED,
-        val paginationStatus: PaginationStatus = PaginationStatus.INACTIVE,
-        val titleOptions: List<Pair<Int, String>> = emptyList(), /* string value : "${round}회차 | title" */
-        val currentRound: Int = 1,
-        internal val nextPage: Int = 0,
-        internal val hasNextPage: Boolean = false,
-        internal val feed: Map<Int, List<GalleryPostDto>> = emptyMap(),
+        val feedState: FeedState,
+        val isOpenTitlePickerBottomSheet: Boolean,
+        val isOpenFilterBottomSheet: Boolean,
     ) : UIState {
 
-        val currentTitleOption: Pair<Int, String>
-            get() = titleOptions.getOrNull(currentRound - 1) ?: (0 to "")
+        data class FeedState(
+            val isRefreshing: Boolean,
+            val postOrderType: PostOrderType,
+            val paginationStatus: PaginationStatus,
+            val titleOptions: List<TitleOption>,
+            val hasNextPage: Boolean,
+            internal val currentRound: Int,
+            internal val loadPage: Int,
+            internal val feed: Feed,
+        ) {
+            val isInitPage: Boolean
+                get() = (loadPage == 0)
 
-        val isFirstPage: Boolean
-            get() = (nextPage == 0)
+            val currentTitleOption: TitleOption
+                get() = titleOptions.getOrNull(currentRound - 1) ?: (currentRound to "")
 
-        val currentRoundGallery: List<GalleryPostDto>
-            get() = feed[currentRound] ?: emptyList()
-
-        override fun toString(): String {
-            return "State(isLoading=$isLoading, isRefreshing = $isRefreshing, isOpenTitlePickerBottomSheet = $isOpenTitlePickerBottomSheet, isOpenFilterBottomSheet=$isOpenFilterBottomSheet, titleItems:$titleOptions, postOrderType:$postOrderType, feeds:$feed)"
+            val currentRoundGallery: List<GalleryPostDto>
+                get() = feed[currentRound] ?: emptyList()
         }
     }
 
@@ -82,21 +87,21 @@ constructor(
 
         data object Init : Intent
 
-        data object RefreshFeed: Intent
+        data object RefreshFeed : Intent
 
-        data object OnClickTitle: Intent
+        data object OnClickTitle : Intent
 
         data object OnTitlePickerDismissRequest : Intent
 
         data class OnSelectTitle(
             val round: Int,
-        ): Intent
+        ) : Intent
 
         data object OnClickFilter : Intent
 
         data object OnFilterDismissRequest : Intent
 
-        data class OnClickSortFilter(
+        data class OnClickFilterItem(
             val postOrderType: PostOrderType,
         ) : Intent
 
@@ -116,7 +121,20 @@ constructor(
     }
 
     override fun createInitialState(savedStateHandle: SavedStateHandle): State {
-        return State()
+        return State(
+            feedState = State.FeedState(
+                isRefreshing = false,
+                postOrderType = PostOrderType.MOST_LIKED,
+                paginationStatus = PaginationStatus.DEFAULT,
+                titleOptions = emptyList(),
+                currentRound = 1,
+                loadPage = 0,
+                hasNextPage = false,
+                feed = emptyMap(),
+            ),
+            isOpenTitlePickerBottomSheet = false,
+            isOpenFilterBottomSheet = false,
+        )
     }
 
     override fun handleClientException(throwable: Throwable) {
@@ -139,7 +157,7 @@ constructor(
 
             is Intent.OnFilterDismissRequest -> handleOnFilterDismissRequest()
 
-            is Intent.OnClickSortFilter -> launch { handleOnClickSortFilter(intent) }
+            is Intent.OnClickFilterItem -> launch { handleOnClickSortFilter(intent) }
 
             is Intent.LoadNextPage -> launch { handleLoadNextPage() }
 
@@ -156,12 +174,23 @@ constructor(
     private suspend fun handleRefreshFeed() {
         reduce {
             copy(
-                isRefreshing = true,
-                nextPage = 0,
+                feedState = feedState.copy(
+                    isRefreshing = true,
+                    loadPage = 0,
+                )
             )
         }
 
-        fetchFeedPage()
+        val paginationStatus = getRemoteGalleryPage()
+
+        reduce {
+            copy(
+                feedState = feedState.copy(
+                    isRefreshing = false,
+                    paginationStatus = paginationStatus,
+                )
+            )
+        }
     }
 
     private fun handleOnClickTitle() {
@@ -183,8 +212,16 @@ constructor(
     private suspend fun handleOnSelectTitle(intent: Intent.OnSelectTitle) {
         val round = intent.round
 
-        if(round != currentState.currentRound) {
-            fetchFeedPage(round = round)
+        if (round != currentState.feedState.currentRound) {
+            val paginationStatus = getRemoteGalleryPage(round = round)
+
+            reduce {
+                copy(
+                    feedState = feedState.copy(
+                        paginationStatus = paginationStatus,
+                    )
+                )
+            }
         }
 
         handleOnTitlePickerDismissRequest()
@@ -206,19 +243,42 @@ constructor(
         }
     }
 
-    private suspend fun handleOnClickSortFilter(intent: Intent.OnClickSortFilter) {
+    private suspend fun handleOnClickSortFilter(intent: Intent.OnClickFilterItem) {
+        val postOrderType = intent.postOrderType
+
         handleOnFilterDismissRequest()
-        fetchFeedPage(postOrderType = intent.postOrderType)
+
+        if (postOrderType != currentState.feedState.postOrderType) {
+            val paginationStatus = getRemoteGalleryPage(postOrderType = intent.postOrderType)
+
+            reduce {
+                copy(
+                    feedState = feedState.copy(
+                        paginationStatus = paginationStatus,
+                    )
+                )
+            }
+        }
     }
 
     private suspend fun handleLoadNextPage() {
         reduce {
             copy(
-                nextPage = nextPage + 1,
+                feedState = feedState.copy(
+                    loadPage = feedState.loadPage + 1,
+                ),
             )
         }
 
-        fetchFeedPage()
+        val paginationStatus = getRemoteGalleryPage()
+
+        reduce {
+            copy(
+                feedState = feedState.copy(
+                    paginationStatus = paginationStatus,
+                )
+            )
+        }
     }
 
     private fun handleOnClickPost(intent: Intent.OnClickPost) {
@@ -226,30 +286,41 @@ constructor(
     }
 
     private fun handleOnReportedPost(intent: Intent.HidePost) {
-        val round = currentState.currentRound
+        val currentRound = currentState.feedState.currentRound
         val postId = intent.postId
 
-        val tempPosts = currentState.feed[round]?.toMutableList() ?: mutableListOf()
-
-        tempPosts.removeAll { it.postId == postId }
-
         reduce {
-            copy(feed = feed.toMutableMap().apply { put(round, tempPosts) }.toMap())
+            copy(
+                feedState = feedState.copy(
+                    feed = feedState.feed.mapValues { (round, gallery) ->
+                        if (round == currentRound) {
+                            gallery.filter { it.postId != postId }
+                        } else gallery
+                    }
+                )
+            )
         }
-
-        analyticsHelper.d { "reported post, postId : $postId" }
     }
 
     private suspend fun syncFeedInfo() {
         getTitleOptions()
-        fetchFeedPage()
+
+        val paginationStatus = getRemoteGalleryPage()
+
+        reduce {
+            copy(
+                feedState = feedState.copy(
+                    paginationStatus = paginationStatus,
+                )
+            )
+        }
     }
 
     private suspend fun getTitleOptions() {
         val weeklyContestInfoListDto = getWeeklyContestInfoListUseCase().getOrNull()
 
         if (weeklyContestInfoListDto == null) {
-            analyticsHelper.d { "getTitleOptions - weeklyContestInfoListDto is null" }
+            postSingleButtonDialogUseCase(type = CommonDialogType.NETWORK_ERROR)
 
             return
         }
@@ -259,83 +330,59 @@ constructor(
 
         reduce {
             copy(
-                titleOptions = titleOptions,
+                feedState = feedState.copy(
+                    titleOptions = titleOptions,
+                )
             )
         }
     }
 
-    private fun setUpPaginationStatus() {
-        if (currentState.isFirstPage) {
-            reduce {
-                copy(
-                    paginationStatus = PaginationStatus.LOADING,
-                    feed = emptyMap(),
-                )
-            }
-        } else {
-            reduce {
-                copy(
-                    paginationStatus = PaginationStatus.PAGINATING,
-                )
-            }
-        }
-    }
+    private suspend fun getRemoteGalleryPage(
+        round: Int = currentState.feedState.currentRound,
+        postOrderType: PostOrderType = currentState.feedState.postOrderType,
+    ): PaginationStatus {
+        val state = currentState.feedState
 
-    private suspend fun fetchFeedPage(
-        round: Int = currentState.currentRound,
-        postOrderType: PostOrderType = currentState.postOrderType,
-    ) {
-        when (currentState.paginationStatus) {
-            PaginationStatus.LOADING,
-            PaginationStatus.PAGINATING,
-            -> return
+        when (state.paginationStatus) {
+            PaginationStatus.REFRESH_LOAD,
+            PaginationStatus.PAGING_LOAD,
+            -> return state.paginationStatus
 
             else -> Unit
         }
 
-        setUpPaginationStatus()
+        reduce {
+            copy(
+                feedState = feedState.copy(
+                    paginationStatus = when (state.isRefreshing) {
+                        true -> PaginationStatus.REFRESH_LOAD
+                        false -> PaginationStatus.PAGING_LOAD
+                    },
+                )
+            )
+        }
 
         val galleryDto = getFilteredGalleryByReportTargetIdsUseCase(
             params = GetFilteredGalleryByReportTargetIdsUseCase.Params(
                 round = round,
                 orderType = postOrderType.name,
-                page = currentState.nextPage,
+                page = state.loadPage,
                 pageSize = AppConst.Main.Gallery.PAGE_SIZE,
             ),
-        ).getOrNull()
+        ).getOrNull() ?: return PaginationStatus.FAILED
 
-        if (galleryDto == null) {
-            analyticsHelper.d { "fetchFeedPage - galleryDto is null" }
-
-            reduce {
-                copy(
-                    paginationStatus = PaginationStatus.ERROR,
-                )
-            }
-
-            return
-        }
-
-        val currentPosts = currentState.feed[round].orEmpty()
-        val updatedPosts = currentPosts + galleryDto.posts
-
-        val updatedFeed = currentState.feed.toMutableMap().apply {
-            put(round, updatedPosts)
-        }.toMap()
+        val updatedPosts = state.feed[round].orEmpty() + galleryDto.posts
 
         reduce {
             copy(
-                paginationStatus = when {
-                    !galleryDto.hasNext -> PaginationStatus.EXHAUST
-
-                    galleryDto.posts.isEmpty() -> PaginationStatus.EMPTY
-
-                    else -> PaginationStatus.INACTIVE
-                },
-                currentRound = round,
-                hasNextPage = galleryDto.hasNext,
-                feed = updatedFeed,
+                feedState = feedState.copy(
+                    currentRound = galleryDto.round ?: 1,
+                    hasNextPage = galleryDto.hasNext,
+                    feed = feedState.feed + (round to updatedPosts),
+                )
             )
         }
+
+        return PaginationStatus.SUCCESS
     }
 }

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/feed/FeedViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/feed/FeedViewModel.kt
@@ -19,11 +19,9 @@ import com.captures2024.soongan.core.model.enums.CommonDialogType
 import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
 import com.captures2024.soongan.presentation.viewmodel.model.PaginationStatus
 import com.captures2024.soongan.presentation.viewmodel.model.PostOrderType
+import com.captures2024.soongan.presentation.viewmodel.model.feed.TitleOption
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-
-typealias TitleOption = Pair<Int, String> // round, subject
-typealias Feed = Map<Int, List<GalleryPostDto>> // round, gallery
 
 @HiltViewModel
 class FeedViewModel
@@ -63,13 +61,13 @@ constructor(
             val hasNextPage: Boolean,
             internal val currentRound: Int,
             internal val loadPage: Int,
-            internal val feed: Feed,
+            internal val feed: Map<Int, List<GalleryPostDto>>,
         ) {
             val isInitPage: Boolean
                 get() = (loadPage == 0)
 
             val currentTitleOption: TitleOption
-                get() = titleOptions.getOrNull(currentRound - 1) ?: (currentRound to "")
+                get() = titleOptions.getOrNull(currentRound - 1) ?: TitleOption()
 
             val currentRoundGallery: List<GalleryPostDto>
                 get() = feed[currentRound] ?: emptyList()
@@ -93,7 +91,7 @@ constructor(
 
         data object OnTitlePickerDismissRequest : Intent
 
-        data class OnSelectTitle(
+        data class OnSelectTitleOption(
             val round: Int,
         ) : Intent
 
@@ -151,7 +149,7 @@ constructor(
 
             is Intent.OnTitlePickerDismissRequest -> launch { handleOnTitlePickerDismissRequest() }
 
-            is Intent.OnSelectTitle -> launch { handleOnSelectTitle(intent) }
+            is Intent.OnSelectTitleOption -> launch { handleOnSelectTitleOption(intent) }
 
             is Intent.OnClickFilter -> handleOnClickFilter()
 
@@ -209,7 +207,7 @@ constructor(
         }
     }
 
-    private suspend fun handleOnSelectTitle(intent: Intent.OnSelectTitle) {
+    private suspend fun handleOnSelectTitleOption(intent: Intent.OnSelectTitleOption) {
         val round = intent.round
 
         if (round != currentState.feedState.currentRound) {
@@ -254,6 +252,7 @@ constructor(
             reduce {
                 copy(
                     feedState = feedState.copy(
+                        postOrderType = postOrderType,
                         paginationStatus = paginationStatus,
                     )
                 )
@@ -325,8 +324,13 @@ constructor(
             return
         }
 
-        val titleOptions: List<Pair<Int, String>> =
-            weeklyContestInfoListDto.weeklyContestInfoList.map { it.round to it.subject }
+        val titleOptions: List<TitleOption> =
+            weeklyContestInfoListDto.weeklyContestInfoList.map {
+                TitleOption(
+                    round = it.round,
+                    subject = it.subject,
+                )
+            }
 
         reduce {
             copy(

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/TitleOption.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/TitleOption.kt
@@ -1,4 +1,4 @@
-package com.captures2024.soongan.presentation.viewmodel.model.feed
+package com.captures2024.soongan.presentation.viewmodel.model
 
 data class TitleOption(
     val round: Int = 1,

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/feed/TitleOption.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/feed/TitleOption.kt
@@ -1,0 +1,9 @@
+package com.captures2024.soongan.presentation.viewmodel.model.feed
+
+data class TitleOption(
+    val round: Int = 1,
+    val subject: String = "",
+) {
+    // check ScrollTitlePicker clickable
+    val hasValidSubject = subject.isNotBlank()
+}


### PR DESCRIPTION
# [SG-133] refactor main-feed

## 변경 사항
- 기존 feed 모듈 로직 refactor
- 회차 선택 용 scroll picker 구현
- 기존 신고/삭제 처리를 위한 navigate 로직 네이밍 변경 및 feed 화면에 추가
  - sharedFlow로 작업을 아직 못해서 일단 붙였습니다.

## Gif / ScreenShot
|스크롤 gif|
|---|
![scroll_picker_video](https://github.com/user-attachments/assets/3c659270-b81d-4f55-820d-b400a0bb8dd7)

<img src="https://github.com/user-attachments/assets/86b69c32-7aa1-4b58-93f9-2f9e5464c809" width="250" height="500"/>

디자인이 변경되어 스크린 샷 추가합니다.

## 비고
- 기존 모듈과 새 presentation 모듈 로직 둘 다 업데이트는 했으나 새 모듈이 좀 더 UI 최신화와 일부 에러 처리가 더 되어 있습니다.
- AppConst 내 PageSize 추가 (기존 모듈 및 feed에만 반영)

[SG-133]: https://captures2024.atlassian.net/browse/SG-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ