### PR TITLE
[SG-169] 게시글 이미지 세로 정렬 수정

### DIFF
--- a/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoBodyComponent.kt
+++ b/presentation/feature/main-post/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/post/component/info/PostInfoBodyComponent.kt
@@ -1,7 +1,7 @@
 package com.captures2024.soongan.presentation.feature.main.post.component.info
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -42,14 +42,18 @@ internal fun PostInfoBodyComponent(
             .padding(horizontal = 16.dp)
             .verticalScroll(scrollState),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.SpaceBetween,
     ) {
-        PostInfoImageComponent(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(postInfo.imageUrl)
-                .build(),
-            modifier = Modifier.clickable(onClick = onClickPhoto),
-        )
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            PostInfoImageComponent(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(postInfo.imageUrl)
+                    .build(),
+                modifier = Modifier.clickable(onClick = onClickPhoto),
+            )
+        }
 
         Column(
             modifier = Modifier


### PR DESCRIPTION
# [SG-169] 게시글 이미지 세로 정렬 수정

## 변경 사항
- 게시글 이미지 세로 정렬 센터 정렬로 변경

## 비고
<img width="220" height="458" alt="image" src="https://github.com/user-attachments/assets/fdd5384e-fdb3-4928-842d-a34ea522a480" />


[SG-169]: https://captures2024.atlassian.net/browse/SG-169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ