### PR TITLE
[SG-158] 프로필 탭 알림 표시 UI 작업

### DIFF
--- a/data/repository/notification-impl/src/main/kotlin/com/captures2024/soongan/data/repository/notification/impl/NotificationRepositoryImpl.kt
+++ b/data/repository/notification-impl/src/main/kotlin/com/captures2024/soongan/data/repository/notification/impl/NotificationRepositoryImpl.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -27,6 +28,9 @@ constructor(
 
     override val notificationEvent: Flow<NotificationDto?>
         get() = notificationLocalDataSource.notificationEvent
+
+    override val isNotReadNotificationCache: StateFlow<Boolean>
+        get() = notificationLocalDataSource.isNotReadNotificationCache
 
     init {
         analyticsHelper.d { "NotificationsRepository:init" }
@@ -48,10 +52,18 @@ constructor(
         return notifications ?: throw NullPointerException("notificationsDto is null")
     }
 
-    override suspend fun getNotificationsCount(): NotificationsCountInfoDto {
-        val notificationsCount = notificationsRemoteDataSource.getNotificationsCount()
+    override suspend fun getUnreadNotificationsCount(): NotificationsCountInfoDto {
+        val notificationsCount = notificationsRemoteDataSource.getUnreadNotificationsCount()
 
-        return notificationsCount ?: throw NullPointerException("notificationsCountDto is null")
+        return notificationsCount
+            .also {
+                notificationLocalDataSource.postIsNotReadNotificationCache(
+                    value = it?.notificationCountItems?.isNotEmpty() ?: false,
+                )
+
+                it
+            }
+            ?: throw NullPointerException("notificationsCountDto is null")
     }
 
     override suspend fun postNotificationRead(notificationId: Long): Boolean {

--- a/data/service/api/src/main/kotlin/com/captures2024/soongan/data/service/api/NotificationsAPI.kt
+++ b/data/service/api/src/main/kotlin/com/captures2024/soongan/data/service/api/NotificationsAPI.kt
@@ -26,7 +26,7 @@ interface NotificationsAPI {
 
     @Headers(AppConst.Network.ACCESS_TOKEN_ALLOW)
     @GET("notifications/unread-count")
-    suspend fun getNotificationsCount(): Response<BaseResponse<GetNotificationsCountResponse>>
+    suspend fun getUnreadNotificationsCount(): Response<BaseResponse<GetNotificationsCountResponse>>
 
     @Headers(AppConst.Network.ACCESS_TOKEN_ALLOW)
     @POST("notifications/{notificationId}/read")

--- a/data/source/notification-impl/src/main/kotlin/com/captures2024/soongan/data/source/notification/impl/local/NotificationLocalDataSourceImpl.kt
+++ b/data/source/notification-impl/src/main/kotlin/com/captures2024/soongan/data/source/notification/impl/local/NotificationLocalDataSourceImpl.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -26,6 +28,10 @@ constructor(
     private val _notificationEvent = MutableStateFlow<NotificationDto?>(null)
     override val notificationEvent: Flow<NotificationDto?>
         get() = _notificationEvent
+
+    private val _isNotReadNotificationCache: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    override val isNotReadNotificationCache: StateFlow<Boolean>
+        get() = _isNotReadNotificationCache.asStateFlow()
 
     init {
         analyticsHelper.d { "NotificationLocalDataSource::init" }
@@ -47,5 +53,9 @@ constructor(
         analyticsHelper.d { "parseNotification - notification: $notification" }
 
         _notificationEvent.value = notification
+    }
+
+    override fun postIsNotReadNotificationCache(value: Boolean) {
+        _isNotReadNotificationCache.value = value
     }
 }

--- a/data/source/notification-impl/src/main/kotlin/com/captures2024/soongan/data/source/notification/impl/remote/NotificationsRemoteDataSourceImpl.kt
+++ b/data/source/notification-impl/src/main/kotlin/com/captures2024/soongan/data/source/notification/impl/remote/NotificationsRemoteDataSourceImpl.kt
@@ -41,18 +41,18 @@ constructor(
         return responseBody?.responseData?.toNotificationsDto()
     }
 
-    override suspend fun getNotificationsCount(): NotificationsCountInfoDto? {
-        analyticsHelper.d { "getNotificationsCount - entry" }
+    override suspend fun getUnreadNotificationsCount(): NotificationsCountInfoDto? {
+        analyticsHelper.d { "getUnreadNotificationsCount - entry" }
 
-        val response = safeAPICall { notificationsAPI.getNotificationsCount() }
+        val response = safeAPICall { notificationsAPI.getUnreadNotificationsCount() }
 
         val responseHeader = response.headers
 
-        analyticsHelper.d { "getNotificationsCount - responseHeader: $responseHeader" }
+        analyticsHelper.d { "getUnreadNotificationsCount - responseHeader: $responseHeader" }
 
         val responseBody = response.body
 
-        analyticsHelper.d { "getNotificationsCount - responseBody: $responseBody" }
+        analyticsHelper.d { "getUnreadNotificationsCount - responseBody: $responseBody" }
 
         return responseBody?.responseData?.toNotificationsCountDto()
     }

--- a/data/source/notification/src/main/kotlin/com/captures2024/soongan/data/source/notification/local/NotificationLocalDataSource.kt
+++ b/data/source/notification/src/main/kotlin/com/captures2024/soongan/data/source/notification/local/NotificationLocalDataSource.kt
@@ -2,6 +2,7 @@ package com.captures2024.soongan.data.source.notification.local
 
 import com.captures2024.soongan.core.model.dto.NotificationDto
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 interface NotificationLocalDataSource {
 
@@ -9,7 +10,11 @@ interface NotificationLocalDataSource {
 
     val notificationEvent: Flow<NotificationDto?>
 
+    val isNotReadNotificationCache: StateFlow<Boolean>
+
     fun emitNotification(payload: Map<String, Any?>)
 
     suspend fun parseNotification(payload: Map<String, Any?>)
+
+    fun postIsNotReadNotificationCache(value: Boolean)
 }

--- a/data/source/notification/src/main/kotlin/com/captures2024/soongan/data/source/notification/remote/NotificationsRemoteDataSource.kt
+++ b/data/source/notification/src/main/kotlin/com/captures2024/soongan/data/source/notification/remote/NotificationsRemoteDataSource.kt
@@ -11,7 +11,7 @@ interface NotificationsRemoteDataSource {
         type: NotificationType,
     ): NotificationsInfoDto?
 
-    suspend fun getNotificationsCount(): NotificationsCountInfoDto?
+    suspend fun getUnreadNotificationsCount(): NotificationsCountInfoDto?
 
     suspend fun postNotificationRead(
         notificationId: Long,

--- a/domain/repository/notification/src/main/kotlin/com/captures2024/soongan/domain/repository/notification/NotificationRepository.kt
+++ b/domain/repository/notification/src/main/kotlin/com/captures2024/soongan/domain/repository/notification/NotificationRepository.kt
@@ -6,9 +6,12 @@ import com.captures2024.soongan.core.model.dto.NotificationsCountInfoDto
 import com.captures2024.soongan.core.model.dto.NotificationsInfoDto
 import com.captures2024.soongan.core.model.utils.NotificationType
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 interface NotificationRepository {
     val notificationEvent: Flow<NotificationDto?>
+
+    val isNotReadNotificationCache: StateFlow<Boolean>
 
     fun emitNotification(payload: Map<String, Any?>)
 
@@ -16,7 +19,7 @@ interface NotificationRepository {
         type: NotificationType,
     ): NotificationsInfoDto
 
-    suspend fun getNotificationsCount(): NotificationsCountInfoDto
+    suspend fun getUnreadNotificationsCount(): NotificationsCountInfoDto
 
     suspend fun postNotificationRead(
         notificationId: Long,

--- a/domain/usecase/module/src/main/kotlin/com/captures2024/soongan/domain/usecase/module/NotificationUseCaseModule.kt
+++ b/domain/usecase/module/src/main/kotlin/com/captures2024/soongan/domain/usecase/module/NotificationUseCaseModule.kt
@@ -2,15 +2,17 @@ package com.captures2024.soongan.domain.usecase.module
 
 import com.captures2024.soongan.domain.usecase.notification.DeleteNotificationUseCase
 import com.captures2024.soongan.domain.usecase.notification.EmitNotificationUseCase
+import com.captures2024.soongan.domain.usecase.notification.GetIsNotReadNotificationCacheFlowUseCase
 import com.captures2024.soongan.domain.usecase.notification.GetNotificationSettingsUseCase
-import com.captures2024.soongan.domain.usecase.notification.GetNotificationsCountUseCase
+import com.captures2024.soongan.domain.usecase.notification.GetUnreadNotificationsCountUseCase
 import com.captures2024.soongan.domain.usecase.notification.GetNotificationsUseCase
 import com.captures2024.soongan.domain.usecase.notification.PatchNotificationSettingsUseCase
 import com.captures2024.soongan.domain.usecase.notification.PostNotificationReadUseCase
 import com.captures2024.soongan.domain.usecase.notification.impl.DeleteNotificationUseCaseImpl
 import com.captures2024.soongan.domain.usecase.notification.impl.EmitNotificationUseCaseImpl
+import com.captures2024.soongan.domain.usecase.notification.impl.GetIsNotReadNotificationCacheFlowUseCaseImpl
 import com.captures2024.soongan.domain.usecase.notification.impl.GetNotificationSettingsUseCaseImpl
-import com.captures2024.soongan.domain.usecase.notification.impl.GetNotificationsCountUseCaseImpl
+import com.captures2024.soongan.domain.usecase.notification.impl.GetUnreadNotificationsCountUseCaseImpl
 import com.captures2024.soongan.domain.usecase.notification.impl.GetNotificationsUseCaseImpl
 import com.captures2024.soongan.domain.usecase.notification.impl.PatchNotificationSettingsUseCaseImpl
 import com.captures2024.soongan.domain.usecase.notification.impl.PostNotificationReadUseCaseImpl
@@ -30,7 +32,7 @@ internal abstract class NotificationUseCaseModule {
     abstract fun bindEmitNotificationUseCase(emitNotificationUseCaseImpl: EmitNotificationUseCaseImpl): EmitNotificationUseCase
 
     @Binds
-    abstract fun bindGetNotificationsCountUseCase(getNotificationsCountUseCaseImpl: GetNotificationsCountUseCaseImpl): GetNotificationsCountUseCase
+    abstract fun bindGetUnreadNotificationsCountUseCase(getUnreadNotificationsCountUseCaseImpl: GetUnreadNotificationsCountUseCaseImpl): GetUnreadNotificationsCountUseCase
 
     @Binds
     abstract fun bindGetNotificationsUseCase(getNotificationsUseCaseImpl: GetNotificationsUseCaseImpl): GetNotificationsUseCase
@@ -43,4 +45,7 @@ internal abstract class NotificationUseCaseModule {
 
     @Binds
     abstract fun bindPatchNotificationSettingsUseCase(patchNotificationSettingsUseCaseImpl: PatchNotificationSettingsUseCaseImpl): PatchNotificationSettingsUseCase
+
+    @Binds
+    abstract fun bindGetIsNotReadNotificationCacheFlowUseCase(getIsNotReadNotificationCacheFlowUseCaseImpl: GetIsNotReadNotificationCacheFlowUseCaseImpl): GetIsNotReadNotificationCacheFlowUseCase
 }

--- a/domain/usecase/notification-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/impl/GetIsNotReadNotificationCacheFlowUseCaseImpl.kt
+++ b/domain/usecase/notification-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/impl/GetIsNotReadNotificationCacheFlowUseCaseImpl.kt
@@ -1,0 +1,15 @@
+package com.captures2024.soongan.domain.usecase.notification.impl
+
+import com.captures2024.soongan.domain.repository.notification.NotificationRepository
+import com.captures2024.soongan.domain.usecase.notification.GetIsNotReadNotificationCacheFlowUseCase
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+class GetIsNotReadNotificationCacheFlowUseCaseImpl
+@Inject
+constructor(
+    private val notificationRepository: NotificationRepository,
+) : GetIsNotReadNotificationCacheFlowUseCase {
+
+    override fun invoke(): StateFlow<Boolean> = notificationRepository.isNotReadNotificationCache
+}

--- a/domain/usecase/notification-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/impl/GetUnreadNotificationsCountUseCaseImpl.kt
+++ b/domain/usecase/notification-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/impl/GetUnreadNotificationsCountUseCaseImpl.kt
@@ -2,18 +2,18 @@ package com.captures2024.soongan.domain.usecase.notification.impl
 
 import com.captures2024.soongan.core.model.dto.NotificationsCountInfoDto
 import com.captures2024.soongan.domain.repository.notification.NotificationRepository
-import com.captures2024.soongan.domain.usecase.notification.GetNotificationsCountUseCase
+import com.captures2024.soongan.domain.usecase.notification.GetUnreadNotificationsCountUseCase
 import com.captures2024.soongan.domain.usecase.utils.runSuspendCatching
 import javax.inject.Inject
 
-class GetNotificationsCountUseCaseImpl
+class GetUnreadNotificationsCountUseCaseImpl
 @Inject
 constructor(
     private val repository: NotificationRepository,
-) : GetNotificationsCountUseCase {
+) : GetUnreadNotificationsCountUseCase {
 
     override suspend fun invoke(): Result<NotificationsCountInfoDto> = runSuspendCatching {
-        val notificationsCountDto = repository.getNotificationsCount()
+        val notificationsCountDto = repository.getUnreadNotificationsCount()
 
         return@runSuspendCatching notificationsCountDto
     }

--- a/domain/usecase/notification/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/GetIsNotReadNotificationCacheFlowUseCase.kt
+++ b/domain/usecase/notification/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/GetIsNotReadNotificationCacheFlowUseCase.kt
@@ -1,0 +1,8 @@
+package com.captures2024.soongan.domain.usecase.notification
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface GetIsNotReadNotificationCacheFlowUseCase {
+
+    operator fun invoke(): StateFlow<Boolean>
+}

--- a/domain/usecase/notification/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/GetUnreadNotificationsCountUseCase.kt
+++ b/domain/usecase/notification/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/GetUnreadNotificationsCountUseCase.kt
@@ -2,7 +2,7 @@ package com.captures2024.soongan.domain.usecase.notification
 
 import com.captures2024.soongan.core.model.dto.NotificationsCountInfoDto
 
-interface GetNotificationsCountUseCase {
+interface GetUnreadNotificationsCountUseCase {
 
     suspend operator fun invoke(): Result<NotificationsCountInfoDto>
 }

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileTopBarComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileTopBarComponent.kt
@@ -43,6 +43,7 @@ import com.captures2024.soongan.presentation.designsystem.ui.R as RDesign
 @Composable
 internal fun ProfileTopBarComponent(
     userProfile: UserProfile,
+    isShowBadge: Boolean,
     modifier: Modifier = Modifier,
     onClickNotification: () -> Unit,
     onClickMenu: () -> Unit,
@@ -59,6 +60,7 @@ internal fun ProfileTopBarComponent(
         WeightSpacer(1f)
 
         IconBox(
+            isShowBadge = isShowBadge,
             onClickNotification = onClickNotification,
             onClickMenu = onClickMenu,
         )
@@ -116,6 +118,7 @@ private fun ProfileCard(
 
 @Composable
 private fun IconBox(
+    isShowBadge: Boolean,
     modifier: Modifier = Modifier,
     onClickNotification: () -> Unit,
     onClickMenu: () -> Unit,
@@ -127,15 +130,18 @@ private fun IconBox(
                 .clickable(onClick = onClickNotification),
             contentAlignment = Alignment.Center,
         ) {
-            Badge(
-                modifier = Modifier
-                    .size(8.dp)
-                    .offset(
-                        x = (-6).dp,
-                        y = (-6).dp,
-                    ),
-                containerColor = Color(0xffFBC304),
-            )
+            if (isShowBadge) {
+                Badge(
+                    modifier = Modifier
+                        .size(8.dp)
+                        .offset(
+                            x = (-6).dp,
+                            y = (-6).dp,
+                        ),
+                    containerColor = Color(0xffFBC304),
+                )
+            }
+
             Icon(
                 imageVector = MyIconPack.IconNonFillBell,
                 contentDescription = stringResource(R.string.notification_description),
@@ -163,6 +169,7 @@ private fun PreviewProfileTopBarComponent() {
     SGTheme {
         ProfileTopBarComponent(
             userProfile = UserProfile(),
+            isShowBadge = true,
             onClickNotification = {},
             onClickMenu = {},
         )

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileScreen.kt
@@ -41,6 +41,7 @@ internal fun ProfileScreen(
     ) {
         ProfileTopBarComponent(
             userProfile = state.userProfile,
+            isShowBadge = state.isNotReadNotification,
             modifier = Modifier.padding(
                 start = 20.dp,
                 end = 16.dp,

--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/MainComponent.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/MainComponent.kt
@@ -18,6 +18,7 @@ import com.captures2024.soongan.presentation.feature.main.navigation.MainTopLeve
 @Composable
 internal fun MainComponent(
     navigationState: MainNavigationState,
+    isNotReadNotification: Boolean,
     content: @Composable (PaddingValues) -> Unit,
 ) {
     Scaffold(
@@ -44,6 +45,7 @@ internal fun MainComponent(
                     }
                     .animateContentSize()
                     .testTag("SoonGanBottomBar"),
+                isNotReadNotification = isNotReadNotification,
             )
         },
         content = content,

--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/SoonGanBottomBar.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/SoonGanBottomBar.kt
@@ -1,8 +1,12 @@
 package com.captures2024.soongan.presentation.feature.main.component
 
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDestination
@@ -20,6 +24,7 @@ internal fun SoonGanBottomBar(
     onNavigateToDestination: (MainTopLevelDestination) -> Unit,
     currentDestination: NavDestination?,
     modifier: Modifier = Modifier,
+    isNotReadNotification: Boolean = false,
 ) {
     SoonGanNavigationBar(
         modifier = modifier,
@@ -35,20 +40,89 @@ internal fun SoonGanBottomBar(
                     }
                 },
                 icon = {
-                    Icon(
-                        imageVector = destination.unselectedIcon,
-                        contentDescription = null,
-                        tint = SGColor.primaryA.copy(alpha = 0.3f),
-                        modifier = Modifier.size(24.dp, 24.dp),
-                    )
+                    when (destination) {
+                        MainTopLevelDestination.PROFILE -> {
+                            Box {
+                                if (isNotReadNotification) {
+                                    Box(
+                                        modifier = Modifier.wrapContentSize(),
+                                    ) {
+                                        Canvas(
+                                            modifier = Modifier
+                                                .size(8.dp)
+                                                .align(Alignment.Center),
+                                        ) {
+                                            drawCircle(
+                                                color = SGColor.Main.primary,
+                                                radius = size.width / 2,
+                                            )
+                                        }
+                                    }
+                                }
+
+                                Icon(
+                                    imageVector = destination.unselectedIcon,
+                                    contentDescription = null,
+                                    tint = SGColor.primaryA.copy(alpha = 0.3f),
+                                    modifier = Modifier.size(24.dp, 24.dp),
+                                )
+                            }
+                        }
+
+                        else -> Icon(
+                            imageVector = destination.unselectedIcon,
+                            contentDescription = null,
+                            tint = SGColor.primaryA.copy(alpha = 0.3f),
+                            modifier = Modifier.size(
+                                width = 24.dp,
+                                height = 24.dp,
+                            ),
+                        )
+                    }
                 },
                 selectedIcon = {
-                    Icon(
-                        imageVector = destination.selectedIcon,
-                        contentDescription = null,
-                        tint = SGColor.primaryA,
-                        modifier = Modifier.size(24.dp, 24.dp),
-                    )
+                    when (destination) {
+                        MainTopLevelDestination.PROFILE -> {
+                            Box {
+                                if (isNotReadNotification) {
+                                    Box(
+                                        modifier = Modifier.wrapContentSize(),
+                                    ) {
+                                        Canvas(
+                                            modifier = Modifier
+                                                .size(8.dp)
+                                                .align(Alignment.Center),
+                                        ) {
+                                            drawCircle(
+                                                color = SGColor.Main.primary,
+                                                radius = size.width / 2,
+                                            )
+                                        }
+                                    }
+                                }
+
+                                Icon(
+                                    imageVector = destination.selectedIcon,
+                                    contentDescription = null,
+                                    tint = SGColor.primaryA,
+                                    modifier = Modifier.size(
+                                        width = 24.dp,
+                                        height = 24.dp,
+                                    ),
+                                )
+                            }
+                        }
+
+                        else -> Icon(
+                            imageVector = destination.selectedIcon,
+                            contentDescription = null,
+                            tint = SGColor.primaryA,
+                            modifier = Modifier.size(
+                                width = 24.dp,
+                                height = 24.dp,
+                            ),
+                        )
+                    }
                 },
             )
         }

--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/screen/MainScreen.kt
@@ -31,11 +31,15 @@ import com.captures2024.soongan.presentation.feature.main.navigation.MainNavigat
 import com.captures2024.soongan.presentation.feature.main.navigation.welcome
 import com.captures2024.soongan.presentation.feature.main.post.navigation.mainPost
 import com.captures2024.soongan.presentation.feature.main.profile.navigation.mainProfile
+import com.captures2024.soongan.presentation.viewmodel.main.MainNotificationViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
-internal fun MainScreen(navigationState: MainNavigationState) {
+internal fun MainScreen(
+    navigationState: MainNavigationState,
+    state: MainNotificationViewModel.State,
+) {
     val scope = rememberCoroutineScope()
     val navController = navigationState.navController
 
@@ -53,7 +57,10 @@ internal fun MainScreen(navigationState: MainNavigationState) {
         }
     }
 
-    MainComponent(navigationState = navigationState) { innerPadding ->
+    MainComponent(
+        navigationState = navigationState,
+        isNotReadNotification = state.isNotReadNotification,
+    ) { innerPadding ->
         NavHost(
             modifier = Modifier.padding(innerPadding),
             navController = navController,

--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/route/MainRoute.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/route/MainRoute.kt
@@ -1,21 +1,29 @@
 package com.captures2024.soongan.presentation.feature.main.route
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.captures2024.soongan.presentation.feature.main.component.screen.MainScreen
 import com.captures2024.soongan.presentation.feature.main.navigation.rememberMainNavigationState
+import com.captures2024.soongan.presentation.viewmodel.main.MainNotificationViewModel
 
 @Composable
 fun MainRoute(
     isGuestMode: Boolean,
     navController: NavHostController,
+    mainNotificationViewModel: MainNotificationViewModel = hiltViewModel(),
 ) {
     val mainNavigationState = rememberMainNavigationState(
         isGuestMode = isGuestMode,
         navController = navController,
     )
 
+    val state by mainNotificationViewModel.state.collectAsState()
+
     MainScreen(
         navigationState = mainNavigationState,
+        state = state,
     )
 }

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/MainNotificationViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/MainNotificationViewModel.kt
@@ -1,0 +1,83 @@
+package com.captures2024.soongan.presentation.viewmodel.main
+
+import androidx.lifecycle.SavedStateHandle
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.domain.usecase.member.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.domain.usecase.notification.GetIsNotReadNotificationCacheFlowUseCase
+import com.captures2024.soongan.domain.usecase.notification.GetUnreadNotificationsCountUseCase
+import com.captures2024.soongan.domain.usecase.system.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.domain.usecase.system.loading.ClearLoadingUseCase
+import com.captures2024.soongan.domain.usecase.system.loading.HideLoadingUseCase
+import com.captures2024.soongan.domain.usecase.system.loading.ShowLoadingUseCase
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class MainNotificationViewModel
+@Inject
+constructor(
+    private val isNotReadNotificationCacheFlowUseCase: GetIsNotReadNotificationCacheFlowUseCase,
+    private val getUnreadNotificationsCountUseCase: GetUnreadNotificationsCountUseCase,
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle: SavedStateHandle,
+) : BaseViewModel<MainNotificationViewModel.State, MainNotificationViewModel.Effect, MainNotificationViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle = savedStateHandle,
+) {
+
+    data class State(
+        val isNotReadNotification: Boolean = false,
+    ) : UIState
+
+    sealed interface Effect : UISideEffect
+
+    sealed interface Intent : UIIntent {
+        data object Init : Intent
+    }
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State = State()
+
+    override fun handleIntent(intent: Intent) {
+        when (intent) {
+            is Intent.Init -> launch { handleInit() }
+        }
+    }
+
+    init {
+        intent(Intent.Init)
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        analyticsHelper.e(throwable = throwable) { "state: $currentState" }
+    }
+
+    private suspend fun handleInit() {
+        collectIsNotReadNotificationFlow()
+
+        getUnreadNotificationsCountUseCase().getOrNull()
+    }
+
+    private fun collectIsNotReadNotificationFlow() = launch {
+        isNotReadNotificationCacheFlowUseCase().collect {
+            reduce {
+                copy(
+                    isNotReadNotification = it,
+                )
+            }
+        }
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/MainNotificationViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/MainNotificationViewModel.kt
@@ -20,8 +20,6 @@ import javax.inject.Inject
 class MainNotificationViewModel
 @Inject
 constructor(
-    private val isNotReadNotificationCacheFlowUseCase: GetIsNotReadNotificationCacheFlowUseCase,
-    private val getUnreadNotificationsCountUseCase: GetUnreadNotificationsCountUseCase,
     analyticsHelper: AnalyticsHelper,
     showLoadingUseCase: ShowLoadingUseCase,
     hideLoadingUseCase: HideLoadingUseCase,
@@ -29,6 +27,8 @@ constructor(
     getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
     setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
+    private val isNotReadNotificationCacheFlowUseCase: GetIsNotReadNotificationCacheFlowUseCase,
+    private val getUnreadNotificationsCountUseCase: GetUnreadNotificationsCountUseCase,
 ) : BaseViewModel<MainNotificationViewModel.State, MainNotificationViewModel.Effect, MainNotificationViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileNotificationViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileNotificationViewModel.kt
@@ -13,7 +13,7 @@ import com.captures2024.soongan.core.model.utils.NotificationsCountTable
 import com.captures2024.soongan.core.model.utils.NotificationsTable
 import com.captures2024.soongan.domain.usecase.member.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.domain.usecase.notification.DeleteNotificationUseCase
-import com.captures2024.soongan.domain.usecase.notification.GetNotificationsCountUseCase
+import com.captures2024.soongan.domain.usecase.notification.GetUnreadNotificationsCountUseCase
 import com.captures2024.soongan.domain.usecase.notification.GetNotificationsUseCase
 import com.captures2024.soongan.domain.usecase.notification.PostNotificationReadUseCase
 import com.captures2024.soongan.domain.usecase.system.dialog.PostSingleButtonDialogUseCase
@@ -39,7 +39,7 @@ constructor(
     savedStateHandle: SavedStateHandle,
     private val postSingleButtonDialogUseCase: PostSingleButtonDialogUseCase,
     private val getNotificationsUseCase: GetNotificationsUseCase,
-    private val getNotificationsCountUseCase: GetNotificationsCountUseCase,
+    private val getUnreadNotificationsCountUseCase: GetUnreadNotificationsCountUseCase,
     private val postNotificationReadUseCase: PostNotificationReadUseCase,
     private val deleteNotificationUseCase: DeleteNotificationUseCase,
 ) : BaseViewModel<ProfileNotificationViewModel.State, ProfileNotificationViewModel.Effect, ProfileNotificationViewModel.Intent>(
@@ -203,7 +203,7 @@ constructor(
     }
 
     private suspend fun initSetNotificationsCount() {
-        val notificationsCountDto = getNotificationsCountUseCase().getOrNull()
+        val notificationsCountDto = getUnreadNotificationsCountUseCase().getOrNull()
 
         if (notificationsCountDto == null) {
             postSingleButtonDialogUseCase(CommonDialogType.NETWORK_ERROR)

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileViewModel.kt
@@ -11,6 +11,8 @@ import com.captures2024.soongan.domain.usecase.contest.GetMyGalleryUseCase
 import com.captures2024.soongan.domain.usecase.contest.GetRegisterPostEventUseCase
 import com.captures2024.soongan.domain.usecase.member.GetCurrentMemberFlowUseCase
 import com.captures2024.soongan.domain.usecase.member.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.domain.usecase.notification.GetIsNotReadNotificationCacheFlowUseCase
+import com.captures2024.soongan.domain.usecase.notification.GetUnreadNotificationsCountUseCase
 import com.captures2024.soongan.domain.usecase.system.dialog.SetIsShowGuestModeDialogFlowUseCase
 import com.captures2024.soongan.domain.usecase.system.inapp.LaunchTermsUseCase
 import com.captures2024.soongan.domain.usecase.system.loading.ClearLoadingUseCase
@@ -38,6 +40,8 @@ constructor(
     private val getMyGalleryUseCase: GetMyGalleryUseCase,
     private val getRegisterPostEventUseCase: GetRegisterPostEventUseCase,
     private val getHidePostEventUseCase: GetHidePostEventUseCase,
+    private val isNotReadNotificationCacheFlowUseCase: GetIsNotReadNotificationCacheFlowUseCase,
+    private val getUnreadNotificationsCountUseCase: GetUnreadNotificationsCountUseCase,
 ) : BaseViewModel<ProfileViewModel.State, ProfileViewModel.Effect, ProfileViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
@@ -52,6 +56,7 @@ constructor(
         val userProfile: UserProfile,
         val myGalleryState: MyGalleryState,
         val isShowMenuBottomSheet: Boolean,
+        val isNotReadNotification: Boolean = false,
     ) : UIState {
 
         data class MyGalleryState(
@@ -151,8 +156,10 @@ constructor(
         launch { collectUserProfile() }
         launch { collectRegisterPostEvent() }
         launch { collectHidePostEvent() }
+        launch { collectIsNotReadNotificationFlow() }
 
         fetchInitData()
+        getUnreadNotificationsCountUseCase()
     }
 
     private fun handleOnClickMenu() {
@@ -256,6 +263,16 @@ constructor(
                     myGalleryState = myGalleryState.copy(
                         posts = myGalleryState.posts.filter { it.postId != postId },
                     ),
+                )
+            }
+        }
+    }
+
+    private suspend fun collectIsNotReadNotificationFlow() {
+        isNotReadNotificationCacheFlowUseCase().collect {
+            reduce {
+                copy(
+                    isNotReadNotification = it,
                 )
             }
         }


### PR DESCRIPTION
# [SG-158] 프로필 탭 알림 표시 UI 작업

## 변경 사항
- unread notification usecase 로 이름 변경
- 해당 값을 cache 하는 flow를 notification local source 에 생성
- main 과 profile에서 해당 값을 통해 뱃지 표출 여부 설정

[SG-158]: https://captures2024.atlassian.net/browse/SG-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ