### PR TITLE
[SG-172] 회차 관련 문제 수정

### DIFF
--- a/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/feed/FeedNavigator.kt
+++ b/core/navigator/src/main/kotlin/com/captures2024/soongan/core/navigator/screen/main/feed/FeedNavigator.kt
@@ -5,11 +5,21 @@ import androidx.navigation.NavOptions
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object FeedNavigator
+data class FeedNavigator(
+    val round: Long? = null,
+)
 
-fun NavController.navigateToFeed() = navigateToFeed(null)
+fun NavController.navigateToFeed(round: Long? = null) = navigateToFeed(
+    round = round,
+    navOptions = null,
+)
 
-fun NavController.navigateToFeed(navOptions: NavOptions?) = navigate(
-    route = FeedNavigator,
+fun NavController.navigateToFeed(
+    navOptions: NavOptions?,
+    round: Long? = null,
+) = navigate(
+    route = FeedNavigator(
+        round = round,
+    ),
     navOptions = navOptions,
 )

--- a/presentation/feature/main-awards/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/awards/component/info/AwardsInfoComponent.kt
+++ b/presentation/feature/main-awards/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/awards/component/info/AwardsInfoComponent.kt
@@ -35,7 +35,7 @@ internal fun AwardsInfoComponent(
     modifier: Modifier = Modifier,
     onClickBack: () -> Unit,
     onClickPost: (postId: Long) -> Unit,
-    onClickAllPosts: () -> Unit,
+    onClickAllPosts: (round: Long) -> Unit,
 ) {
     val gridPadding = 8.dp
 
@@ -90,7 +90,7 @@ internal fun AwardsInfoComponent(
 
         item(span = StaggeredGridItemSpan.FullLine) {
             TempButton(
-                onClick = onClickAllPosts,
+                onClick = { onClickAllPosts(awardsInfo.round) },
             )
         }
     }

--- a/presentation/feature/main-awards/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/awards/component/info/AwardsInfoComponent.kt
+++ b/presentation/feature/main-awards/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/awards/component/info/AwardsInfoComponent.kt
@@ -44,7 +44,11 @@ internal fun AwardsInfoComponent(
     }
 
     val otherTop7Posts = remember(awardsInfo.prizePosts) {
-        awardsInfo.prizePosts.subList(1, awardsInfo.prizePosts.lastIndex)
+        if (awardsInfo.prizePosts.size > 1) {
+            awardsInfo.prizePosts.subList(1, awardsInfo.prizePosts.lastIndex)
+        } else {
+            emptyList()
+        }
     }
 
     LazyVerticalStaggeredGrid(

--- a/presentation/feature/main-awards/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/awards/component/screen/AwardsInfoScreen.kt
+++ b/presentation/feature/main-awards/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/awards/component/screen/AwardsInfoScreen.kt
@@ -22,7 +22,7 @@ internal fun AwardsInfoScreen(
     modifier: Modifier = Modifier,
     onClickBack: () -> Unit,
     onClickPost: (postId: Long) -> Unit,
-    onClickAllPosts: () -> Unit,
+    onClickAllPosts: (round: Long) -> Unit,
     onClickRetry: () -> Unit,
 ) {
     Box(

--- a/presentation/feature/main-awards/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/awards/navigation/MainAwardsNavigation.kt
+++ b/presentation/feature/main-awards/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/awards/navigation/MainAwardsNavigation.kt
@@ -14,7 +14,7 @@ fun NavGraphBuilder.mainAwards(
     navigateToAwardsInfo: (id: Long) -> Unit,
     navigateToBack: () -> Unit,
     navigateToPost: (postId: Long) -> Unit,
-    navigateToFeed: (NavOptions) -> Unit,
+    navigateToFeed: (NavOptions, round: Long) -> Unit,
 ) {
     composable<AwardsNavigator> {
         AwardsRoute(
@@ -34,7 +34,7 @@ fun NavGraphBuilder.mainAwards(
         AwardsInfoRoute(
             navigateToBack = navigateToBack,
             navigateToPost = navigateToPost,
-            navigateToFeed = { navigateToFeed(feedNavOption) },
+            navigateToFeed = { round -> navigateToFeed(feedNavOption, round) },
         )
     }
 }

--- a/presentation/feature/main-awards/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/awards/route/AwardsInfoRoute.kt
+++ b/presentation/feature/main-awards/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/awards/route/AwardsInfoRoute.kt
@@ -12,7 +12,7 @@ import com.captures2024.soongan.presentation.viewmodel.main.award.AwardsInfoView
 internal fun AwardsInfoRoute(
     navigateToBack: () -> Unit,
     navigateToPost: (postId: Long) -> Unit,
-    navigateToFeed: () -> Unit,
+    navigateToFeed: (round: Long) -> Unit,
     viewModel: AwardsInfoViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
@@ -24,7 +24,7 @@ internal fun AwardsInfoRoute(
 
                 is AwardsInfoViewModel.Effect.NavigateToPost -> navigateToPost(effect.postId)
 
-                is AwardsInfoViewModel.Effect.NavigateToFeed -> navigateToFeed()
+                is AwardsInfoViewModel.Effect.NavigateToFeed -> navigateToFeed(effect.round)
             }
         }
     }
@@ -33,7 +33,7 @@ internal fun AwardsInfoRoute(
         state = state,
         onClickBack = { viewModel.intent(AwardsInfoViewModel.Intent.OnClickBack) },
         onClickPost = { viewModel.intent(AwardsInfoViewModel.Intent.OnClickPost(it)) },
-        onClickAllPosts = { viewModel.intent(AwardsInfoViewModel.Intent.OnClickAllPosts) },
+        onClickAllPosts = { viewModel.intent(AwardsInfoViewModel.Intent.OnClickAllPosts(it)) },
         onClickRetry = { viewModel.intent(AwardsInfoViewModel.Intent.OnClickRetry) },
     )
 }

--- a/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/SoonGanBottomBar.kt
+++ b/presentation/feature/main/src/main/kotlin/com/captures2024/soongan/presentation/feature/main/component/SoonGanBottomBar.kt
@@ -135,7 +135,8 @@ internal fun NavDestination?.isTopLevelDestinationInHierarchy(destination: MainT
             it.route
                 ?.split(".")
                 ?.lastOrNull()
-                ?.removeSuffix("Navigator")
+                ?.split("Navigator")
+                ?.firstOrNull()
                 ?.equals(destination.name, true) == true
         } == true
 }

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/award/AwardsInfoViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/award/AwardsInfoViewModel.kt
@@ -63,7 +63,9 @@ constructor(
             val postId: Long,
         ) : Effect
 
-        data object NavigateToFeed : Effect
+        data class NavigateToFeed(
+            val round: Long,
+        ) : Effect
     }
 
     sealed interface Intent : UIIntent {
@@ -76,7 +78,9 @@ constructor(
             val postId: Long,
         ) : Intent
 
-        data object OnClickAllPosts : Intent
+        data class OnClickAllPosts(
+            val round: Long,
+        ) : Intent
 
         data object OnClickRetry : Intent
     }
@@ -107,7 +111,7 @@ constructor(
 
             is Intent.OnClickPost -> handleOnClickPost(intent)
 
-            is Intent.OnClickAllPosts -> handleOnClickAllPosts()
+            is Intent.OnClickAllPosts -> handleOnClickAllPosts(intent)
 
             is Intent.OnClickRetry -> loadingLaunch { handleOnClickRetry() }
         }
@@ -139,8 +143,8 @@ constructor(
         postSideEffect(Effect.NavigateToPost(intent.postId))
     }
 
-    private fun handleOnClickAllPosts() {
-        postSideEffect(Effect.NavigateToFeed)
+    private fun handleOnClickAllPosts(intent: Intent.OnClickAllPosts) {
+        postSideEffect(Effect.NavigateToFeed(intent.round))
     }
 
     private suspend fun handleOnClickRetry() {

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/feed/FeedViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/feed/FeedViewModel.kt
@@ -1,6 +1,7 @@
 package com.captures2024.soongan.presentation.viewmodel.main.feed
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
 import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
 import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
@@ -8,6 +9,7 @@ import com.captures2024.soongan.core.common.base.UIState
 import com.captures2024.soongan.core.model.AppConst
 import com.captures2024.soongan.core.model.dto.GalleryPostDto
 import com.captures2024.soongan.core.model.enums.CommonDialogType
+import com.captures2024.soongan.core.navigator.screen.main.feed.FeedNavigator
 import com.captures2024.soongan.domain.usecase.contest.GetFilteredGalleryByReportTargetIdsUseCase
 import com.captures2024.soongan.domain.usecase.contest.GetHidePostEventUseCase
 import com.captures2024.soongan.domain.usecase.contest.GetRegisterPostEventUseCase
@@ -116,6 +118,8 @@ constructor(
     }
 
     override fun createInitialState(savedStateHandle: SavedStateHandle): State {
+        val route = savedStateHandle.toRoute<FeedNavigator>()
+
         return State(
             feedState = State.FeedState(
                 isRefreshing = false,
@@ -124,7 +128,7 @@ constructor(
                 titleOptions = emptyList(),
                 hasNextPage = false,
                 posts = emptyList(),
-                currentRound = 1,
+                currentRound = route.round?.toInt() ?: 0,
                 loadPage = 0,
             ),
             isOpenTitlePickerBottomSheet = false,
@@ -340,11 +344,18 @@ constructor(
                 )
             }
 
+        val currentRound =
+            if (currentState.feedState.currentRound == 0) {
+                titleOptions.last().round
+            } else {
+                currentState.feedState.currentRound
+            }
+
         reduce {
             copy(
                 feedState = feedState.copy(
                     titleOptions = titleOptions,
-                    currentRound = titleOptions.last().round,
+                    currentRound = currentRound,
                 ),
             )
         }

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/feed/FeedViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/feed/FeedViewModel.kt
@@ -344,6 +344,7 @@ constructor(
             copy(
                 feedState = feedState.copy(
                     titleOptions = titleOptions,
+                    currentRound = titleOptions.last().round,
                 ),
             )
         }


### PR DESCRIPTION
# [SG-172] 회차 선택 시 앱 종료 현상

## 작업 사항
- AwardsScreen에서 평화 회차 선택 시 앱 종료되는 현상
  - 2-7위 작품을 subList하는 과정에서 fromIdx > toIdx 되는 부분 예외 처리
- feed 화면 디폴트 회차를 최신 회차로 변경
- AwardsInfoScreen에서 참여작품 보러 가기 클릭 시, 최신 회차가 아닌 해당 회차로 이동하도록 수정

## 비고
- 기존 navigateToFeed를 사용하는 부분과 충돌되지 않기 위해 second param에 round 값을 둔 상태입니다.
```kotlin
fun NavController.navigateToFeed(
    navOptions: NavOptions?,
    round: Long? = null,
) = navigate(
    route = FeedNavigator(
        round = round,
    ),
    navOptions = navOptions,
)
```

[SG-172]: https://captures2024.atlassian.net/browse/SG-172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ