### PR TITLE
[SG-149] 갤러리 이미지 테두리만 크게 보이는 현상 수정

### DIFF
--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoImageComponent.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoImageComponent.kt
@@ -2,9 +2,7 @@ package com.captures2024.soongan.presentation.feature.main.post.component.info
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -33,8 +31,8 @@ internal fun PostInfoImageComponent(
 
     Box(
         modifier = Modifier
-            .width(360.dp)
-            .height(460.dp)
+            .widthIn(max = 360.dp)
+            .heightIn(max = 460.dp)
             .dropShadow(
                 shape = RoundedCornerShape(0.dp),
                 color = SGColor.Grayscale.black100.copy(alpha = 0.3f),


### PR DESCRIPTION
# [SG-149] 갤러리 이미지 테두리만 크게 보이는 현상 수정

## 변경 사항
- widthIn max 설정
- heightIn max 설정

[SG-149]: https://captures2024.atlassian.net/browse/SG-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ