### PR TITLE
[SG-142] Bottom Navigation issue

### DIFF
--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/navigation/MainNavigationState.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/navigation/MainNavigationState.kt
@@ -12,6 +12,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navOptions
 import com.captures2024.soongan.core.navigator.screen.main.awards.navigateToAwards
 import com.captures2024.soongan.core.navigator.screen.main.feed.navigateToFeed
+import com.captures2024.soongan.core.navigator.screen.main.home.HomeNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHome
 import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToProfile
 
@@ -64,7 +65,7 @@ internal class MainNavigationState(
     }
 
     fun buildTopLevelNavOptions(): NavOptions = navOptions {
-        popUpTo(navController.graph.findStartDestination().id) {
+        popUpTo(HomeNavigator) {
             saveState = true
         }
         launchSingleTop = true


### PR DESCRIPTION
# [SG-142] Bottom Navigation issue

## 변경 사항
- 바텀 네비게이션이 다중으로 스택이 쌓이는 현상 해결
- 무조건 최하단 라우트는 HomeNavigator로 설정

[SG-142]: https://captures2024.atlassian.net/browse/SG-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ