### PR TITLE
[SG-156] 프로필 탭 수정

### DIFF
--- a/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/screen/FeedScreen.kt
+++ b/presentation/feature/main-feed/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/feed/component/screen/FeedScreen.kt
@@ -88,6 +88,10 @@ internal fun FeedScreen(
             ) {
                 when {
                     feedState.posts.isEmpty() -> when (feedState.paginationStatus) {
+                        PaginationStatus.GUEST -> {
+                            // guest 모드여도 결과 차이 X
+                        }
+
                         PaginationStatus.DEFAULT,
                         PaginationStatus.REFRESH_LOAD,
                         PaginationStatus.PAGING_LOAD,

--- a/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/component/screen/HomeGalleryScreen.kt
+++ b/presentation/feature/main-home/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/home/component/screen/HomeGalleryScreen.kt
@@ -88,6 +88,10 @@ internal fun HomeGalleryScreen(
             ) {
                 when {
                     state.posts.isEmpty() -> when (state.paginationStatus) {
+                        PaginationStatus.GUEST -> {
+                            // guest 모드여도 결과 차이 X
+                        }
+
                         PaginationStatus.DEFAULT,
                         PaginationStatus.REFRESH_LOAD,
                         PaginationStatus.PAGING_LOAD,

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileBodyComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileBodyComponent.kt
@@ -74,7 +74,9 @@ internal fun ProfileBodyComponent(
                         SGGallerySkeletonItem(height = height)
                     }
 
-                    PaginationStatus.SUCCESS -> {
+                    PaginationStatus.GUEST,
+                    PaginationStatus.SUCCESS,
+                    -> {
                         item(span = StaggeredGridItemSpan.FullLine) {
                             SGGalleryEmptyItem(
                                 emptyText = stringResource(R.string.profile_gallery_post_empty_content),

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileEditBodyComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileEditBodyComponent.kt
@@ -138,7 +138,7 @@ private fun PreviewProfileEditBodyComponent() {
     SGTheme {
         ProfileEditBodyComponent(
             state = ProfileEditViewModel.State(
-                userProfile = UserProfile(),
+                userProfile = UserProfile.guestUserProfile,
                 editingState = ProfileEditViewModel.State.EditingProfileState(),
                 isShowEditBottomSheet = false,
             ),

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileTopBarComponent.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/profile/ProfileTopBarComponent.kt
@@ -168,7 +168,7 @@ private fun IconBox(
 private fun PreviewProfileTopBarComponent() {
     SGTheme {
         ProfileTopBarComponent(
-            userProfile = UserProfile(),
+            userProfile = UserProfile.guestUserProfile,
             isShowBadge = true,
             onClickNotification = {},
             onClickMenu = {},

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileEditScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileEditScreen.kt
@@ -71,9 +71,9 @@ private fun PreviewProfileEditScreen() {
     SGTheme {
         ProfileEditScreen(
             state = ProfileEditViewModel.State(
-                userProfile = UserProfile(),
+                userProfile = UserProfile.guestUserProfile,
                 editingState = ProfileEditViewModel.State.EditingProfileState(
-                    editingProfile = UserProfile(),
+                    editingProfile = UserProfile.guestUserProfile,
                     isDuplicatedNickname = false,
                 ),
                 isShowEditBottomSheet = false,

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileScreen.kt
@@ -77,7 +77,7 @@ private fun PreviewProfileScreen() {
     SGTheme {
         ProfileScreen(
             state = ProfileViewModel.State(
-                userProfile = UserProfile(),
+                userProfile = UserProfile.guestUserProfile,
                 myGalleryState = ProfileViewModel.State.MyGalleryState(
                     isRefreshing = false,
                     posts = emptyList(),

--- a/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileScreen.kt
+++ b/presentation/feature/main-profile/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/profile/component/screen/ProfileScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -36,7 +37,7 @@ internal fun ProfileScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(color = SGColor.Grayscale.white)
+            .background(color = SGColor.BG.background)
             .padding(top = 26.dp),
     ) {
         ProfileTopBarComponent(
@@ -51,6 +52,11 @@ internal fun ProfileScreen(
         )
 
         HeightSpacer(28.dp)
+
+        HorizontalDivider(
+            thickness = 1.dp,
+            color = SGColor.buttonDisableGray,
+        )
 
         ProfileBodyComponent(
             state = state.myGalleryState,

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileEditViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileEditViewModel.kt
@@ -57,7 +57,7 @@ constructor(
             get() = userProfile != editingState.editingProfile
 
         data class EditingProfileState(
-            val editingProfile: UserProfile = UserProfile(),
+            val editingProfile: UserProfile = UserProfile.guestUserProfile,
             val isDuplicatedNickname: Boolean = false,
         ) {
             val isValidNickname: Validation.NicknameValidState
@@ -109,7 +109,7 @@ constructor(
 
     override fun createInitialState(savedStateHandle: SavedStateHandle): State {
         return State(
-            userProfile = UserProfile(),
+            userProfile = UserProfile.guestUserProfile,
             editingState = State.EditingProfileState(),
             isShowEditBottomSheet = false,
         )
@@ -242,7 +242,7 @@ constructor(
             currentMember?.let {
                 val userProfile = UserProfile(
                     nickname = currentMember.nickname ?: "user1",
-                    selfIntroduction = currentMember.selfIntroduction ?: "본인을 소개해주세요",
+                    selfIntroduction = currentMember.selfIntroduction ?: UserProfile.DEFAULT_SELF_INTRODUCTION,
                     profileImageUrl = currentMember.profileImageUrl,
                 )
 

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ProfileViewModel.kt
@@ -53,19 +53,19 @@ constructor(
 ) {
 
     data class State(
-        val userProfile: UserProfile,
-        val myGalleryState: MyGalleryState,
-        val isShowMenuBottomSheet: Boolean,
+        val userProfile: UserProfile = UserProfile.guestUserProfile,
+        val myGalleryState: MyGalleryState = MyGalleryState(),
+        val isShowMenuBottomSheet: Boolean = false,
         val isNotReadNotification: Boolean = false,
     ) : UIState {
 
         data class MyGalleryState(
-            val isRefreshing: Boolean,
-            val posts: List<GalleryPostDto>,
-            val paginationStatus: PaginationStatus,
-            val loadPage: Int,
-            val loadPageSize: Int,
-            val hasNextPage: Boolean,
+            val isRefreshing: Boolean = false,
+            val posts: List<GalleryPostDto> = emptyList(),
+            val paginationStatus: PaginationStatus = PaginationStatus.DEFAULT,
+            val loadPage: Int = 0,
+            val loadPageSize: Int = 50,
+            val hasNextPage: Boolean = false,
         ) {
             val isInitPage: Boolean
                 get() = loadPage == 0
@@ -117,20 +117,7 @@ constructor(
         intent(Intent.Init)
     }
 
-    override fun createInitialState(savedStateHandle: SavedStateHandle): State {
-        return State(
-            userProfile = UserProfile(),
-            myGalleryState = State.MyGalleryState(
-                isRefreshing = false,
-                posts = emptyList(),
-                paginationStatus = PaginationStatus.DEFAULT,
-                loadPage = 0,
-                loadPageSize = 50,
-                hasNextPage = false,
-            ),
-            isShowMenuBottomSheet = false,
-        )
-    }
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State = State()
 
     override fun handleIntent(intent: Intent) {
         when (intent) {
@@ -143,7 +130,7 @@ constructor(
             is Intent.OnClickTerms -> loadingLaunch { handleOnClickTerms() }
             is Intent.OnRefresh -> launch { handleOnRefresh() }
             is Intent.OnLoadNextPage -> launch { handleOnLoadNextPage() }
-            is Intent.OnClickRegisterPost -> handleOnClickRegisterPost()
+            is Intent.OnClickRegisterPost -> blockGuestModeLogic { handleOnClickRegisterPost() }
             is Intent.OnClickPost -> handleOnClickPost(intent)
         }
     }
@@ -157,6 +144,18 @@ constructor(
         launch { collectRegisterPostEvent() }
         launch { collectHidePostEvent() }
         launch { collectIsNotReadNotificationFlow() }
+
+        getCurrentMemberFlowUseCase().value?.let { currentMember ->
+            reduce {
+                copy(
+                    userProfile = UserProfile(
+                        nickname = currentMember.nickname ?: "user",
+                        selfIntroduction = currentMember.selfIntroduction ?: UserProfile.DEFAULT_SELF_INTRODUCTION,
+                        profileImageUrl = currentMember.profileImageUrl,
+                    ),
+                )
+            }
+        }
 
         fetchInitData()
         getUnreadNotificationsCountUseCase()
@@ -240,8 +239,8 @@ constructor(
                 reduce {
                     copy(
                         userProfile = UserProfile(
-                            nickname = currentMember.nickname ?: "user1",
-                            selfIntroduction = currentMember.selfIntroduction ?: "본인을 소개해주세요",
+                            nickname = currentMember.nickname ?: "user",
+                            selfIntroduction = currentMember.selfIntroduction ?: UserProfile.DEFAULT_SELF_INTRODUCTION,
                             profileImageUrl = currentMember.profileImageUrl,
                         ),
                     )
@@ -314,6 +313,10 @@ constructor(
         isRefreshing: Boolean = false,
     ): PaginationStatus {
         val state = currentState
+
+        if (state.userProfile == UserProfile.guestUserProfile) {
+            return PaginationStatus.GUEST
+        }
 
         when (state.myGalleryState.paginationStatus) {
             PaginationStatus.REFRESH_LOAD,

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/PaginationStatus.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/PaginationStatus.kt
@@ -6,4 +6,5 @@ enum class PaginationStatus {
     PAGING_LOAD,
     SUCCESS,
     FAILED,
+    GUEST,
 }

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/UserProfile.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/model/UserProfile.kt
@@ -1,7 +1,18 @@
 package com.captures2024.soongan.presentation.viewmodel.model
 
 data class UserProfile(
-    val nickname: String = "user1",
-    val selfIntroduction: String = "본인을 소개해주세요",
-    val profileImageUrl: String? = null,
-)
+    val nickname: String,
+    val selfIntroduction: String,
+    val profileImageUrl: String?,
+) {
+
+    companion object {
+        const val DEFAULT_SELF_INTRODUCTION = "본인을 소개해주세요"
+
+        val guestUserProfile: UserProfile = UserProfile(
+            nickname = "로그인이 필요해요",
+            selfIntroduction = "로그인 후 본인을 소개해주세요",
+            profileImageUrl = null,
+        )
+    }
+}


### PR DESCRIPTION
# [SG-156] 프로필 탭 수정

## 수정 사항
- 프로필 탭 UI 수정
- 게스트 모드 게시글 정보 오류 처리되던 현상 해결

## 비고
<img width="499" height="192" alt="image" src="https://github.com/user-attachments/assets/f1b50430-db4a-487a-8506-6f46334a8291" />
<img width="488" height="1001" alt="image" src="https://github.com/user-attachments/assets/3b538535-7059-4eda-8f32-7f9ea48303c3" />


[SG-156]: https://captures2024.atlassian.net/browse/SG-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ