### PR TITLE
[SG-141] UI 현행화

### DIFF
--- a/app/src/main/kotlin/com/captures2024/soongan/route/DialogHost.kt
+++ b/app/src/main/kotlin/com/captures2024/soongan/route/DialogHost.kt
@@ -39,6 +39,7 @@ internal fun DialogHost(viewModel: AppViewModel) {
                 CommonDialogType.TOKEN_EXPIRED -> "토큰이 만료되었습니다. 다시 로그인해주세요."
                 CommonDialogType.SUCCESS_SIGN -> "로그인이 완료되었습니다."
                 CommonDialogType.NETWORK_ERROR -> "네트워크 오류가 발생하였습니다."
+                CommonDialogType.OTHER_SOCIAL -> "다른 소셜로 가입된 계정입니다."
             },
             confirmContent = "확인",
             onClickConfirm = { isShowDialog = false },

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/enums/CommonDialogType.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/enums/CommonDialogType.kt
@@ -4,4 +4,5 @@ enum class CommonDialogType {
     TOKEN_EXPIRED,
     SUCCESS_SIGN,
     NETWORK_ERROR,
+    OTHER_SOCIAL,
 }

--- a/domain/usecase/system-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/system/impl/di/SystemUseCaseModule.kt
+++ b/domain/usecase/system-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/system/impl/di/SystemUseCaseModule.kt
@@ -9,6 +9,7 @@ import com.captures2024.soongan.domain.usecase.system.impl.dialog.GetSingleButto
 import com.captures2024.soongan.domain.usecase.system.impl.dialog.PostSingleButtonDialogUseCaseImpl
 import com.captures2024.soongan.domain.usecase.system.impl.dialog.SetIsShowGuestModeDialogFlowUseCaseImpl
 import com.captures2024.soongan.domain.usecase.system.impl.inapp.GetInAppBrowserUrlFlowUseCaseImpl
+import com.captures2024.soongan.domain.usecase.system.impl.inapp.LaunchInquiryUseCaseImpl
 import com.captures2024.soongan.domain.usecase.system.impl.inapp.LaunchPrivacyPolicyUseCaseImpl
 import com.captures2024.soongan.domain.usecase.system.impl.inapp.LaunchTermsUseCaseImpl
 import com.captures2024.soongan.domain.usecase.system.impl.loading.ClearLoadingUseCaseImpl
@@ -17,6 +18,7 @@ import com.captures2024.soongan.domain.usecase.system.impl.loading.HideLoadingUs
 import com.captures2024.soongan.domain.usecase.system.impl.loading.IsLoadingUseCaseImpl
 import com.captures2024.soongan.domain.usecase.system.impl.loading.ShowLoadingUseCaseImpl
 import com.captures2024.soongan.domain.usecase.system.inapp.GetInAppBrowserUrlFlowUseCase
+import com.captures2024.soongan.domain.usecase.system.inapp.LaunchInquiryUseCase
 import com.captures2024.soongan.domain.usecase.system.inapp.LaunchPrivacyPolicyUseCase
 import com.captures2024.soongan.domain.usecase.system.inapp.LaunchTermsUseCase
 import com.captures2024.soongan.domain.usecase.system.loading.ClearLoadingUseCase
@@ -53,6 +55,9 @@ internal abstract class SystemUseCaseModule {
 
     @Binds
     abstract fun bindLaunchTermsUseCase(launchTermsUseCaseImpl: LaunchTermsUseCaseImpl): LaunchTermsUseCase
+
+    @Binds
+    abstract fun bindLaunchInquiryUseCase(launchInquiryUseCaseImpl: LaunchInquiryUseCaseImpl): LaunchInquiryUseCase
 
     @Binds
     abstract fun bindClearLoadingUseCase(clearLoadingUseCaseImpl: ClearLoadingUseCaseImpl): ClearLoadingUseCase

--- a/domain/usecase/system-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/system/impl/inapp/LaunchInquiryUseCaseImpl.kt
+++ b/domain/usecase/system-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/system/impl/inapp/LaunchInquiryUseCaseImpl.kt
@@ -1,0 +1,19 @@
+package com.captures2024.soongan.domain.usecase.system.impl.inapp
+
+import com.captures2024.soongan.data.repository.system.SystemRepository
+import com.captures2024.soongan.domain.usecase.system.inapp.LaunchInquiryUseCase
+import com.captures2024.soongan.domain.usecase.utils.runSuspendCatching
+import javax.inject.Inject
+
+class LaunchInquiryUseCaseImpl
+@Inject
+constructor(
+    private val systemRepository: SystemRepository,
+) : LaunchInquiryUseCase {
+
+    override suspend fun invoke(): Result<Unit> = runSuspendCatching {
+        systemRepository.launchInAppBrowser(
+            url = "https://forms.gle/sPEVxtXh9Kt4mVm36",
+        )
+    }
+}

--- a/domain/usecase/system/src/main/kotlin/com/captures2024/soongan/domain/usecase/system/inapp/LaunchInquiryUseCase.kt
+++ b/domain/usecase/system/src/main/kotlin/com/captures2024/soongan/domain/usecase/system/inapp/LaunchInquiryUseCase.kt
@@ -1,0 +1,6 @@
+package com.captures2024.soongan.domain.usecase.system.inapp
+
+interface LaunchInquiryUseCase {
+
+    suspend operator fun invoke(): Result<Unit>
+}

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedFilterBottomSheetComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedFilterBottomSheetComponent.kt
@@ -55,13 +55,11 @@ internal fun FeedFilterBottomSheetComponent(
         containerColor = Color.White,
     ) {
         Column(
-            modifier = Modifier.padding(
-                horizontal = 20.dp,
-                vertical = 20.dp,
-            ),
+            modifier = Modifier.padding(horizontal = 20.dp)
+                .padding(bottom = 20.dp),
         ) {
             PostOrderType.entries.forEachIndexed { idx, postOrderType ->
-                if (idx != 0) HorizontalDivider(color = SGColor.primaryA.copy(alpha = 0.3f))
+                if (idx != 0) HorizontalDivider(color = SGColor.Grayscale.black100.copy(alpha = 0.3f))
 
                 FeedGalleryFilterItem(
                     text = stringResource(id = postOrderType.getStringResId()),
@@ -85,7 +83,7 @@ private fun FeedGalleryFilterItem(
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(8.dp))
-            .clickable { onClickItem() },
+            .clickable(onClick = onClickItem),
     ) {
         Row(
             modifier = Modifier
@@ -99,14 +97,14 @@ private fun FeedGalleryFilterItem(
                 text = text,
                 style = getSGNonScaleTextStyle(
                     color = when (selected) {
-                        true -> SGColor.primaryA
+                        true -> SGColor.Grayscale.black100
 
-                        false -> SGColor.primaryA.copy(alpha = 0.3f)
+                        false -> SGColor.Grayscale.black100.copy(alpha = 0.3f)
                     },
                     fontSize = 16.sp,
                     fontWeight = FontWeight.Bold,
                     lineHeight = 24.sp,
-                    fontFamily = SGTypography.nanumSquareNeo,
+                    fontFamily = SGTypography.pretendard,
                 ),
             )
 
@@ -115,9 +113,9 @@ private fun FeedGalleryFilterItem(
                 imageVector = icon,
                 contentDescription = text,
                 tint = when (selected) {
-                    true -> SGColor.primaryA
+                    true -> SGColor.Grayscale.black100
 
-                    false -> SGColor.primaryA.copy(alpha = 0.3f)
+                    false -> SGColor.Grayscale.black100.copy(alpha = 0.3f)
                 },
             )
         }

--- a/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/component/gallery/GalleryFilterBottomSheetComponent.kt
+++ b/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/component/gallery/GalleryFilterBottomSheetComponent.kt
@@ -3,6 +3,7 @@ package com.captures2024.soongan.presentation.feature.main.home.component.galler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -48,22 +49,24 @@ internal fun GalleryFilterBottomSheetComponent(
         sheetState = sheetState,
         containerColor = SGColor.Grayscale.white,
     ) {
-        PostOrderType.entries.forEachIndexed { idx, postOrderType ->
-            if (idx != 0) {
-                HorizontalDivider(
-                    color = SGColor.Grayscale.black100
-                        .copy(
-                            alpha = 0.3f,
-                        ),
+        Column(
+            modifier = Modifier.padding(horizontal = 20.dp)
+                .padding(bottom = 20.dp),
+        ) {
+            PostOrderType.entries.forEachIndexed { idx, postOrderType ->
+                if (idx != 0) {
+                    HorizontalDivider(
+                        color = SGColor.Grayscale.black100.copy(alpha = 0.3f),
+                    )
+                }
+
+                GalleryFilterItem(
+                    text = stringResource(id = postOrderType.getStringResId()),
+                    icon = postOrderType.getIcon(),
+                    selected = selectedPostOrderType == postOrderType,
+                    onClickItem = { onClickItem(postOrderType) },
                 )
             }
-
-            GalleryFilterItem(
-                text = stringResource(id = postOrderType.getStringResId()),
-                icon = postOrderType.getIcon(),
-                selected = selectedPostOrderType == postOrderType,
-                onClickItem = { onClickItem(postOrderType) },
-            )
         }
     }
 }

--- a/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/component/home/HomeContestInfoBottomSheet.kt
+++ b/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/component/home/HomeContestInfoBottomSheet.kt
@@ -1,12 +1,13 @@
 package com.captures2024.soongan.presentation.feature.main.home.component.home
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -18,7 +19,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.captures2024.soongan.presentation.designsystem.ui.component.HeightSpacer
-import com.captures2024.soongan.presentation.designsystem.ui.component.button.SGTextButtonType2
 import com.captures2024.soongan.presentation.designsystem.ui.component.text.SGText
 import com.captures2024.soongan.presentation.designsystem.ui.component.text.getSGNonScaleTextStyle
 import com.captures2024.soongan.presentation.designsystem.ui.theme.SGColor
@@ -41,11 +41,9 @@ internal fun HomeContestInfoBottomSheet(
         modifier = modifier,
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
-        containerColor = SGColor.Grayscale.white,
+        containerColor = SGColor.BG.background,
         content = @Composable {
-            HomeContestInfoComponent(
-                onDismissRequest = onDismissRequest,
-            )
+            HomeContestInfoComponent()
         },
     )
 }
@@ -53,7 +51,6 @@ internal fun HomeContestInfoBottomSheet(
 @Composable
 private fun ColumnScope.HomeContestInfoComponent(
     modifier: Modifier = Modifier,
-    onDismissRequest: () -> Unit,
 ) {
     val titleStyle = getSGNonScaleTextStyle(
         color = SGColor.Grayscale.black100,
@@ -79,28 +76,31 @@ private fun ColumnScope.HomeContestInfoComponent(
             .wrapContentHeight(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        SGText(
-            text = stringResource(R.string.contest_info_bs_title),
-            style = getSGNonScaleTextStyle(
-                color = SGColor.Grayscale.black100,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Bold,
-                lineHeight = 20.sp,
-                fontFamily = SGTypography.pretendard,
-                letterSpacing = (-5).em,
-            ),
-        )
-
-        HeightSpacer(12.dp)
-
-        HorizontalDivider(color = SGColor.primaryA.copy(alpha = 0.3f))
+        Box(
+            modifier = Modifier.fillMaxWidth()
+                .wrapContentHeight()
+                .padding(vertical = 8.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            SGText(
+                text = stringResource(R.string.contest_info_bs_title),
+                style = getSGNonScaleTextStyle(
+                    color = SGColor.Grayscale.black100,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 20.sp,
+                    fontFamily = SGTypography.pretendard,
+                    letterSpacing = (-5).em,
+                ),
+            )
+        }
 
         Column(
             modifier = Modifier.fillMaxWidth()
                 .wrapContentHeight()
                 .padding(
                     top = 40.dp,
-                    bottom = 28.dp,
+                    bottom = 120.dp,
                 )
                 .padding(horizontal = 20.dp),
         ) {
@@ -199,14 +199,6 @@ private fun ColumnScope.HomeContestInfoComponent(
                     modifier = Modifier.padding(start = 16.dp),
                 )
             }
-
-            HeightSpacer(44.dp)
-
-            SGTextButtonType2(
-                text = stringResource(R.string.contest_info_bs_button_content),
-                modifier = Modifier.fillMaxWidth(),
-                onClick = onDismissRequest,
-            )
         }
     }
 }
@@ -227,9 +219,7 @@ private fun PreviewHomeContestInfoBottomSheet() {
 private fun PreviewHomeContestInfoComponent() {
     SGTheme {
         Column {
-            HomeContestInfoComponent(
-                onDismissRequest = {},
-            )
+            HomeContestInfoComponent()
         }
     }
 }

--- a/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/component/registration/RegistrationPostBodyComponent.kt
+++ b/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/component/registration/RegistrationPostBodyComponent.kt
@@ -1,11 +1,14 @@
 package com.captures2024.soongan.presentation.feature.main.home.component.registration
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -15,6 +18,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
@@ -49,16 +53,21 @@ internal fun RegistrationPostBodyComponent(
     onTitleValueChanged: (String) -> Unit,
     onClickSubmit: () -> Unit,
 ) {
+    val focusManager = LocalFocusManager.current
     val scrollState = rememberScrollState()
 
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(
-                bottom = 58.dp,
-            )
+            .padding(bottom = 58.dp)
             .padding(horizontal = 20.dp)
-            .verticalScroll(scrollState),
+            .verticalScroll(scrollState)
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = { focusManager.clearFocus() }
+            )
+            .imePadding(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         AsyncImage(

--- a/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/component/screen/RegistrationPostScreen.kt
+++ b/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/component/screen/RegistrationPostScreen.kt
@@ -1,12 +1,16 @@
 package com.captures2024.soongan.presentation.feature.main.home.component.screen
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.presentation.designsystem.ui.component.HeightSpacer
 import com.captures2024.soongan.presentation.designsystem.ui.component.dialog.SGDoubleButtonDialog
 import com.captures2024.soongan.presentation.designsystem.ui.theme.SGColor
 import com.captures2024.soongan.presentation.designsystem.ui.theme.SGTheme
@@ -28,20 +32,19 @@ internal fun RegistrationPostScreen(
     onClickConfirmSubmitBottomSheet: () -> Unit,
     onClickCancelSubmitBottomSheet: () -> Unit,
 ) {
-    Scaffold(
+    Column(
         modifier = Modifier.fillMaxSize()
             .background(color = SGColor.BG.background),
-        topBar = @Composable {
-            RegistrationPostTopBarComponent(
-                contestInfo = state.currentContestInfo,
-                onBackPressed = onClickBack,
-            )
-        },
-        containerColor = SGColor.transparent,
-    ) { paddingValues ->
+    ) {
+        RegistrationPostTopBarComponent(
+            contestInfo = state.currentContestInfo,
+            onBackPressed = onClickBack,
+        )
+
+        HeightSpacer(20.dp)
+
         RegistrationPostBodyComponent(
             state = state,
-            modifier = Modifier.padding(paddingValues),
             onTitleValueChanged = onTitleValueChanged,
             onClickSubmit = onClickSubmit,
         )

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/FaqViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/FaqViewModel.kt
@@ -7,6 +7,7 @@ import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
 import com.captures2024.soongan.domain.usecase.member.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.domain.usecase.system.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.domain.usecase.system.inapp.LaunchInquiryUseCase
 import com.captures2024.soongan.domain.usecase.system.loading.ClearLoadingUseCase
 import com.captures2024.soongan.domain.usecase.system.loading.HideLoadingUseCase
 import com.captures2024.soongan.domain.usecase.system.loading.ShowLoadingUseCase
@@ -26,6 +27,7 @@ constructor(
     getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
     setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
+    private val launchInquiryUseCase: LaunchInquiryUseCase,
 ) : BaseViewModel<FaqViewModel.State, FaqViewModel.Effect, FaqViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
@@ -66,7 +68,7 @@ constructor(
         when (intent) {
             is Intent.OnClickBack -> handleOnClickBack()
             is Intent.OnClickCategory -> handleOnClickCategory(intent)
-            is Intent.OnClickInquiry -> handleOnClickInquiry()
+            is Intent.OnClickInquiry -> loadingLaunch { handleOnClickInquiry() }
         }
     }
 
@@ -86,7 +88,7 @@ constructor(
         }
     }
 
-    private fun handleOnClickInquiry() {
-        // TODO()
+    private suspend fun handleOnClickInquiry() {
+        launchInquiryUseCase()
     }
 }

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/sign/SignInViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/sign/SignInViewModel.kt
@@ -5,12 +5,16 @@ import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.model.dto.UserInfoDto
+import com.captures2024.soongan.core.model.enums.CommonDialogType
+import com.captures2024.soongan.core.model.exception.NetworkExceptionWrapper
 import com.captures2024.soongan.domain.usecase.auth.SigningGoogleUseCase
 import com.captures2024.soongan.domain.usecase.auth.SigningKakaoUseCase
 import com.captures2024.soongan.domain.usecase.fcm.GetFcmUseCase
 import com.captures2024.soongan.domain.usecase.member.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.domain.usecase.member.GetMemberInfoUseCase
 import com.captures2024.soongan.domain.usecase.member.SetGuestModeUseCase
+import com.captures2024.soongan.domain.usecase.system.dialog.PostSingleButtonDialogUseCase
 import com.captures2024.soongan.domain.usecase.system.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.domain.usecase.system.inapp.LaunchPrivacyPolicyUseCase
 import com.captures2024.soongan.domain.usecase.system.inapp.LaunchTermsUseCase
@@ -39,6 +43,7 @@ constructor(
     private val signingKakaoUseCase: SigningKakaoUseCase,
     private val signingGoogleUseCase: SigningGoogleUseCase,
     private val getMemberInfoUseCase: GetMemberInfoUseCase,
+    private val postSingleButtonDialogUseCase: PostSingleButtonDialogUseCase,
 ) : BaseViewModel<SignInViewModel.State, SignInViewModel.Effect, SignInViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
@@ -132,26 +137,20 @@ constructor(
         val result = signingKakaoUseCase(
             token = token,
             fcmToken = fcmToken,
-        ).getOrNull()
+        ).getOrElse(this::failedSignInCase)
 
-        when (result) {
-            true -> {
-                val infoDto = getMemberInfoUseCase().getOrNull()
+        if (result) {
+            val infoDto = getMemberInfoUseCase().getOrNull()
 
-                if (infoDto == null) {
-                    analyticsHelper.d { "kakaoSignIn - infoDto is null" }
+            if (infoDto == null) {
+                analyticsHelper.d { "kakaoSignIn - infoDto is null" }
 
-                    return
-                }
-
-                when {
-                    infoDto.nickname == null || infoDto.birthYear == null -> postSideEffect(Effect.NavigateToSignUp)
-                    else -> Unit
-                }
+                return
             }
 
-            else -> {
-                analyticsHelper.d { "kakaoSignIn - result: $result" }
+            when {
+                infoDto.nickname == null || infoDto.birthYear == null -> postSideEffect(Effect.NavigateToSignUp)
+                else -> Unit
             }
         }
     }
@@ -167,26 +166,38 @@ constructor(
         val result = signingGoogleUseCase(
             token = token,
             fcmToken = fcmToken,
-        ).getOrNull()
+        ).getOrElse(this::failedSignInCase)
 
-        when (result) {
-            true -> {
-                val infoDto = getMemberInfoUseCase().getOrNull()
+        if (result) {
+            val infoDto = getMemberInfoUseCase().getOrNull()
 
-                if (infoDto == null) {
-                    analyticsHelper.d { "googleSign - infoDto is null" }
-                    return
-                }
-
-                when {
-                    infoDto.nickname == null || infoDto.birthYear == null -> postSideEffect(Effect.NavigateToSignUp)
-                    else -> Unit
-                }
+            if (infoDto == null) {
+                analyticsHelper.d { "googleSign - infoDto is null" }
+                return
             }
 
-            else -> {
-                analyticsHelper.d { "googleSign - result: $result" }
+            when {
+                infoDto.nickname == null || infoDto.birthYear == null -> postSideEffect(Effect.NavigateToSignUp)
+                else -> Unit
             }
         }
+    }
+
+    private fun failedSignInCase(exception: Throwable): Boolean {
+        analyticsHelper.d { "failedSignInCase - exception: $exception" }
+
+        if (exception is NetworkExceptionWrapper) {
+            launch {
+                postSingleButtonDialogUseCase(
+                    when (exception.statusCode) {
+                        705 -> CommonDialogType.OTHER_SOCIAL
+
+                        else -> CommonDialogType.NETWORK_ERROR
+                    }
+                )
+            }
+        }
+
+        return false
     }
 }


### PR DESCRIPTION
# [SG-141] UI 현행화

## 변경 사항
- 소셜 로그인 시 다른 도메인 인 경우 표시하는 dialog 추가
- 콘테스트 정보 바텀시트 ui 수정
- gallery 백그라운드 색상 사용하도록 변경
- 정렬 바텀 시트 UI 변경
- 게시글 등록 ui 변경
- faq 문의하기 인앱 브라우저 연결

[SG-141]: https://captures2024.atlassian.net/browse/SG-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ