### PR TITLE
[SG-140] content-visibility event 처리

### DIFF
--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/util/NavCotrollerExt.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/util/NavCotrollerExt.kt
@@ -1,55 +1,10 @@
 package com.captures2024.soongan.core.navigator.screen.main.util
 
 import androidx.navigation.NavController
-import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.navOptions
-import com.captures2024.soongan.core.model.AppConst
 import com.captures2024.soongan.core.model.utils.NotificationSubType
-import com.captures2024.soongan.core.navigator.screen.main.feed.FeedNavigator
-import com.captures2024.soongan.core.navigator.screen.main.home.HomeGalleryNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.HomeNavigator
 import com.captures2024.soongan.core.navigator.screen.main.home.navigateToHome
-
-private enum class HideTargetScreen(val navigator: Any) {
-    HOME_GALLERY(HomeGalleryNavigator),
-    FEED(FeedNavigator),
-}
-
-/**
- *  직전 화면에 즉시 숨겨야 할 콘텐츠가 있는 경우, target ID를 직전 화면 스택에 저장 후 뒤로 가기
- *  save hideTargetContentId in previousBackStackEntry (HomeGallery || Feed) + popBackStack
- *
- *  ps. 직전 화면에서 NavController.getHideTargetContentId()를 통해 targetId를 획득 가능
- *
- * @param targetId
- */
-fun NavController.navigateToBackWithHideTargetContentId(targetId: Long) {
-    val prevDestination = this.previousBackStackEntry?.destination ?: return
-
-    val hideTargetScreen = HideTargetScreen.entries.find { screen ->
-        prevDestination.hasRoute(screen.navigator::class)
-    }
-
-    if (hideTargetScreen == null) {
-        popBackStack()
-
-        return
-    }
-
-    setHideTargetContentId(targetId)
-
-    when (hideTargetScreen) {
-        HideTargetScreen.HOME_GALLERY -> popBackStack<HomeGalleryNavigator>(inclusive = false)
-
-        HideTargetScreen.FEED -> popBackStack<FeedNavigator>(inclusive = false)
-    }
-}
-
-private fun NavController.setHideTargetContentId(targetId: Long) =
-    this.previousBackStackEntry?.savedStateHandle?.set(AppConst.SavedStateHandle.UGC_HIDE_KEY, targetId)
-
-fun NavController.getHideTargetContentId(): Long =
-    this.currentBackStackEntry?.savedStateHandle?.get(AppConst.SavedStateHandle.UGC_HIDE_KEY) ?: -1L
 
 /**
  * 알림 하위 타입에 따른 타겟 화면으로 전환.

--- a/data/repository/contest-impl/src/main/kotlin/com/captures2024/soongan/data/repository/contest/impl/ContentVisibilityRepositoryImpl.kt
+++ b/data/repository/contest-impl/src/main/kotlin/com/captures2024/soongan/data/repository/contest/impl/ContentVisibilityRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package com.captures2024.soongan.data.repository.contest.impl
+
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.data.repository.contest.ContentVisibilityRepository
+import com.captures2024.soongan.data.source.contest.local.ContentVisibilityLocalDataSource
+import kotlinx.coroutines.flow.SharedFlow
+import javax.inject.Inject
+
+class ContentVisibilityRepositoryImpl
+@Inject
+constructor(
+    private val analyticsHelper: AnalyticsHelper,
+    private val contentVisibilityLocalDataSource: ContentVisibilityLocalDataSource,
+) : ContentVisibilityRepository {
+
+    override val registerPostEvent: SharedFlow<Unit>
+        get() = contentVisibilityLocalDataSource.registerPostEvent
+
+    override val hidePostEvent: SharedFlow<Long>
+        get() = contentVisibilityLocalDataSource.hidePostEvent
+
+    override val hideCommentEvent: SharedFlow<Long>
+        get() = contentVisibilityLocalDataSource.hideCommentEvent
+
+    init {
+        analyticsHelper.d { "ContentVisibilityRepository::init" }
+    }
+}

--- a/data/repository/contest-impl/src/main/kotlin/com/captures2024/soongan/data/repository/contest/impl/WeeklyContestRepositoryImpl.kt
+++ b/data/repository/contest-impl/src/main/kotlin/com/captures2024/soongan/data/repository/contest/impl/WeeklyContestRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.captures2024.soongan.core.model.dto.MyGalleryDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import com.captures2024.soongan.core.model.dto.WeeklyContestInfoListDto
 import com.captures2024.soongan.data.repository.contest.WeeklyContestRepository
+import com.captures2024.soongan.data.source.contest.local.ContentVisibilityLocalDataSource
 import com.captures2024.soongan.data.source.contest.remote.WeeklyContestRemoteDataSource
 import com.captures2024.soongan.data.source.member.local.GuestLocalDataSource
 import javax.inject.Inject
@@ -16,6 +17,7 @@ constructor(
     private val analyticsHelper: AnalyticsHelper,
     private val weeklyContestRemoteDataSource: WeeklyContestRemoteDataSource,
     private val guestLocalDataSource: GuestLocalDataSource,
+    private val contentVisibilityLocalDataSource: ContentVisibilityLocalDataSource,
 ) : WeeklyContestRepository {
 
     init {
@@ -47,7 +49,13 @@ constructor(
             imageFile = imageFile,
         )
 
-        return postInfoDto ?: throw NullPointerException("postInfoDto is null")
+        if (postInfoDto == null) {
+            throw NullPointerException("postInfoDto is null")
+        }
+
+        contentVisibilityLocalDataSource.emitRegisterPostEvent()
+
+        return postInfoDto
     }
 
     override suspend fun getPostInfo(postId: Long): PostInfoDto {
@@ -60,8 +68,15 @@ constructor(
         return postInfoDto ?: throw NullPointerException("postInfoDto is null")
     }
 
-    override suspend fun deletePost(postId: Long): Boolean =
-        weeklyContestRemoteDataSource.deletePost(postId = postId)
+    override suspend fun deletePost(postId: Long): Boolean {
+        val result = weeklyContestRemoteDataSource.deletePost(postId = postId)
+
+        if (result) {
+            contentVisibilityLocalDataSource.emitHidePostEvent(postId = postId)
+        }
+
+        return result
+    }
 
     override suspend fun editPostTitle(postId: Long, title: String): String {
         val editedTitle = weeklyContestRemoteDataSource.editPostTitle(

--- a/data/repository/contest-impl/src/main/kotlin/com/captures2024/soongan/data/repository/contest/impl/di/ContestRepositoryModule.kt
+++ b/data/repository/contest-impl/src/main/kotlin/com/captures2024/soongan/data/repository/contest/impl/di/ContestRepositoryModule.kt
@@ -1,7 +1,9 @@
 package com.captures2024.soongan.data.repository.contest.impl.di
 
+import com.captures2024.soongan.data.repository.contest.ContentVisibilityRepository
 import com.captures2024.soongan.data.repository.contest.PostLikeRepository
 import com.captures2024.soongan.data.repository.contest.WeeklyContestRepository
+import com.captures2024.soongan.data.repository.contest.impl.ContentVisibilityRepositoryImpl
 import com.captures2024.soongan.data.repository.contest.impl.PostLikeRepositoryImpl
 import com.captures2024.soongan.data.repository.contest.impl.WeeklyContestRepositoryImpl
 import dagger.Binds
@@ -21,4 +23,8 @@ internal abstract class ContestRepositoryModule {
     @Binds
     @Singleton
     abstract fun bindWeeklyContestRepository(weeklyContestRepositoryImpl: WeeklyContestRepositoryImpl): WeeklyContestRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindContentVisibilityRepository(contentVisibilityRepositoryImpl: ContentVisibilityRepositoryImpl): ContentVisibilityRepository
 }

--- a/data/repository/contest/src/main/kotlin/com/captures2024/soongan/data/repository/contest/ContentVisibilityRepository.kt
+++ b/data/repository/contest/src/main/kotlin/com/captures2024/soongan/data/repository/contest/ContentVisibilityRepository.kt
@@ -1,0 +1,12 @@
+package com.captures2024.soongan.data.repository.contest
+
+import kotlinx.coroutines.flow.SharedFlow
+
+interface ContentVisibilityRepository {
+
+    val registerPostEvent: SharedFlow<Unit>
+
+    val hidePostEvent: SharedFlow<Long>
+
+    val hideCommentEvent: SharedFlow<Long>
+}

--- a/data/repository/report-impl/build.gradle.kts
+++ b/data/repository/report-impl/build.gradle.kts
@@ -15,5 +15,6 @@ dependencies {
     implementation(projects.core.model)
 
     implementation(projects.data.source.report)
+    implementation(projects.data.source.contest)
     implementation(projects.data.repository.report)
 }

--- a/data/repository/report-impl/src/main/kotlin/com/captures2024/soongan/data/repository/report/impl/ReportRepositoryImpl.kt
+++ b/data/repository/report-impl/src/main/kotlin/com/captures2024/soongan/data/repository/report/impl/ReportRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.captures2024.soongan.core.model.dto.ReportInfoDto
 import com.captures2024.soongan.core.model.utils.ReportTargetType
 import com.captures2024.soongan.core.model.utils.ReportType
 import com.captures2024.soongan.data.repository.report.ReportRepository
+import com.captures2024.soongan.data.source.contest.local.ContentVisibilityLocalDataSource
 import com.captures2024.soongan.data.source.report.remote.ReportRemoteDataSource
 import javax.inject.Inject
 
@@ -12,7 +13,8 @@ class ReportRepositoryImpl
 @Inject
 constructor(
     private val analyticsHelper: AnalyticsHelper,
-    private val dataSource: ReportRemoteDataSource,
+    private val reportRemoteDataSource: ReportRemoteDataSource,
+    private val contentVisibilityLocalDataSource: ContentVisibilityLocalDataSource,
 ) : ReportRepository {
 
     init {
@@ -25,7 +27,7 @@ constructor(
         reportType: ReportType,
         reason: String?,
     ): ReportInfoDto {
-        val reportInfo = dataSource.postReport(
+        val reportInfo = reportRemoteDataSource.postReport(
             targetId = targetId,
             targetType = targetType,
             reportType = reportType,
@@ -42,6 +44,8 @@ constructor(
             reason != reportInfo.reason) {
             error("mismatch between request and response data")
         }
+
+        contentVisibilityLocalDataSource.emitHidePostEvent(postId = targetId)
 
         return reportInfo
     }

--- a/data/source/contest-impl/src/main/kotlin/com/captures2024/soongan/data/source/contest/impl/di/ContestSourceModule.kt
+++ b/data/source/contest-impl/src/main/kotlin/com/captures2024/soongan/data/source/contest/impl/di/ContestSourceModule.kt
@@ -1,7 +1,9 @@
 package com.captures2024.soongan.data.source.contest.impl.di
 
+import com.captures2024.soongan.data.source.contest.impl.local.ContentVisibilityLocalDataSourceImpl
 import com.captures2024.soongan.data.source.contest.impl.remote.PostLikeRemoteDataSourceImpl
 import com.captures2024.soongan.data.source.contest.impl.remote.WeeklyContestRemoteDataSourceImpl
+import com.captures2024.soongan.data.source.contest.local.ContentVisibilityLocalDataSource
 import com.captures2024.soongan.data.source.contest.remote.PostLikeRemoteDataSource
 import com.captures2024.soongan.data.source.contest.remote.WeeklyContestRemoteDataSource
 import dagger.Binds
@@ -21,4 +23,8 @@ internal abstract class ContestSourceModule {
     @Binds
     @Singleton
     abstract fun bindWeeklyContestRemoteDataSource(weeklyContestRemoteDataSourceImpl: WeeklyContestRemoteDataSourceImpl): WeeklyContestRemoteDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindContentVisibilityLocalDataSource(contentVisibilityLocalDataSourceImpl: ContentVisibilityLocalDataSourceImpl): ContentVisibilityLocalDataSource
 }

--- a/data/source/contest-impl/src/main/kotlin/com/captures2024/soongan/data/source/contest/impl/local/ContentVisibilityLocalDataSourceImpl.kt
+++ b/data/source/contest-impl/src/main/kotlin/com/captures2024/soongan/data/source/contest/impl/local/ContentVisibilityLocalDataSourceImpl.kt
@@ -1,0 +1,46 @@
+package com.captures2024.soongan.data.source.contest.impl.local
+
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.data.source.contest.local.ContentVisibilityLocalDataSource
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+
+class ContentVisibilityLocalDataSourceImpl
+@Inject
+constructor(
+    private val analyticsHelper: AnalyticsHelper,
+) : ContentVisibilityLocalDataSource {
+
+    private val _registerPostEvent = MutableSharedFlow<Unit>()
+    override val registerPostEvent: SharedFlow<Unit>
+        get() = _registerPostEvent.asSharedFlow()
+
+    private val _hidePostEvent = MutableSharedFlow<Long>()
+    override val hidePostEvent: SharedFlow<Long>
+        get() = _hidePostEvent.asSharedFlow()
+
+    private val _hideCommentEvent = MutableSharedFlow<Long>()
+    override val hideCommentEvent: SharedFlow<Long>
+        get() = _hideCommentEvent.asSharedFlow()
+
+    init {
+        analyticsHelper.d { "ContentVisibilityLocalDataSource::Init" }
+    }
+
+    override suspend fun emitRegisterPostEvent() {
+        analyticsHelper.d { "emitRegisterPostEvent" }
+        _registerPostEvent.emit(Unit)
+    }
+
+    override suspend fun emitHidePostEvent(postId: Long) {
+        analyticsHelper.d { "emitHidePostEvent - postId: $postId" }
+        _hidePostEvent.emit(postId)
+    }
+
+    override suspend fun emitHideCommentEvent(commentId: Long) {
+        analyticsHelper.d { "emitHideCommentEvent - commentId: $commentId" }
+        _hideCommentEvent.emit(commentId)
+    }
+}

--- a/data/source/contest/src/main/kotlin/com/captures2024/soongan/data/source/contest/local/ContentVisibilityLocalDataSource.kt
+++ b/data/source/contest/src/main/kotlin/com/captures2024/soongan/data/source/contest/local/ContentVisibilityLocalDataSource.kt
@@ -1,0 +1,18 @@
+package com.captures2024.soongan.data.source.contest.local
+
+import kotlinx.coroutines.flow.SharedFlow
+
+interface ContentVisibilityLocalDataSource {
+
+    val registerPostEvent: SharedFlow<Unit>
+
+    val hidePostEvent: SharedFlow<Long>
+
+    val hideCommentEvent: SharedFlow<Long>
+
+    suspend fun emitRegisterPostEvent()
+
+    suspend fun emitHidePostEvent(postId: Long)
+
+    suspend fun emitHideCommentEvent(commentId: Long)
+}

--- a/domain/usecase/contest-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/contest/impl/GetHideCommentEventUseCaseImpl.kt
+++ b/domain/usecase/contest-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/contest/impl/GetHideCommentEventUseCaseImpl.kt
@@ -1,0 +1,15 @@
+package com.captures2024.soongan.domain.usecase.contest.impl
+
+import com.captures2024.soongan.data.repository.contest.ContentVisibilityRepository
+import com.captures2024.soongan.domain.usecase.contest.GetHideCommentEventUseCase
+import kotlinx.coroutines.flow.SharedFlow
+import javax.inject.Inject
+
+class GetHideCommentEventUseCaseImpl
+@Inject
+constructor(
+    private val repository: ContentVisibilityRepository,
+) : GetHideCommentEventUseCase {
+
+    override fun invoke(): SharedFlow<Long> = repository.hideCommentEvent
+}

--- a/domain/usecase/contest-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/contest/impl/GetHidePostEventUseCaseImpl.kt
+++ b/domain/usecase/contest-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/contest/impl/GetHidePostEventUseCaseImpl.kt
@@ -1,0 +1,15 @@
+package com.captures2024.soongan.domain.usecase.contest.impl
+
+import com.captures2024.soongan.data.repository.contest.ContentVisibilityRepository
+import com.captures2024.soongan.domain.usecase.contest.GetHidePostEventUseCase
+import kotlinx.coroutines.flow.SharedFlow
+import javax.inject.Inject
+
+class GetHidePostEventUseCaseImpl
+@Inject
+constructor(
+    private val repository: ContentVisibilityRepository,
+) : GetHidePostEventUseCase {
+
+    override fun invoke(): SharedFlow<Long> = repository.hidePostEvent
+}

--- a/domain/usecase/contest-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/contest/impl/GetRegisterRegisterPostEventUseCaseImpl.kt
+++ b/domain/usecase/contest-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/contest/impl/GetRegisterRegisterPostEventUseCaseImpl.kt
@@ -1,0 +1,15 @@
+package com.captures2024.soongan.domain.usecase.contest.impl
+
+import com.captures2024.soongan.data.repository.contest.ContentVisibilityRepository
+import com.captures2024.soongan.domain.usecase.contest.GetRegisterPostEventUseCase
+import kotlinx.coroutines.flow.SharedFlow
+import javax.inject.Inject
+
+class GetRegisterRegisterPostEventUseCaseImpl
+@Inject
+constructor(
+    private val repository: ContentVisibilityRepository,
+) : GetRegisterPostEventUseCase {
+
+    override fun invoke(): SharedFlow<Unit> = repository.registerPostEvent
+}

--- a/domain/usecase/contest-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/contest/impl/di/ContestUseCaseModule.kt
+++ b/domain/usecase/contest-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/contest/impl/di/ContestUseCaseModule.kt
@@ -4,8 +4,11 @@ import com.captures2024.soongan.domain.usecase.contest.DeletePostLikeUseCase
 import com.captures2024.soongan.domain.usecase.contest.DeletePostUseCase
 import com.captures2024.soongan.domain.usecase.contest.EditPostTitleUseCase
 import com.captures2024.soongan.domain.usecase.contest.GetFilteredGalleryByReportTargetIdsUseCase
+import com.captures2024.soongan.domain.usecase.contest.GetHideCommentEventUseCase
+import com.captures2024.soongan.domain.usecase.contest.GetHidePostEventUseCase
 import com.captures2024.soongan.domain.usecase.contest.GetMyGalleryUseCase
 import com.captures2024.soongan.domain.usecase.contest.GetPostInfoUseCase
+import com.captures2024.soongan.domain.usecase.contest.GetRegisterPostEventUseCase
 import com.captures2024.soongan.domain.usecase.contest.GetWeeklyContestInfoListUseCase
 import com.captures2024.soongan.domain.usecase.contest.PutPostLikeUseCase
 import com.captures2024.soongan.domain.usecase.contest.RegisterPostUseCase
@@ -13,8 +16,11 @@ import com.captures2024.soongan.domain.usecase.contest.impl.DeletePostLikeUseCas
 import com.captures2024.soongan.domain.usecase.contest.impl.DeletePostUseCaseImpl
 import com.captures2024.soongan.domain.usecase.contest.impl.EditPostTitleUseCaseImpl
 import com.captures2024.soongan.domain.usecase.contest.impl.GetFilteredGalleryByReportTargetIdsUseCaseImpl
+import com.captures2024.soongan.domain.usecase.contest.impl.GetHideCommentEventUseCaseImpl
+import com.captures2024.soongan.domain.usecase.contest.impl.GetHidePostEventUseCaseImpl
 import com.captures2024.soongan.domain.usecase.contest.impl.GetMyGalleryUseCaseImpl
 import com.captures2024.soongan.domain.usecase.contest.impl.GetPostInfoUseCaseImpl
+import com.captures2024.soongan.domain.usecase.contest.impl.GetRegisterRegisterPostEventUseCaseImpl
 import com.captures2024.soongan.domain.usecase.contest.impl.GetWeeklyContestInfoListUseCaseImpl
 import com.captures2024.soongan.domain.usecase.contest.impl.PutPostLikeUseCaseImpl
 import com.captures2024.soongan.domain.usecase.contest.impl.RegisterPostUseCaseImpl
@@ -53,4 +59,13 @@ internal abstract class ContestUseCaseModule {
 
     @Binds
     abstract fun bindRegisterPostUseCase(registerPostUseCaseImpl: RegisterPostUseCaseImpl): RegisterPostUseCase
+
+    @Binds
+    abstract fun bindGetRegisterPostEventUseCase(getRegisterPostEventUseCaseImpl: GetRegisterRegisterPostEventUseCaseImpl): GetRegisterPostEventUseCase
+
+    @Binds
+    abstract fun bindGetHidePostEventUseCase(getHidePostEventUseCaseImpl: GetHidePostEventUseCaseImpl): GetHidePostEventUseCase
+
+    @Binds
+    abstract fun bindGetHideCommentEventUseCase(getHideCommentEventUseCaseImpl: GetHideCommentEventUseCaseImpl): GetHideCommentEventUseCase
 }

--- a/domain/usecase/contest/src/main/kotlin/com/captures2024/soongan/domain/usecase/contest/GetHideCommentEventUseCase.kt
+++ b/domain/usecase/contest/src/main/kotlin/com/captures2024/soongan/domain/usecase/contest/GetHideCommentEventUseCase.kt
@@ -1,0 +1,8 @@
+package com.captures2024.soongan.domain.usecase.contest
+
+import kotlinx.coroutines.flow.SharedFlow
+
+interface GetHideCommentEventUseCase {
+
+    operator fun invoke(): SharedFlow<Long>
+}

--- a/domain/usecase/contest/src/main/kotlin/com/captures2024/soongan/domain/usecase/contest/GetHidePostEventUseCase.kt
+++ b/domain/usecase/contest/src/main/kotlin/com/captures2024/soongan/domain/usecase/contest/GetHidePostEventUseCase.kt
@@ -1,0 +1,8 @@
+package com.captures2024.soongan.domain.usecase.contest
+
+import kotlinx.coroutines.flow.SharedFlow
+
+interface GetHidePostEventUseCase {
+
+    operator fun invoke(): SharedFlow<Long>
+}

--- a/domain/usecase/contest/src/main/kotlin/com/captures2024/soongan/domain/usecase/contest/GetRegisterPostEventUseCase.kt
+++ b/domain/usecase/contest/src/main/kotlin/com/captures2024/soongan/domain/usecase/contest/GetRegisterPostEventUseCase.kt
@@ -1,0 +1,8 @@
+package com.captures2024.soongan.domain.usecase.contest
+
+import kotlinx.coroutines.flow.SharedFlow
+
+interface GetRegisterPostEventUseCase {
+
+    operator fun invoke(): SharedFlow<Unit>
+}

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/navigation/MainFeedNavigation.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/navigation/MainFeedNavigation.kt
@@ -8,12 +8,10 @@ import com.captures2024.soongan.presentation.feature.main.feed.route.FeedRoute
 
 fun NavGraphBuilder.mainFeed(
     navigateToPost: (Long, NavOptions?) -> Unit,
-    getHideTargetContentId: () -> Long,
 ) {
     composable<FeedNavigator> {
         FeedRoute(
             navigateToPost = navigateToPost,
-            getHideTargetContentId = getHideTargetContentId,
         )
     }
 }

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/route/FeedRoute.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/route/FeedRoute.kt
@@ -4,8 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavOptions
 import com.captures2024.soongan.presentation.feature.main.feed.component.screen.FeedScreen
@@ -15,7 +13,6 @@ import com.captures2024.soongan.presentation.viewmodel.main.feed.FeedViewModel.I
 @Composable
 internal fun FeedRoute(
     navigateToPost: (Long, NavOptions?) -> Unit,
-    getHideTargetContentId: () -> Long,
     feedViewModel: FeedViewModel = hiltViewModel(),
 ) {
     val uiState by feedViewModel.state.collectAsStateWithLifecycle()
@@ -25,14 +22,6 @@ internal fun FeedRoute(
             when (effect) {
                 is FeedViewModel.Effect.NavigateToHomePost -> navigateToPost(effect.postId, null)
             }
-        }
-    }
-
-    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-        val postId = getHideTargetContentId()
-
-        if (postId != -1L) {
-            feedViewModel.intent(Intent.HidePost(postId))
         }
     }
 

--- a/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/navigation/MainHomeNavigation.kt
+++ b/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/navigation/MainHomeNavigation.kt
@@ -12,7 +12,6 @@ import com.captures2024.soongan.presentation.feature.main.home.route.HomeRoute
 import com.captures2024.soongan.presentation.feature.main.home.route.RegistrationPostRoute
 
 fun NavGraphBuilder.mainHome(
-    getHideTargetContentId: () -> Long,
     navigateToBack: () -> Unit,
     navigateToRegistrationPost: () -> Unit,
     navigateToGallery: () -> Unit,
@@ -41,7 +40,6 @@ fun NavGraphBuilder.mainHome(
 
     composable<HomeGalleryNavigator> {
         HomeGalleryRoute(
-            getHideTargetContentId = getHideTargetContentId,
             navigateToBack = navigateToBack,
             navigateToPost = { navigateToPost(it, null) },
             navigateToRegistrationPost = navigateToRegistrationPost,

--- a/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/route/HomeGalleryRoute.kt
+++ b/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/route/HomeGalleryRoute.kt
@@ -5,14 +5,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LifecycleEventEffect
 import com.captures2024.soongan.presentation.feature.main.home.component.screen.HomeGalleryScreen
 import com.captures2024.soongan.presentation.viewmodel.main.home.HomeGalleryViewModel
 
 @Composable
 internal fun HomeGalleryRoute(
-    getHideTargetContentId: () -> Long,
     navigateToBack: () -> Unit,
     navigateToPost: (Long) -> Unit,
     navigateToRegistrationPost: () -> Unit,
@@ -27,14 +24,6 @@ internal fun HomeGalleryRoute(
                 is HomeGalleryViewModel.Effect.NavigateToPost -> navigateToPost(effect.postId)
                 is HomeGalleryViewModel.Effect.NavigateToRegisterPost -> navigateToRegistrationPost()
             }
-        }
-    }
-
-    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-        val postId = getHideTargetContentId()
-
-        if (postId != -1L) {
-            viewModel.intent(HomeGalleryViewModel.Intent.HidePost(postId))
         }
     }
 

--- a/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/route/HomeRoute.kt
+++ b/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/route/HomeRoute.kt
@@ -1,17 +1,14 @@
 package com.captures2024.soongan.presentation.feature.main.home.route
 
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import com.captures2024.soongan.presentation.feature.main.home.component.screen.HomeScreen
 import com.captures2024.soongan.presentation.viewmodel.main.home.HomeViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun HomeRoute(
     navigateToPost: (PostInfoDto) -> Unit,
@@ -29,11 +26,6 @@ internal fun HomeRoute(
                 is HomeViewModel.Effect.NavigateToRegister -> navigateToRegister()
             }
         }
-    }
-
-    LifecycleResumeEffect(Unit) {
-        viewModel.intent(HomeViewModel.Intent.ViewOnResume)
-        onPauseOrDispose {}
     }
 
     HomeScreen(

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/navigation/MainPostNavigation.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/navigation/MainPostNavigation.kt
@@ -13,14 +13,12 @@ fun NavGraphBuilder.mainPost(
     navigateToBack: () -> Unit,
     navigateToImageViewer: (String) -> Unit,
     navigateToEditPost: (Long, String, String) -> Unit,
-    navigateToBackWithHideTargetContentId: (Long) -> Unit,
 ) {
     composable<PostInfoNavigator> {
         PostInfoRoute(
             navigateToBack = navigateToBack,
             navigateToImageViewer = navigateToImageViewer,
             navigateToEditPost = navigateToEditPost,
-            navigateToBackWithHideTargetContentId = navigateToBackWithHideTargetContentId,
         )
     }
 

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/PostInfoRoute.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/route/PostInfoRoute.kt
@@ -13,7 +13,6 @@ internal fun PostInfoRoute(
     navigateToBack: () -> Unit,
     navigateToEditPost: (Long, String, String) -> Unit,
     navigateToImageViewer: (String) -> Unit,
-    navigateToBackWithHideTargetContentId: (Long) -> Unit,
     viewModel: PostInfoViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
@@ -24,7 +23,6 @@ internal fun PostInfoRoute(
                 is PostInfoViewModel.Effect.NavigateToBack -> navigateToBack()
                 is PostInfoViewModel.Effect.NavigateToEditPost -> navigateToEditPost(effect.postId, effect.url, effect.title)
                 is PostInfoViewModel.Effect.NavigateToImageViewer -> navigateToImageViewer(effect.url)
-                is PostInfoViewModel.Effect.NavigateToBackWithHidePost -> navigateToBackWithHideTargetContentId(effect.postId)
             }
         }
     }

--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
@@ -21,9 +21,7 @@ import com.captures2024.soongan.core.navigator.screen.main.post.navigateToPostIn
 import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToEditProfile
 import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToFAQ
 import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToNotification
-import com.captures2024.soongan.core.navigator.screen.main.util.getHideTargetContentId
 import com.captures2024.soongan.core.navigator.screen.main.util.navigateFromNotification
-import com.captures2024.soongan.core.navigator.screen.main.util.navigateToBackWithHideTargetContentId
 import com.captures2024.soongan.core.navigator.screen.main.welcome.WelcomeNavigator
 import com.captures2024.soongan.presentation.feature.main.awards.navigation.mainAwards
 import com.captures2024.soongan.presentation.feature.main.component.MainComponent
@@ -75,20 +73,17 @@ internal fun MainScreen(navigationState: MainNavigationState) {
             )
             mainFeed(
                 navigateToPost = navController::navigateToPostInfo,
-                getHideTargetContentId = navController::getHideTargetContentId,
             )
             mainHome(
                 navigateToBack = navigateToBack,
                 navigateToRegistrationPost = navController::navigateToRegistrationPost,
                 navigateToGallery = navController::navigateToHomeGallery,
                 navigateToPost = navController::navigateToPostInfo,
-                getHideTargetContentId = navController::getHideTargetContentId,
             )
             mainPost(
                 navigateToBack = navigateToBack,
                 navigateToImageViewer = navController::navigateToImageViewer,
                 navigateToEditPost = navController::navigateToEditPost,
-                navigateToBackWithHideTargetContentId = navController::navigateToBackWithHideTargetContentId,
             )
             mainProfile(
                 navigateToBack = navigateToBack,

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/award/AwardsInfoViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/award/AwardsInfoViewModel.kt
@@ -5,6 +5,7 @@ import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.domain.usecase.contest.GetHidePostEventUseCase
 import com.captures2024.soongan.domain.usecase.contest.GetWeeklyContestInfoListUseCase
 import com.captures2024.soongan.domain.usecase.member.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.domain.usecase.system.dialog.SetIsShowGuestModeDialogFlowUseCase
@@ -50,6 +51,7 @@ constructor(
     setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
     private val getWeeklyContestInfoListUseCase: GetWeeklyContestInfoListUseCase,
+    private val getHidePostEventUseCase: GetHidePostEventUseCase,
 ) : BaseViewModel<AwardsInfoViewModel.State, AwardsInfoViewModel.Effect, AwardsInfoViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
@@ -133,6 +135,8 @@ constructor(
     }
 
     private suspend fun handleInit() {
+        launch { collectHidePostEvent() }
+
         val weeklyContestInfoListDto = getWeeklyContestInfoListUseCase().getOrNull()
 
         if (weeklyContestInfoListDto == null) {
@@ -179,5 +183,11 @@ constructor(
 
     private suspend fun handleOnClickRetry() {
         handleInit()
+    }
+
+    private suspend fun collectHidePostEvent() {
+        getHidePostEventUseCase().collect { postId ->
+            // TODO(hidden post 처리 - display text or blur)
+        }
     }
 }

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/feed/FeedViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/feed/FeedViewModel.kt
@@ -9,6 +9,8 @@ import com.captures2024.soongan.core.model.AppConst
 import com.captures2024.soongan.core.model.dto.GalleryPostDto
 import com.captures2024.soongan.core.model.enums.CommonDialogType
 import com.captures2024.soongan.domain.usecase.contest.GetFilteredGalleryByReportTargetIdsUseCase
+import com.captures2024.soongan.domain.usecase.contest.GetHidePostEventUseCase
+import com.captures2024.soongan.domain.usecase.contest.GetRegisterPostEventUseCase
 import com.captures2024.soongan.domain.usecase.contest.GetWeeklyContestInfoListUseCase
 import com.captures2024.soongan.domain.usecase.member.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.domain.usecase.system.dialog.PostSingleButtonDialogUseCase
@@ -37,6 +39,8 @@ constructor(
     private val postSingleButtonDialogUseCase: PostSingleButtonDialogUseCase,
     private val getWeeklyContestInfoListUseCase: GetWeeklyContestInfoListUseCase,
     private val getFilteredGalleryByReportTargetIdsUseCase: GetFilteredGalleryByReportTargetIdsUseCase,
+    private val getRegisterPostEventUseCase: GetRegisterPostEventUseCase,
+    private val getHidePostEventUseCase: GetHidePostEventUseCase,
 ) : BaseViewModel<FeedViewModel.State, FeedViewModel.Effect, FeedViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
@@ -105,10 +109,6 @@ constructor(
         data class OnClickPost(
             val postId: Long,
         ) : Intent
-
-        data class HidePost(
-            val postId: Long,
-        ) : Intent
     }
 
     init {
@@ -139,31 +139,23 @@ constructor(
     override fun handleIntent(intent: Intent) {
         when (intent) {
             is Intent.Init -> loadingLaunch { handleInit() }
-
             is Intent.RefreshFeed -> launch { handleRefreshFeed() }
-
             is Intent.OnClickTitle -> launch { handleOnClickTitle() }
-
             is Intent.OnTitlePickerDismissRequest -> launch { handleOnTitlePickerDismissRequest() }
-
             is Intent.OnSelectTitleOption -> launch { handleOnSelectTitleOption(intent) }
-
             is Intent.OnClickFilter -> handleOnClickFilter()
-
             is Intent.OnFilterDismissRequest -> handleOnFilterDismissRequest()
-
             is Intent.OnClickFilterItem -> launch { handleOnClickSortFilter(intent) }
-
             is Intent.LoadNextPage -> launch { handleLoadNextPage() }
-
             is Intent.OnClickPost -> handleOnClickPost(intent)
-
-            is Intent.HidePost -> handleOnReportedPost(intent)
         }
     }
 
     private suspend fun handleInit() {
-        syncFeedInfo()
+        launch { collectRegisterPostEvent() }
+        launch { collectHidePostEvent() }
+
+        fetchInitData()
     }
 
     private suspend fun handleRefreshFeed() {
@@ -299,19 +291,25 @@ constructor(
         postSideEffect(Effect.NavigateToHomePost(intent.postId))
     }
 
-    private fun handleOnReportedPost(intent: Intent.HidePost) {
-        val postId = intent.postId
-
-        reduce {
-            copy(
-                feedState = feedState.copy(
-                    posts = feedState.posts.filter { it.postId != postId },
-                ),
-            )
+    private suspend fun collectRegisterPostEvent() {
+        getRegisterPostEventUseCase().collect {
+            handleRefreshFeed()
         }
     }
 
-    private suspend fun syncFeedInfo() {
+    private suspend fun collectHidePostEvent() {
+        getHidePostEventUseCase().collect { postId ->
+            reduce {
+                copy(
+                    feedState = feedState.copy(
+                        posts = feedState.posts.filter { it.postId != postId },
+                    ),
+                )
+            }
+        }
+    }
+
+    private suspend fun fetchInitData() {
         getTitleOptions()
 
         val paginationStatus = getRemoteGalleryPost()

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/home/HomeGalleryViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/home/HomeGalleryViewModel.kt
@@ -9,6 +9,7 @@ import com.captures2024.soongan.core.model.AppConst
 import com.captures2024.soongan.core.model.dto.GalleryPostDto
 import com.captures2024.soongan.core.model.enums.CommonDialogType
 import com.captures2024.soongan.domain.usecase.contest.GetFilteredGalleryByReportTargetIdsUseCase
+import com.captures2024.soongan.domain.usecase.contest.GetHidePostEventUseCase
 import com.captures2024.soongan.domain.usecase.contest.GetWeeklyContestInfoListUseCase
 import com.captures2024.soongan.domain.usecase.member.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.domain.usecase.system.dialog.PostSingleButtonDialogUseCase
@@ -36,6 +37,7 @@ constructor(
     private val postSingleButtonDialogUseCase: PostSingleButtonDialogUseCase,
     private val getFilteredGalleryByReportTargetIdsUseCase: GetFilteredGalleryByReportTargetIdsUseCase,
     private val getWeeklyContestInfoListUseCase: GetWeeklyContestInfoListUseCase,
+    private val getHidePostEventUseCase: GetHidePostEventUseCase,
 ) : BaseViewModel<HomeGalleryViewModel.State, HomeGalleryViewModel.Effect, HomeGalleryViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
@@ -96,10 +98,6 @@ constructor(
         data class OnClickFilterItem(
             val selectedOrderType: PostOrderType,
         ) : Intent
-
-        data class HidePost(
-            val postId: Long,
-        ) : Intent
     }
 
     init {
@@ -134,38 +132,13 @@ constructor(
             is Intent.OnClickPost -> handleOnClickPost(intent)
             is Intent.OnDismissRequestFilterBottomSheet -> handleOnDismissRequestFilterBottomSheet()
             is Intent.OnClickFilterItem -> loadingLaunch { handleOnClickFilterItem(intent) }
-            is Intent.HidePost -> handleHidePost(intent)
         }
     }
 
     private suspend fun handleInit() {
-        val weeklyInfo = getWeeklyContestInfoListUseCase
-            .invoke()
-            .getOrNull()
-            ?.weeklyContestInfoList
-            ?.lastOrNull()
+        launch { collectHidePostEvent() }
 
-        if (weeklyInfo == null) {
-            postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
-        }
-
-        reduce {
-            copy(
-                round = weeklyInfo?.round,
-                subject = weeklyInfo?.subject ?: AppConst.EMPTY_STRING,
-            )
-        }
-
-        val status = getRemotePost(
-            page = 0,
-            isRefreshing = true,
-        )
-
-        reduce {
-            copy(
-                paginationStatus = status,
-            )
-        }
+        fetchInitData()
     }
 
     private fun handleOnClickBack() {
@@ -247,11 +220,42 @@ constructor(
         }
     }
 
-    private fun handleHidePost(intent: Intent.HidePost) {
+    private suspend fun collectHidePostEvent() {
+        getHidePostEventUseCase().collect { postId ->
+            reduce {
+                copy(
+                    posts = posts.filter { it.postId != postId },
+                )
+            }
+        }
+    }
+
+    private suspend fun fetchInitData() {
+        val weeklyInfo = getWeeklyContestInfoListUseCase
+            .invoke()
+            .getOrNull()
+            ?.weeklyContestInfoList
+            ?.lastOrNull()
+
+        if (weeklyInfo == null) {
+            postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+        }
+
         reduce {
             copy(
-                posts = currentState.posts
-                    .filter { it.postId != intent.postId },
+                round = weeklyInfo?.round,
+                subject = weeklyInfo?.subject ?: AppConst.EMPTY_STRING,
+            )
+        }
+
+        val status = getRemotePost(
+            page = 0,
+            isRefreshing = true,
+        )
+
+        reduce {
+            copy(
+                paginationStatus = status,
             )
         }
     }

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/home/HomeViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/home/HomeViewModel.kt
@@ -9,6 +9,8 @@ import com.captures2024.soongan.core.model.AppConst
 import com.captures2024.soongan.core.model.dto.HomeContestInfoDto
 import com.captures2024.soongan.core.model.dto.PostInfoDto
 import com.captures2024.soongan.core.model.enums.CommonDialogType
+import com.captures2024.soongan.domain.usecase.contest.GetHidePostEventUseCase
+import com.captures2024.soongan.domain.usecase.contest.GetRegisterPostEventUseCase
 import com.captures2024.soongan.domain.usecase.home.GetHomeUseCase
 import com.captures2024.soongan.domain.usecase.member.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.domain.usecase.system.dialog.PostSingleButtonDialogUseCase
@@ -33,6 +35,8 @@ constructor(
     savedStateHandle: SavedStateHandle,
     private val getHomeUseCase: GetHomeUseCase,
     private val postSingleButtonDialogUseCase: PostSingleButtonDialogUseCase,
+    private val getRegisterPostEventUseCase: GetRegisterPostEventUseCase,
+    private val getHidePostEventUseCase: GetHidePostEventUseCase,
 ) : BaseViewModel<HomeViewModel.State, HomeViewModel.Effect, HomeViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
@@ -72,8 +76,6 @@ constructor(
     sealed interface Intent : UIIntent {
         data object Init : Intent
 
-        data object ViewOnResume : Intent
-
         data object OnClickContestInfo : Intent
 
         data object OnClickPostList : Intent
@@ -109,7 +111,6 @@ constructor(
     override fun handleIntent(intent: Intent) {
         when (intent) {
             is Intent.Init -> loadingLaunch { handleInit() }
-            is Intent.ViewOnResume -> launch { handleViewOnResume() }
             is Intent.OnClickContestInfo -> handleOnClickContestInfo()
             is Intent.OnClickPostList -> handleOnClickPostList()
             is Intent.OnClickRegister -> blockGuestModeLogic { handleOnClickRegister() }
@@ -124,24 +125,10 @@ constructor(
     }
 
     private suspend fun handleInit() {
-        syncHomeInfo()
-    }
+        launch { collectRegisterPostEvent() }
+        launch { collectHidePostEvent() }
 
-    private suspend fun handleViewOnResume() {
-        val state = currentState
-
-        when (state.initState) {
-            State.InitState.INIT,
-            State.InitState.LOADING,
-            -> {
-                analyticsHelper.d { "handleViewOnResume - state.isInit: ${state.initState}" }
-                return
-            }
-
-            else -> Unit
-        }
-
-        syncHomeInfo()
+        fetchInitData()
     }
 
     private fun handleOnClickContestInfo() {
@@ -161,14 +148,30 @@ constructor(
     }
 
     private suspend fun handleOnClickRetry() {
-        syncHomeInfo()
+        fetchInitData()
     }
 
     private fun handleDismissContestInfoBottomSheet() {
         dismissContestInfoBottomSheet()
     }
 
-    private suspend fun syncHomeInfo() {
+    private suspend fun collectRegisterPostEvent() {
+        getRegisterPostEventUseCase().collect {
+            fetchInitData()
+        }
+    }
+
+    private suspend fun collectHidePostEvent() {
+        getHidePostEventUseCase().collect { postId ->
+            reduce {
+                copy(
+                    postInfoList = postInfoList.filter { it.postId != postId },
+                )
+            }
+        }
+    }
+
+    private suspend fun fetchInitData() {
         reduce {
             copy(
                 initState = State.InitState.LOADING,

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/home/RegistrationPostViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/home/RegistrationPostViewModel.kt
@@ -127,20 +127,7 @@ constructor(
     }
 
     private suspend fun handleInit() {
-        val rounds = getWeeklyContestInfoListUseCase
-            .invoke()
-            .getOrNull()
-
-        if (rounds == null || rounds.weeklyContestInfoList.isEmpty()) {
-            postSideEffect(Effect.NavigateToBack)
-            return
-        }
-
-        reduce {
-            copy(
-                currentContestInfo = rounds.weeklyContestInfoList.last(),
-            )
-        }
+        fetchInitData()
     }
 
     private fun handleOpenMediaPicker() {
@@ -213,6 +200,23 @@ constructor(
         dismissSubmitBottomSheet()
 
         submitRemote()
+    }
+
+    private suspend fun fetchInitData() {
+        val rounds = getWeeklyContestInfoListUseCase
+            .invoke()
+            .getOrNull()
+
+        if (rounds == null || rounds.weeklyContestInfoList.isEmpty()) {
+            postSideEffect(Effect.NavigateToBack)
+            return
+        }
+
+        reduce {
+            copy(
+                currentContestInfo = rounds.weeklyContestInfoList.last(),
+            )
+        }
     }
 
     private fun showBackDialog() {

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/post/PostInfoViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/post/PostInfoViewModel.kt
@@ -80,10 +80,6 @@ constructor(
         data class NavigateToImageViewer(
             val url: String,
         ) : Effect
-
-        data class NavigateToBackWithHidePost(
-            val postId: Long,
-        ) : Effect
     }
 
     sealed interface Intent : UIIntent {
@@ -130,7 +126,7 @@ constructor(
 
     override fun handleIntent(intent: Intent) {
         when (intent) {
-            is Intent.Init -> handleInit()
+            is Intent.Init -> loadingLaunch { handleInit() }
             is Intent.OnClickBack -> handleOnClickBack()
             is Intent.OnClickMenu -> blockGuestModeLogic { handleOnClickMenu() }
             is Intent.OnClickHeart -> blockGuestModeLogic {
@@ -150,30 +146,10 @@ constructor(
         analyticsHelper.e(throwable = throwable) { "state: $currentState" }
     }
 
-    private fun handleInit() {
+    private suspend fun handleInit() {
         launch { collectMemberInfo() }
 
-        loadingLaunch {
-            val weeklyInfo = getWeeklyContestInfoListUseCase
-                .invoke()
-                .getOrNull()
-                ?.weeklyContestInfoList
-                ?.lastOrNull()
-
-            if (weeklyInfo == null) {
-                postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
-                return@loadingLaunch
-            }
-
-            reduce {
-                copy(
-                    round = weeklyInfo.round,
-                    subject = weeklyInfo.subject,
-                )
-            }
-
-            loadingLaunch { getRemotePostInfo() }
-        }
+        fetchInitData()
     }
 
     private fun handleOnClickBack() {
@@ -238,7 +214,7 @@ constructor(
             return
         }
 
-        postSideEffect(Effect.NavigateToBackWithHidePost(postId))
+        postSideEffect(Effect.NavigateToBack)
     }
 
     private fun handleOnClickEditPost() {
@@ -262,7 +238,7 @@ constructor(
     }
 
     private fun handleOnDoneReport() {
-        postSideEffect(Effect.NavigateToBackWithHidePost(currentState.postId))
+        postSideEffect(Effect.NavigateToBack)
     }
 
     private suspend fun collectMemberInfo() {
@@ -273,6 +249,28 @@ constructor(
                 )
             }
         }
+    }
+
+    private suspend fun fetchInitData() {
+        val weeklyInfo = getWeeklyContestInfoListUseCase
+            .invoke()
+            .getOrNull()
+            ?.weeklyContestInfoList
+            ?.lastOrNull()
+
+        if (weeklyInfo == null) {
+            postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)
+            return
+        }
+
+        reduce {
+            copy(
+                round = weeklyInfo.round,
+                subject = weeklyInfo.subject,
+            )
+        }
+
+        loadingLaunch { getRemotePostInfo() }
     }
 
     private suspend fun getRemotePostInfo() {

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileViewModel.kt
@@ -6,7 +6,9 @@ import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
 import com.captures2024.soongan.core.model.dto.GalleryPostDto
+import com.captures2024.soongan.domain.usecase.contest.GetHidePostEventUseCase
 import com.captures2024.soongan.domain.usecase.contest.GetMyGalleryUseCase
+import com.captures2024.soongan.domain.usecase.contest.GetRegisterPostEventUseCase
 import com.captures2024.soongan.domain.usecase.member.GetCurrentMemberFlowUseCase
 import com.captures2024.soongan.domain.usecase.member.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.domain.usecase.system.dialog.SetIsShowGuestModeDialogFlowUseCase
@@ -34,6 +36,8 @@ constructor(
     private val getCurrentMemberFlowUseCase: GetCurrentMemberFlowUseCase,
     private val launchTermsUseCase: LaunchTermsUseCase,
     private val getMyGalleryUseCase: GetMyGalleryUseCase,
+    private val getRegisterPostEventUseCase: GetRegisterPostEventUseCase,
+    private val getHidePostEventUseCase: GetHidePostEventUseCase,
 ) : BaseViewModel<ProfileViewModel.State, ProfileViewModel.Effect, ProfileViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
@@ -145,19 +149,10 @@ constructor(
 
     private suspend fun handleInit() {
         launch { collectUserProfile() }
+        launch { collectRegisterPostEvent() }
+        launch { collectHidePostEvent() }
 
-        val status = getRemotePost(
-            page = 0,
-            isRefreshing = true,
-        )
-
-        reduce {
-            copy(
-                myGalleryState = myGalleryState.copy(
-                    paginationStatus = status,
-                ),
-            )
-        }
+        fetchInitData()
     }
 
     private fun handleOnClickMenu() {
@@ -245,6 +240,39 @@ constructor(
                     )
                 }
             }
+        }
+    }
+
+    private suspend fun collectRegisterPostEvent() {
+        getRegisterPostEventUseCase().collect {
+            fetchInitData()
+        }
+    }
+
+    private suspend fun collectHidePostEvent() {
+        getHidePostEventUseCase().collect { postId ->
+            reduce {
+                copy(
+                    myGalleryState = myGalleryState.copy(
+                        posts = myGalleryState.posts.filter { it.postId != postId },
+                    ),
+                )
+            }
+        }
+    }
+
+    private suspend fun fetchInitData() {
+        val status = getRemotePost(
+            page = 0,
+            isRefreshing = true,
+        )
+
+        reduce {
+            copy(
+                myGalleryState = myGalleryState.copy(
+                    paginationStatus = status,
+                ),
+            )
         }
     }
 


### PR DESCRIPTION
# [SG-140] content-visibility event 처리

## 작업 사항
- 게시글 등록, 신고/삭제 시 발생하는 로컬 이벤트 구현
- 기존 코드 제거 및 vm 리펙터링

## GIF
![content_visibility](https://github.com/user-attachments/assets/63c8905f-0a5c-4a1d-ac00-b164eafacb7d)

## 비고
- 신고/삭제 이벤트 발생 시에는 api를 호출하지 않으며 게시글 등록의 경우 정렬을 고려해야해서 api를 호출하는 쪽으로 구현되어 있습니다.

[SG-140]: https://captures2024.atlassian.net/browse/SG-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ