### PR TITLE
[SG-168] 등록한 사진이 홈에서 크기가 바뀌는 문제

### DIFF
--- a/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/component/home/HomeBodyNotEmptyComponent.kt
+++ b/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/component/home/HomeBodyNotEmptyComponent.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
@@ -159,7 +158,7 @@ private fun PostComponent(
             contentDescription = stringResource(R.string.photo_button_description),
             contentScale = ContentScale.Crop,
             modifier = Modifier
-                .widthIn(min = 131.dp + maxBlur)
+                .width(131.dp + maxBlur)
                 .height(257.dp + maxBlur)
                 .dropShadow(
                     shape = commonShape,


### PR DESCRIPTION
# [SG-168] 등록한 사진이 홈에서 크기가 바뀌는 문제

## 변경 사항
- 기존 widthIn이어서 min 사이즈로 적용되던 현상 수정

[SG-168]: https://captures2024.atlassian.net/browse/SG-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ