### PR TITLE
[SG-151] scroll picker interaction

### DIFF
--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/AppConst.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/AppConst.kt
@@ -31,6 +31,7 @@ object AppConst {
 
         object Gallery {
             const val PAGE_SIZE = 50
+            const val SCROLL_PICKER_VISIBLE_OPTION_COUNT = 9
         }
     }
 
@@ -46,9 +47,5 @@ object AppConst {
 
         const val ACCESS_TOKEN_ALLOW = "$AUTH_HEADER: true"
         const val REFRESH_TOKEN_ALLOW = "$AUTH_HEADER: false"
-    }
-
-    object SavedStateHandle {
-        const val UGC_HIDE_KEY = "ugc-hide-key"
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,8 @@ android-credentials = "1.5.0"
 android-compose-bom = "2025.07.00"
 android-compose-activity = "1.10.1"
 android-compose-junit4-test = "1.8.3"
+android-compose-material3-alpha = "1.4.0-alpha02"
+android-compose-material-Icons-Core = "1.7.8"
 
 # test
 test-junit = "4.13.2"
@@ -124,6 +126,8 @@ android-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-tes
 android-compose-activity = { group = "androidx.activity", name = "activity-compose", version.ref = "android-compose-activity" }
 android-compose-lifecycle = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "android-lifecycle-runtime" }
 android-compose-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "android-navigation" }
+android-compose-material3-alpha = { module = "androidx.compose.material3:material3", version.ref = "android-compose-material3-alpha" }
+android-compose-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "android-compose-material-Icons-Core" }
 
 # google
 google-ksp-gradle-plugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "google-ksp" }
@@ -273,4 +277,9 @@ junit5 = [
 androidx-android-test = [
     "test-androidx-junit",
     "test-androidx-espresso-core"
+]
+
+compose-material3-alpha = [
+    "android-compose-material3-alpha",
+    "android-compose-material-icons-core",
 ]

--- a/presentation/feature/main-feed/build.gradle.kts
+++ b/presentation/feature/main-feed/build.gradle.kts
@@ -8,4 +8,6 @@ android {
 
 dependencies {
     implementation(projects.presentation.viewmodel)
+    implementation("androidx.compose.material3:material3:1.4.0-alpha02")
+    implementation("androidx.compose.material:material-icons-core:1.7.8")
 }

--- a/presentation/feature/main-feed/build.gradle.kts
+++ b/presentation/feature/main-feed/build.gradle.kts
@@ -8,6 +8,5 @@ android {
 
 dependencies {
     implementation(projects.presentation.viewmodel)
-    implementation("androidx.compose.material3:material3:1.4.0-alpha02")
-    implementation("androidx.compose.material:material-icons-core:1.7.8")
+    implementation(libs.bundles.compose.material3.alpha)
 }

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedScrollPickerComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedScrollPickerComponent.kt
@@ -7,12 +7,12 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -119,11 +119,10 @@ private fun ScrollPicker(
     selectedOption: TitleOption,
     options: List<TitleOption>,
     modifier: Modifier = Modifier,
-    visibleOptionCount: Int = 5,
     onChangedOption: (Int) -> Unit,
     onItemClick: ((Int) -> Unit)? = null,
 ) {
-    val median = visibleOptionCount / 2
+    val median = AppConst.Main.Gallery.SCROLL_PICKER_VISIBLE_OPTION_COUNT / 2
     val spaceOptions = List(median) { null }
     val adjustedOptions = spaceOptions + options + spaceOptions
     val listCount = adjustedOptions.size
@@ -151,7 +150,7 @@ private fun ScrollPicker(
         1f to Color.Transparent,
     )
 
-    val boxHeight = 264.dp
+    val boxHeight = 252.dp
     val itemSize = 28.dp
 
     val upperDividerYOffset = boxHeight / 2 - itemSize / 2
@@ -200,10 +199,8 @@ private fun ScrollPicker(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .align(Alignment.Center)
-                .wrapContentSize()
-                .height(itemSize * visibleOptionCount)
+                .fillMaxSize()
                 .fadingEdge(fadingEdgeGradient),
-            userScrollEnabled = false,
         ) {
             items(
                 count = listCount,
@@ -312,7 +309,6 @@ private fun ScrollPicker_Preview() {
     ScrollPicker(
         selectedOption = options[0],
         options = options,
-        visibleOptionCount = 5,
         onChangedOption = {},
     )
 }

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedScrollPickerComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedScrollPickerComponent.kt
@@ -1,7 +1,9 @@
 package com.captures2024.soongan.presentation.feature.main.feed.component.feed
 
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -25,23 +27,19 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.captures2024.soongan.core.model.AppConst
 import com.captures2024.soongan.presentation.designsystem.ui.component.HeightSpacer
-import com.captures2024.soongan.presentation.designsystem.ui.component.WidthSpacer
+import com.captures2024.soongan.presentation.designsystem.ui.component.WeightSpacer
 import com.captures2024.soongan.presentation.designsystem.ui.component.text.SGText
 import com.captures2024.soongan.presentation.designsystem.ui.component.text.getSGNonScaleTextStyle
 import com.captures2024.soongan.presentation.designsystem.ui.theme.SGColor
@@ -70,7 +68,7 @@ internal fun FeedScrollTitlePickerComponent(
             text = stringResource(R.string.feed_scroll_title_picker_header_text),
             modifier = Modifier
                 .align(Alignment.Start)
-                .padding(start = 24.dp),
+                .padding(start = 26.dp, top = 27.dp),
             style = getSGNonScaleTextStyle(
                 color = SGColor.Grayscale.black100,
                 fontSize = 20.sp,
@@ -85,12 +83,17 @@ internal fun FeedScrollTitlePickerComponent(
             options = options,
             modifier = Modifier.padding(horizontal = 10.dp),
             onChangedOption = onChangedOption,
+            onItemClick = { clickedIndex ->
+                onChangedOption(clickedIndex)
+            },
         )
 
         HeightSpacer(32.dp)
 
         Row(
-            modifier = Modifier.padding(bottom = 60.dp),
+            modifier = Modifier
+                .padding(bottom = 61.dp)
+                .padding(horizontal = 48.dp),
         ) {
             TempPickerButton(
                 text = stringResource(R.string.feed_scroll_title_picker_dismiss_text),
@@ -99,7 +102,7 @@ internal fun FeedScrollTitlePickerComponent(
                 borderColor = SGColor.black,
                 onClick = onDismissRequest,
             )
-            WidthSpacer(54.dp)
+            WeightSpacer(1f)
             TempPickerButton(
                 text = stringResource(R.string.feed_scroll_title_picker_confirm_text),
                 textColor = SGColor.Grayscale.white,
@@ -118,6 +121,7 @@ private fun ScrollPicker(
     modifier: Modifier = Modifier,
     visibleOptionCount: Int = 5,
     onChangedOption: (Int) -> Unit,
+    onItemClick: ((Int) -> Unit)? = null,
 ) {
     val median = visibleOptionCount / 2
     val spaceOptions = List(median) { null }
@@ -160,6 +164,13 @@ private fun ScrollPicker(
             .collect { round -> onChangedOption(round) }
     }
 
+    LaunchedEffect(selectedOption) {
+        val targetIndex = selectedOption.round - 1
+        if (targetIndex != listState.firstVisibleItemIndex) {
+            listState.animateScrollToItem(targetIndex)
+        }
+    }
+
     Box(
         modifier = modifier
             .fillMaxWidth()
@@ -169,15 +180,6 @@ private fun ScrollPicker(
                 blur = 0.dp,
                 offsetX = 0.dp,
                 offsetY = (-0.5).dp,
-            )
-            .nestedScroll(
-                object : NestedScrollConnection {
-                    override fun onPostScroll(
-                        consumed: Offset,
-                        available: Offset,
-                        source: NestedScrollSource,
-                    ): Offset = available
-                },
             ),
     ) {
         HorizontalDivider(
@@ -201,12 +203,14 @@ private fun ScrollPicker(
                 .wrapContentSize()
                 .height(itemSize * visibleOptionCount)
                 .fadingEdge(fadingEdgeGradient),
+            userScrollEnabled = false,
         ) {
             items(
                 count = listCount,
                 key = { it },
             ) { index ->
                 val distanceFromCenter = kotlin.math.abs(index - currentCenterIndex.value)
+                val centerIndex = index - median
                 val fontSize = when (distanceFromCenter) {
                     0 -> 23.sp
                     1 -> 18.sp
@@ -215,7 +219,19 @@ private fun ScrollPicker(
                 }
 
                 Box(
-                    modifier = Modifier.height(itemSize),
+                    modifier = Modifier
+                        .height(itemSize)
+                        .fillMaxWidth()
+                        .then(
+                            if (onItemClick != null && centerIndex in options.indices) {
+                                Modifier.clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null,
+                                ) { onItemClick(centerIndex) }
+                            } else {
+                                Modifier
+                            },
+                        ),
                     contentAlignment = Alignment.Center,
                 ) {
                     SGText(
@@ -279,11 +295,7 @@ private fun TempPickerButton(
 @DevicePreviews
 @Composable
 private fun FeedScrollTitlePicker_Preview() {
-    val options = listOf(
-        TitleOption(round = 1, subject = "주제"),
-        TitleOption(round = 2, subject = "주제"),
-        TitleOption(round = 3, subject = "주제"),
-    )
+    val options = List(15) { TitleOption(round = 1, subject = "주제") }
     FeedScrollTitlePickerComponent(
         selectedOption = options[0],
         options = options,
@@ -296,11 +308,7 @@ private fun FeedScrollTitlePicker_Preview() {
 @DevicePreviews
 @Composable
 private fun ScrollPicker_Preview() {
-    val options = listOf(
-        TitleOption(round = 1, subject = "주제"),
-        TitleOption(round = 2, subject = "주제"),
-        TitleOption(round = 3, subject = "주제"),
-    )
+    val options = List(15) { TitleOption(round = 1, subject = "주제") }
     ScrollPicker(
         selectedOption = options[0],
         options = options,

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedTitlePickerBottomSheetComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedTitlePickerBottomSheetComponent.kt
@@ -22,10 +22,7 @@ internal fun FeedTitlePickerBottomSheetComponent(
     selectedOption: TitleOption,
     options: List<TitleOption>,
     modifier: Modifier = Modifier,
-    sheetState: SheetState = rememberModalBottomSheetState(
-        skipPartiallyExpanded = true,
-        confirmValueChange = { false },
-    ),
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
     onSelectOption: (round: Int) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
@@ -35,6 +32,7 @@ internal fun FeedTitlePickerBottomSheetComponent(
         onDismissRequest = onDismissRequest,
         modifier = modifier,
         sheetState = sheetState,
+        sheetGesturesEnabled = false,
         containerColor = Color.White,
         dragHandle = { null },
     ) {

--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedTitlePickerBottomSheetComponent.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/feed/FeedTitlePickerBottomSheetComponent.kt
@@ -22,7 +22,10 @@ internal fun FeedTitlePickerBottomSheetComponent(
     selectedOption: TitleOption,
     options: List<TitleOption>,
     modifier: Modifier = Modifier,
-    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    sheetState: SheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true,
+        confirmValueChange = { false },
+    ),
     onSelectOption: (round: Int) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
@@ -33,6 +36,7 @@ internal fun FeedTitlePickerBottomSheetComponent(
         modifier = modifier,
         sheetState = sheetState,
         containerColor = Color.White,
+        dragHandle = { null },
     ) {
         FeedScrollTitlePickerComponent(
             selectedOption = currentSelectedOption,

--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/input/PostInfoInputTitleComponent.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/input/PostInfoInputTitleComponent.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
@@ -48,6 +49,7 @@ internal fun PostInfoInputTitleComponent(
         lineHeight = 22.sp,
         fontFamily = SGTypography.pretendard,
         letterSpacing = (-5).em,
+        textAlign = TextAlign.Center,
     )
 
     Column(horizontalAlignment = Alignment.End) {


### PR DESCRIPTION
# [SG-151] scroll picker interaction

## 작업 사항
- ff2c9239217762c5d98173d9c9ff68554bc91dd9
  - 클릭 이벤트로만 회차를 선택할 수 있습니다.
  - 바텀 시트는 버튼으로만 닫을 수 있습니다.
  
- e8b16f05c4d914c66f5658362780fcde4a3c80b5
  - 스크롤 및 클릭으로 회차를 선택할 수 있습니다.
  - 최대 보여지는 아이템 개수가 9개로 고정되어 있습니다. (스크롤 터치 영역 증가)
  - 바텀 시트는 버튼과 외부 터치로 닫을 수 있습니다.

## gif
![scroll_picker](https://github.com/user-attachments/assets/16867ac4-80bb-44e6-8576-8a88ca1817f2)

## 비고
- 중첩 스크롤 처리가 복잡해서 바텀 시트는 고정시켜 구현해보았습니다.
- [Version 1.4.0-alpha02](https://developer.android.com/jetpack/androidx/releases/compose-material3#1.4.0-alpha02)에 추가된 sheetGestureEnabled를 사용했을 때 가장 원하는 동작이 구현 되었으나 
안정화 버전이 아니라서 main-feed에만 의존성 추가했습니다.
- 현재 테스트 시 이상은 없지만 문제가 생긴다면 클릭 이벤트만 있던 상태(ff2c9239217762c5d98173d9c9ff68554bc91dd9)로 롤백하려고 합니다.

[SG-151]: https://captures2024.atlassian.net/browse/SG-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ