### PR TITLE
[SG-152] 스플래시 스크린

### DIFF
--- a/presentation/feature/root/src/main/kotlin/com/captures2024/soongan/presentation/feature/root/component/screen/SplashScreen.kt
+++ b/presentation/feature/root/src/main/kotlin/com/captures2024/soongan/presentation/feature/root/component/screen/SplashScreen.kt
@@ -1,0 +1,52 @@
+package com.captures2024.soongan.presentation.feature.root.component.screen
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.captures2024.soongan.presentation.designsystem.ui.R
+import com.captures2024.soongan.presentation.designsystem.ui.component.background.SGBackground
+import com.captures2024.soongan.presentation.designsystem.ui.theme.SGColor
+import com.captures2024.soongan.presentation.designsystem.ui.util.DevicePreviews
+
+@Composable
+internal fun SplashScreen() {
+    Column(
+        modifier = Modifier.fillMaxSize()
+            .background(color = SGColor.BG.background),
+    ) {
+        Spacer(modifier = Modifier.weight(0.3f))
+
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.sign_logo),
+                contentDescription = "sign_logo",
+                modifier = Modifier.widthIn(max = 131.dp)
+                    .heightIn(max = 170.dp),
+            )
+        }
+
+        Spacer(modifier = Modifier.weight(0.7f))
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun PreviewSplashScreen() {
+    SGBackground {
+        SplashScreen()
+    }
+}

--- a/presentation/feature/root/src/main/kotlin/com/captures2024/soongan/presentation/feature/root/route/AppLandingRoute.kt
+++ b/presentation/feature/root/src/main/kotlin/com/captures2024/soongan/presentation/feature/root/route/AppLandingRoute.kt
@@ -1,8 +1,9 @@
 package com.captures2024.soongan.presentation.feature.root.route
 
 import androidx.compose.runtime.Composable
+import com.captures2024.soongan.presentation.feature.root.component.screen.SplashScreen
 
 @Composable
 internal fun AppLandingRoute() {
-    // TODO()
+    SplashScreen()
 }


### PR DESCRIPTION
# [SG-152] 스플래시 스크린

## 변경 사항
- 스플래시 스크린 추가

## 비고
<img width="238" height="526" alt="스크린샷 2025-07-20 오후 4 08 36" src="https://github.com/user-attachments/assets/7553f873-e4c4-4d91-a321-4dd79aba2a3a" />


[SG-152]: https://captures2024.atlassian.net/browse/SG-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ