### PR TITLE
[SG-178] notification host 재구현

### DIFF
--- a/app/src/main/kotlin/com/captures2024/soongan/service/FirebaseCloudMessageService.kt
+++ b/app/src/main/kotlin/com/captures2024/soongan/service/FirebaseCloudMessageService.kt
@@ -40,10 +40,6 @@ class FirebaseCloudMessageService : FirebaseMessagingService() {
             return
         }
 
-        if (message.data.isEmpty()) {
-            return
-        }
-
         analyticsHelper.i { "[$simpleName] onMessageReceived - data: ${message.data}" }
 
         message.notification?.let { sgNotification ->

--- a/app/src/main/kotlin/com/captures2024/soongan/service/FirebaseCloudMessageService.kt
+++ b/app/src/main/kotlin/com/captures2024/soongan/service/FirebaseCloudMessageService.kt
@@ -50,14 +50,26 @@ class FirebaseCloudMessageService : FirebaseMessagingService() {
             analyticsHelper.i { "[$simpleName] onMessageReceived - title: ${sgNotification.title}" }
             analyticsHelper.i { "[$simpleName] onMessageReceived - body: ${sgNotification.body}" }
 
-            val pendingIntent = createPendingIntent(message.data)
+            val pendingIntent = createPendingIntent(
+                title = sgNotification.title.orEmpty(),
+                body = sgNotification.body.orEmpty(),
+                messageData = message.data,
+            )
+
             sendNotification(sgNotification, pendingIntent)
         }
     }
 
-    private fun createPendingIntent(messageData: Map<String, String>): PendingIntent {
+    private fun createPendingIntent(
+        title: String,
+        body: String,
+        messageData: Map<String, String>,
+    ): PendingIntent {
         val intent = Intent(this, SoonGanActivity::class.java).apply {
             this.action = AppConst.Notification.PUSH_ACTION_NAME
+
+            putExtra("title", title)
+            putExtra("body", body)
             messageData.forEach { putExtra(it.key, it.value) }
         }
         val intentFlags = PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT

--- a/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/fcm/CloudMessage.kt
+++ b/core/model/src/main/kotlin/com/captures2024/soongan/core/model/dto/fcm/CloudMessage.kt
@@ -5,6 +5,8 @@ import com.captures2024.soongan.core.model.utils.NotificationType
 sealed interface CloudMessage {
 
     data class CommentMessageDto(
+        val title: String,
+        val body: String,
         val notificationType: NotificationType,
         val postId: Long,
         val timestamp: String,
@@ -13,6 +15,8 @@ sealed interface CloudMessage {
         companion object {
             fun fromPayload(payload: Map<String, Any?>): CommentMessageDto? = runCatching {
                 CommentMessageDto(
+                    title = payload["title"]!!.toString(),
+                    body = payload["body"]!!.toString(),
                     notificationType = NotificationType.fromString(payload[CommentMessageDto::notificationType.name]!!.toString())!!,
                     postId = payload[CommentMessageDto::postId.name]!!.toString().toLong(),
                     timestamp = payload[CommentMessageDto::timestamp.name]!!.toString(),
@@ -22,6 +26,8 @@ sealed interface CloudMessage {
     }
 
     data class NeedExplainMessageDto(
+        val title: String,
+        val body: String,
         val notificationType: NotificationType,
         val targetId: Long,
         val targetType: String,
@@ -31,6 +37,8 @@ sealed interface CloudMessage {
         companion object {
             fun fromPayload(payload: Map<String, Any?>): NeedExplainMessageDto? = runCatching {
                 NeedExplainMessageDto(
+                    title = payload["title"]!!.toString().takeIf { it.contains("소명") }!!,
+                    body = payload["body"]!!.toString(),
                     notificationType = NotificationType.fromString(payload[NeedExplainMessageDto::notificationType.name]!!.toString())!!,
                     targetId = payload[NeedExplainMessageDto::targetId.name]!!.toString().toLong(),
                     targetType = payload[NeedExplainMessageDto::targetType.name]!!.toString(),
@@ -41,6 +49,8 @@ sealed interface CloudMessage {
     }
 
     data class BlockMessageDto(
+        val title: String,
+        val body: String,
         val notificationType: NotificationType,
         val targetId: Long,
         val targetType: String,
@@ -50,6 +60,8 @@ sealed interface CloudMessage {
         companion object {
             fun fromPayload(payload: Map<String, Any?>): BlockMessageDto? = runCatching {
                 BlockMessageDto(
+                    title = payload["title"]!!.toString(),
+                    body = payload["body"]!!.toString(),
                     notificationType = NotificationType.fromString(payload[BlockMessageDto::notificationType.name]!!.toString())!!,
                     targetId = payload[BlockMessageDto::targetId.name]!!.toString().toLong(),
                     targetType = payload[BlockMessageDto::targetType.name]!!.toString(),
@@ -60,6 +72,8 @@ sealed interface CloudMessage {
     }
 
     data class ReportResultMessageDto(
+        val title: String,
+        val body: String,
         val link: String,
         val notificationType: NotificationType,
         val postId: Long,
@@ -69,6 +83,8 @@ sealed interface CloudMessage {
         companion object {
             fun fromPayload(payload: Map<String, Any?>): ReportResultMessageDto? = runCatching {
                 ReportResultMessageDto(
+                    title = payload["title"]!!.toString(),
+                    body = payload["body"]!!.toString(),
                     link = payload[ReportResultMessageDto::link.name]!!.toString(),
                     notificationType = NotificationType.fromString(payload[ReportResultMessageDto::notificationType.name]!!.toString())!!,
                     postId = payload[ReportResultMessageDto::postId.name]!!.toString().toLong(),

--- a/data/repository/notification-impl/src/main/kotlin/com/captures2024/soongan/data/repository/notification/impl/NotificationRepositoryImpl.kt
+++ b/data/repository/notification-impl/src/main/kotlin/com/captures2024/soongan/data/repository/notification/impl/NotificationRepositoryImpl.kt
@@ -101,4 +101,12 @@ constructor(
 
         return notificationSetting
     }
+
+    override fun clearNotificationEvent() {
+        notificationLocalDataSource.clearNotificationEvent()
+    }
+
+    override fun clearCloudMessageEvent() {
+        notificationLocalDataSource.clearCloudMessageEvent()
+    }
 }

--- a/data/source/notification-impl/src/main/kotlin/com/captures2024/soongan/data/source/notification/impl/local/NotificationLocalDataSourceImpl.kt
+++ b/data/source/notification-impl/src/main/kotlin/com/captures2024/soongan/data/source/notification/impl/local/NotificationLocalDataSourceImpl.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -68,5 +69,13 @@ constructor(
 
     override fun postIsNotReadNotificationCache(value: Boolean) {
         _isNotReadNotificationCache.value = value
+    }
+
+    override fun clearNotificationEvent() {
+        _notificationEvent.update { null }
+    }
+
+    override fun clearCloudMessageEvent() {
+        _cloudMessageEvent.update { null }
     }
 }

--- a/data/source/notification/src/main/kotlin/com/captures2024/soongan/data/source/notification/local/NotificationLocalDataSource.kt
+++ b/data/source/notification/src/main/kotlin/com/captures2024/soongan/data/source/notification/local/NotificationLocalDataSource.kt
@@ -20,4 +20,8 @@ interface NotificationLocalDataSource {
     suspend fun parseNotification(payload: Map<String, Any?>)
 
     fun postIsNotReadNotificationCache(value: Boolean)
+
+    fun clearNotificationEvent()
+
+    fun clearCloudMessageEvent()
 }

--- a/domain/repository/notification/src/main/kotlin/com/captures2024/soongan/domain/repository/notification/NotificationRepository.kt
+++ b/domain/repository/notification/src/main/kotlin/com/captures2024/soongan/domain/repository/notification/NotificationRepository.kt
@@ -35,4 +35,8 @@ interface NotificationRepository {
     suspend fun getNotificationSettings(): NotificationSettingDto
 
     suspend fun patchNotificationSettings(settings: NotificationSettingDto): NotificationSettingDto
+
+    fun clearNotificationEvent()
+
+    fun clearCloudMessageEvent()
 }

--- a/domain/usecase/module/src/main/kotlin/com/captures2024/soongan/domain/usecase/module/NotificationUseCaseModule.kt
+++ b/domain/usecase/module/src/main/kotlin/com/captures2024/soongan/domain/usecase/module/NotificationUseCaseModule.kt
@@ -1,5 +1,7 @@
 package com.captures2024.soongan.domain.usecase.module
 
+import com.captures2024.soongan.domain.usecase.notification.ClearCloudMessageEventUseCase
+import com.captures2024.soongan.domain.usecase.notification.ClearNotificationEventUseCase
 import com.captures2024.soongan.domain.usecase.notification.DeleteNotificationUseCase
 import com.captures2024.soongan.domain.usecase.notification.EmitNotificationUseCase
 import com.captures2024.soongan.domain.usecase.notification.GetCloudMessageEventFlowUseCase
@@ -10,6 +12,8 @@ import com.captures2024.soongan.domain.usecase.notification.GetUnreadNotificatio
 import com.captures2024.soongan.domain.usecase.notification.GetNotificationsUseCase
 import com.captures2024.soongan.domain.usecase.notification.PatchNotificationSettingsUseCase
 import com.captures2024.soongan.domain.usecase.notification.PostNotificationReadUseCase
+import com.captures2024.soongan.domain.usecase.notification.impl.ClearCloudMessageEventUseCaseImpl
+import com.captures2024.soongan.domain.usecase.notification.impl.ClearNotificationEventUseCaseImpl
 import com.captures2024.soongan.domain.usecase.notification.impl.DeleteNotificationUseCaseImpl
 import com.captures2024.soongan.domain.usecase.notification.impl.EmitNotificationUseCaseImpl
 import com.captures2024.soongan.domain.usecase.notification.impl.GetCloudMessageEventFlowUseCaseImpl
@@ -58,4 +62,10 @@ internal abstract class NotificationUseCaseModule {
 
     @Binds
     abstract fun bindGetNotificationEventFlowUseCase(getNotificationEventFlowUseCaseImpl: GetNotificationEventFlowUseCaseImpl): GetNotificationEventFlowUseCase
+
+    @Binds
+    abstract fun bindClearNotificationEventUseCase(clearNotificationEventUseCaseImpl: ClearNotificationEventUseCaseImpl): ClearNotificationEventUseCase
+
+    @Binds
+    abstract fun bindClearCloudMessageEventUseCase(clearCloudMessageEventUseCaseImpl: ClearCloudMessageEventUseCaseImpl): ClearCloudMessageEventUseCase
 }

--- a/domain/usecase/module/src/main/kotlin/com/captures2024/soongan/domain/usecase/module/NotificationUseCaseModule.kt
+++ b/domain/usecase/module/src/main/kotlin/com/captures2024/soongan/domain/usecase/module/NotificationUseCaseModule.kt
@@ -2,7 +2,9 @@ package com.captures2024.soongan.domain.usecase.module
 
 import com.captures2024.soongan.domain.usecase.notification.DeleteNotificationUseCase
 import com.captures2024.soongan.domain.usecase.notification.EmitNotificationUseCase
+import com.captures2024.soongan.domain.usecase.notification.GetCloudMessageEventFlowUseCase
 import com.captures2024.soongan.domain.usecase.notification.GetIsNotReadNotificationCacheFlowUseCase
+import com.captures2024.soongan.domain.usecase.notification.GetNotificationEventFlowUseCase
 import com.captures2024.soongan.domain.usecase.notification.GetNotificationSettingsUseCase
 import com.captures2024.soongan.domain.usecase.notification.GetUnreadNotificationsCountUseCase
 import com.captures2024.soongan.domain.usecase.notification.GetNotificationsUseCase
@@ -10,7 +12,9 @@ import com.captures2024.soongan.domain.usecase.notification.PatchNotificationSet
 import com.captures2024.soongan.domain.usecase.notification.PostNotificationReadUseCase
 import com.captures2024.soongan.domain.usecase.notification.impl.DeleteNotificationUseCaseImpl
 import com.captures2024.soongan.domain.usecase.notification.impl.EmitNotificationUseCaseImpl
+import com.captures2024.soongan.domain.usecase.notification.impl.GetCloudMessageEventFlowUseCaseImpl
 import com.captures2024.soongan.domain.usecase.notification.impl.GetIsNotReadNotificationCacheFlowUseCaseImpl
+import com.captures2024.soongan.domain.usecase.notification.impl.GetNotificationEventFlowUseCaseImpl
 import com.captures2024.soongan.domain.usecase.notification.impl.GetNotificationSettingsUseCaseImpl
 import com.captures2024.soongan.domain.usecase.notification.impl.GetUnreadNotificationsCountUseCaseImpl
 import com.captures2024.soongan.domain.usecase.notification.impl.GetNotificationsUseCaseImpl
@@ -48,4 +52,10 @@ internal abstract class NotificationUseCaseModule {
 
     @Binds
     abstract fun bindGetIsNotReadNotificationCacheFlowUseCase(getIsNotReadNotificationCacheFlowUseCaseImpl: GetIsNotReadNotificationCacheFlowUseCaseImpl): GetIsNotReadNotificationCacheFlowUseCase
+
+    @Binds
+    abstract fun bindGetCloudMessageEventFlowUseCase(getCloudMessageEventFlowUseCaseImpl: GetCloudMessageEventFlowUseCaseImpl): GetCloudMessageEventFlowUseCase
+
+    @Binds
+    abstract fun bindGetNotificationEventFlowUseCase(getNotificationEventFlowUseCaseImpl: GetNotificationEventFlowUseCaseImpl): GetNotificationEventFlowUseCase
 }

--- a/domain/usecase/notification-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/impl/ClearCloudMessageEventUseCaseImpl.kt
+++ b/domain/usecase/notification-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/impl/ClearCloudMessageEventUseCaseImpl.kt
@@ -1,0 +1,16 @@
+package com.captures2024.soongan.domain.usecase.notification.impl
+
+import com.captures2024.soongan.domain.repository.notification.NotificationRepository
+import com.captures2024.soongan.domain.usecase.notification.ClearCloudMessageEventUseCase
+import javax.inject.Inject
+
+class ClearCloudMessageEventUseCaseImpl
+@Inject
+constructor(
+    private val notificationRepository: NotificationRepository,
+) : ClearCloudMessageEventUseCase {
+
+    override operator fun invoke() {
+        notificationRepository.clearCloudMessageEvent()
+    }
+}

--- a/domain/usecase/notification-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/impl/ClearNotificationEventUseCaseImpl.kt
+++ b/domain/usecase/notification-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/impl/ClearNotificationEventUseCaseImpl.kt
@@ -1,0 +1,16 @@
+package com.captures2024.soongan.domain.usecase.notification.impl
+
+import com.captures2024.soongan.domain.repository.notification.NotificationRepository
+import com.captures2024.soongan.domain.usecase.notification.ClearNotificationEventUseCase
+import javax.inject.Inject
+
+class ClearNotificationEventUseCaseImpl
+@Inject
+constructor(
+    private val notificationRepository: NotificationRepository,
+) : ClearNotificationEventUseCase {
+
+    override operator fun invoke() {
+        notificationRepository.clearNotificationEvent()
+    }
+}

--- a/domain/usecase/notification-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/impl/GetCloudMessageEventFlowUseCaseImpl.kt
+++ b/domain/usecase/notification-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/impl/GetCloudMessageEventFlowUseCaseImpl.kt
@@ -1,0 +1,18 @@
+package com.captures2024.soongan.domain.usecase.notification.impl
+
+import com.captures2024.soongan.core.model.dto.fcm.CloudMessage
+import com.captures2024.soongan.domain.repository.notification.NotificationRepository
+import com.captures2024.soongan.domain.usecase.notification.GetCloudMessageEventFlowUseCase
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetCloudMessageEventFlowUseCaseImpl
+@Inject
+constructor(
+    private val notificationRepository: NotificationRepository,
+) : GetCloudMessageEventFlowUseCase {
+
+    override fun invoke(): Flow<CloudMessage?> {
+        return notificationRepository.cloudMessageEvent
+    }
+}

--- a/domain/usecase/notification-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/impl/GetNotificationEventFlowUseCaseImpl.kt
+++ b/domain/usecase/notification-impl/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/impl/GetNotificationEventFlowUseCaseImpl.kt
@@ -1,0 +1,18 @@
+package com.captures2024.soongan.domain.usecase.notification.impl
+
+import com.captures2024.soongan.core.model.dto.NotificationDto
+import com.captures2024.soongan.domain.repository.notification.NotificationRepository
+import com.captures2024.soongan.domain.usecase.notification.GetNotificationEventFlowUseCase
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetNotificationEventFlowUseCaseImpl
+@Inject
+constructor(
+    private val notificationRepository: NotificationRepository,
+) : GetNotificationEventFlowUseCase {
+
+    override fun invoke(): Flow<NotificationDto?> {
+        return notificationRepository.notificationEvent
+    }
+}

--- a/domain/usecase/notification/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/ClearCloudMessageEventUseCase.kt
+++ b/domain/usecase/notification/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/ClearCloudMessageEventUseCase.kt
@@ -1,0 +1,6 @@
+package com.captures2024.soongan.domain.usecase.notification
+
+interface ClearCloudMessageEventUseCase {
+
+    operator fun invoke()
+}

--- a/domain/usecase/notification/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/ClearNotificationEventUseCase.kt
+++ b/domain/usecase/notification/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/ClearNotificationEventUseCase.kt
@@ -1,0 +1,6 @@
+package com.captures2024.soongan.domain.usecase.notification
+
+interface ClearNotificationEventUseCase {
+
+    operator fun invoke()
+}

--- a/domain/usecase/notification/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/GetCloudMessageEventFlowUseCase.kt
+++ b/domain/usecase/notification/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/GetCloudMessageEventFlowUseCase.kt
@@ -1,0 +1,9 @@
+package com.captures2024.soongan.domain.usecase.notification
+
+import com.captures2024.soongan.core.model.dto.fcm.CloudMessage
+import kotlinx.coroutines.flow.Flow
+
+interface GetCloudMessageEventFlowUseCase {
+
+    operator fun invoke(): Flow<CloudMessage?>
+}

--- a/domain/usecase/notification/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/GetNotificationEventFlowUseCase.kt
+++ b/domain/usecase/notification/src/main/kotlin/com/captures2024/soongan/domain/usecase/notification/GetNotificationEventFlowUseCase.kt
@@ -1,0 +1,9 @@
+package com.captures2024.soongan.domain.usecase.notification
+
+import com.captures2024.soongan.core.model.dto.NotificationDto
+import kotlinx.coroutines.flow.Flow
+
+interface GetNotificationEventFlowUseCase {
+
+    operator fun invoke(): Flow<NotificationDto?>
+}

--- a/presentation/feature/root/build.gradle.kts
+++ b/presentation/feature/root/build.gradle.kts
@@ -9,6 +9,8 @@ android {
 }
 
 dependencies {
+    implementation(projects.presentation.viewmodel)
+
     implementation(projects.presentation.feature.main)
     implementation(projects.presentation.feature.sign)
 }

--- a/presentation/feature/root/src/main/kotlin/com/captures2024/soongan/presentation/feature/root/route/AppRoute.kt
+++ b/presentation/feature/root/src/main/kotlin/com/captures2024/soongan/presentation/feature/root/route/AppRoute.kt
@@ -33,6 +33,10 @@ internal fun AppRoute(viewModel: AppViewModel) {
             },
         )
 
+        if (state.isInitialized) {
+            NotificationHost(navController)
+        }
+
         DialogHost(appViewModel = viewModel)
         LoadingHost(visible = state.isLoading)
     }

--- a/presentation/feature/root/src/main/kotlin/com/captures2024/soongan/presentation/feature/root/route/NotificationHost.kt
+++ b/presentation/feature/root/src/main/kotlin/com/captures2024/soongan/presentation/feature/root/route/NotificationHost.kt
@@ -6,9 +6,15 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import androidx.navigation.navOptions
 import com.captures2024.soongan.core.android.utils.LocalAnalyticsHelper
 import com.captures2024.soongan.core.model.dto.fcm.CloudMessage
 import com.captures2024.soongan.core.model.utils.NotificationSubType
+import com.captures2024.soongan.core.navigator.screen.main.home.HomeNavigator
+import com.captures2024.soongan.core.navigator.screen.main.post.navigateToPostInfo
+import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToExplain
+import com.captures2024.soongan.core.navigator.screen.main.profile.navigateToProfile
 import com.captures2024.soongan.presentation.viewmodel.root.NotificationViewModel
 
 @Composable
@@ -79,7 +85,12 @@ internal fun NotificationHost(
 
             when (event) {
                 is CloudMessage.BlockMessageDto -> {
-                    // TODO navigate to post
+                    navController.navigateToProfile(
+                        navOptions = buildTopLevelNavOptions(),
+                    )
+                    navController.navigateToPostInfo(
+                        id = event.targetId,
+                    )
                 }
 
                 is CloudMessage.CommentMessageDto -> {
@@ -87,7 +98,12 @@ internal fun NotificationHost(
                 }
 
                 is CloudMessage.NeedExplainMessageDto -> {
-                    // TODO navigate to appeal
+                    navController.navigateToProfile(
+                        navOptions = buildTopLevelNavOptions(),
+                    )
+                    navController.navigateToExplain(
+                        postId = event.targetId,
+                    )
                 }
 
                 is CloudMessage.ReportResultMessageDto -> {
@@ -96,4 +112,12 @@ internal fun NotificationHost(
             }
         }
     }
+}
+
+private fun buildTopLevelNavOptions(): NavOptions = navOptions {
+    popUpTo(HomeNavigator) {
+        saveState = true
+    }
+    launchSingleTop = true
+    restoreState = true
 }

--- a/presentation/feature/root/src/main/kotlin/com/captures2024/soongan/presentation/feature/root/route/NotificationHost.kt
+++ b/presentation/feature/root/src/main/kotlin/com/captures2024/soongan/presentation/feature/root/route/NotificationHost.kt
@@ -1,0 +1,99 @@
+package com.captures2024.soongan.presentation.feature.root.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.captures2024.soongan.core.android.utils.LocalAnalyticsHelper
+import com.captures2024.soongan.core.model.dto.fcm.CloudMessage
+import com.captures2024.soongan.core.model.utils.NotificationSubType
+import com.captures2024.soongan.presentation.viewmodel.root.NotificationViewModel
+
+@Composable
+internal fun NotificationHost(
+    navController: NavController,
+    viewModel: NotificationViewModel = hiltViewModel()
+) {
+    val analyticsHelper = LocalAnalyticsHelper.current
+    val state by viewModel.state.collectAsState()
+
+    val notification = state.notification
+    val cloudMessage = state.cloudMessage
+    val isLoggedIn = state.isLoggedIn
+
+    LaunchedEffect(
+        notification,
+        isLoggedIn
+    ) {
+        analyticsHelper.d { "NotificationHost - notification: $notification, isLoggedIn: $isLoggedIn" }
+
+        notification?.let { event ->
+            if (!isLoggedIn) {
+                return@LaunchedEffect
+            }
+
+            viewModel.intent(NotificationViewModel.Intent.ClearNotification)
+
+            when (event.subType) {
+                NotificationSubType.CONTEST_START -> {
+                    // TODO navigate to home
+                }
+
+                NotificationSubType.CONTEST_END -> {
+                    // TODO navigate to home
+                }
+
+                NotificationSubType.COMMENT -> {
+                    // TODO navigate to comment
+                }
+
+                NotificationSubType.LIKE -> {
+                    // TODO navigate to post
+                }
+
+                NotificationSubType.APPEAL -> {
+                    // TODO navigate to appeal
+                }
+
+                NotificationSubType.NOTICE -> {
+                    // TODO navigate to notice
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(
+        cloudMessage,
+        isLoggedIn,
+    ) {
+        analyticsHelper.d { "NotificationHost - cloudMessage: $cloudMessage, isLoggedIn: $isLoggedIn" }
+
+        cloudMessage?.let { event ->
+            if (!isLoggedIn) {
+                return@LaunchedEffect
+            }
+
+            viewModel.intent(NotificationViewModel.Intent.ClearCloudMessage)
+
+            when (event) {
+                is CloudMessage.BlockMessageDto -> {
+                    // TODO navigate to post
+                }
+
+                is CloudMessage.CommentMessageDto -> {
+                    // TODO navigate to comment
+                }
+
+                is CloudMessage.NeedExplainMessageDto -> {
+                    // TODO navigate to appeal
+                }
+
+                is CloudMessage.ReportResultMessageDto -> {
+                    // TODO ?
+                }
+            }
+        }
+    }
+}

--- a/presentation/feature/root/src/main/kotlin/com/captures2024/soongan/presentation/feature/root/route/NotificationHost.kt
+++ b/presentation/feature/root/src/main/kotlin/com/captures2024/soongan/presentation/feature/root/route/NotificationHost.kt
@@ -20,7 +20,7 @@ import com.captures2024.soongan.presentation.viewmodel.root.NotificationViewMode
 @Composable
 internal fun NotificationHost(
     navController: NavController,
-    viewModel: NotificationViewModel = hiltViewModel()
+    viewModel: NotificationViewModel = hiltViewModel(),
 ) {
     val analyticsHelper = LocalAnalyticsHelper.current
     val state by viewModel.state.collectAsState()
@@ -31,7 +31,7 @@ internal fun NotificationHost(
 
     LaunchedEffect(
         notification,
-        isLoggedIn
+        isLoggedIn,
     ) {
         analyticsHelper.d { "NotificationHost - notification: $notification, isLoggedIn: $isLoggedIn" }
 

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ExplainViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ExplainViewModel.kt
@@ -7,6 +7,7 @@ import com.captures2024.soongan.core.common.base.UIIntent
 import com.captures2024.soongan.core.common.base.UISideEffect
 import com.captures2024.soongan.core.common.base.UIState
 import com.captures2024.soongan.core.navigator.screen.main.profile.ExplainNavigator
+import com.captures2024.soongan.domain.usecase.contest.GetPostInfoUseCase
 import com.captures2024.soongan.domain.usecase.member.GetIsCurrentGuestModeUseCase
 import com.captures2024.soongan.domain.usecase.report.PostExplainUseCase
 import com.captures2024.soongan.domain.usecase.system.dialog.SetIsShowGuestModeDialogFlowUseCase
@@ -29,6 +30,7 @@ constructor(
     setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
     savedStateHandle: SavedStateHandle,
     private val postExplainUseCase: PostExplainUseCase,
+    private val getPostInfoUseCase: GetPostInfoUseCase,
 ) : BaseViewModel<ExplainViewModel.State, ExplainViewModel.Effect, ExplainViewModel.Intent>(
     analyticsHelper = analyticsHelper,
     showLoadingUseCase = showLoadingUseCase,
@@ -86,7 +88,7 @@ constructor(
 
     override fun handleIntent(intent: Intent) {
         when (intent) {
-            is Intent.Init -> handleInit()
+            is Intent.Init -> loadingLaunch { handleInit() }
             is Intent.OnClickBack -> handleOnClickBack()
             is Intent.OnClickReport -> loadingLaunch { handleOnClickReport() }
             is Intent.OnExplainValueChange -> handleOnExplainValueChange(intent)
@@ -97,11 +99,26 @@ constructor(
         analyticsHelper.e(throwable = throwable) { "state: $currentState" }
     }
 
-    private fun handleInit() {
+    private suspend fun handleInit() {
         val currentPostId = currentState.postId
 
         if (currentPostId == -1L) {
             postSideEffect(Effect.NavigateToBack)
+            return
+        }
+
+        val postInfo = getPostInfoUseCase(currentPostId).getOrNull()
+
+        if (postInfo == null) {
+            postSideEffect(Effect.NavigateToBack)
+            return
+        }
+
+        reduce {
+            copy(
+                postTitle = postInfo.title,
+                postImageUrl = postInfo.imageUrl,
+            )
         }
     }
 

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ExplainViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/main/profile/ExplainViewModel.kt
@@ -14,8 +14,10 @@ import com.captures2024.soongan.domain.usecase.system.loading.ClearLoadingUseCas
 import com.captures2024.soongan.domain.usecase.system.loading.HideLoadingUseCase
 import com.captures2024.soongan.domain.usecase.system.loading.ShowLoadingUseCase
 import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
+@HiltViewModel
 class ExplainViewModel
 @Inject
 constructor(

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/root/NotificationViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/root/NotificationViewModel.kt
@@ -1,0 +1,134 @@
+package com.captures2024.soongan.presentation.viewmodel.root
+
+import androidx.lifecycle.SavedStateHandle
+import com.captures2024.soongan.core.analytics.helper.AnalyticsHelper
+import com.captures2024.soongan.core.common.base.UIIntent
+import com.captures2024.soongan.core.common.base.UISideEffect
+import com.captures2024.soongan.core.common.base.UIState
+import com.captures2024.soongan.core.model.dto.NotificationDto
+import com.captures2024.soongan.core.model.dto.fcm.CloudMessage
+import com.captures2024.soongan.domain.usecase.member.GetCurrentMemberFlowUseCase
+import com.captures2024.soongan.domain.usecase.member.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.domain.usecase.notification.GetCloudMessageEventFlowUseCase
+import com.captures2024.soongan.domain.usecase.notification.GetNotificationEventFlowUseCase
+import com.captures2024.soongan.domain.usecase.system.dialog.SetIsShowGuestModeDialogFlowUseCase
+import com.captures2024.soongan.domain.usecase.system.loading.ClearLoadingUseCase
+import com.captures2024.soongan.domain.usecase.system.loading.HideLoadingUseCase
+import com.captures2024.soongan.domain.usecase.system.loading.ShowLoadingUseCase
+import com.captures2024.soongan.presentation.viewmodel.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class NotificationViewModel
+@Inject
+constructor(
+    private val getNotificationEventFlowUseCase: GetNotificationEventFlowUseCase,
+    private val getCloudMessageEventFlowUseCase: GetCloudMessageEventFlowUseCase,
+    private val getCurrentMemberFlowUseCase: GetCurrentMemberFlowUseCase,
+
+    analyticsHelper: AnalyticsHelper,
+    showLoadingUseCase: ShowLoadingUseCase,
+    hideLoadingUseCase: HideLoadingUseCase,
+    clearLoadingUseCase: ClearLoadingUseCase,
+    getIsCurrentGuestModeUseCase: GetIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase: SetIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle: SavedStateHandle,
+) : BaseViewModel<NotificationViewModel.State, NotificationViewModel.Effect, NotificationViewModel.Intent>(
+    analyticsHelper = analyticsHelper,
+    showLoadingUseCase = showLoadingUseCase,
+    hideLoadingUseCase = hideLoadingUseCase,
+    clearLoadingUseCase = clearLoadingUseCase,
+    getIsCurrentGuestModeUseCase = getIsCurrentGuestModeUseCase,
+    setIsShowGuestModeDialogFlowUseCase = setIsShowGuestModeDialogFlowUseCase,
+    savedStateHandle = savedStateHandle,
+) {
+
+    data class State(
+        val notification: NotificationDto? = null,
+        val cloudMessage: CloudMessage? = null,
+        val isLoggedIn: Boolean = false,
+    ) : UIState
+
+    sealed interface Effect : UISideEffect
+
+    sealed interface Intent : UIIntent {
+        data object Init : Intent
+
+        data object ClearNotification : Intent
+
+        data object ClearCloudMessage : Intent
+    }
+
+    init {
+        intent(Intent.Init)
+    }
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): State {
+        return State()
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        analyticsHelper.e(throwable) { "createInitialState - currentState: $currentState" }
+    }
+
+    override fun handleIntent(intent: Intent) {
+        when (intent) {
+            is Intent.Init -> handleInit()
+            is Intent.ClearNotification -> handleClearNotification()
+            is Intent.ClearCloudMessage -> handleClearCloudMessage()
+        }
+    }
+
+    private fun handleInit() {
+        launch { collectCurrentMember() }
+        launch { collectNotificationMessage() }
+        launch { collectCloudMessage() }
+    }
+
+    private fun handleClearNotification() {
+        reduce {
+            copy(
+                notification = null,
+            )
+        }
+    }
+
+    private fun handleClearCloudMessage() {
+        reduce {
+            copy(
+                cloudMessage = null,
+            )
+        }
+    }
+
+    private suspend fun collectCurrentMember() {
+        getCurrentMemberFlowUseCase().collect {
+            reduce {
+                copy(
+                    isLoggedIn = it != null,
+                )
+            }
+        }
+    }
+
+    private suspend fun collectNotificationMessage() {
+        getNotificationEventFlowUseCase().collect {
+            reduce {
+                copy(
+                    notification = it,
+                )
+            }
+        }
+    }
+
+    private suspend fun collectCloudMessage() {
+        getCloudMessageEventFlowUseCase().collect {
+            reduce {
+                copy(
+                    cloudMessage = it,
+                )
+            }
+        }
+    }
+}

--- a/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/root/NotificationViewModel.kt
+++ b/presentation/viewmodel/src/main/kotlin/com/captures2024/soongan/presentation/viewmodel/root/NotificationViewModel.kt
@@ -9,6 +9,8 @@ import com.captures2024.soongan.core.model.dto.NotificationDto
 import com.captures2024.soongan.core.model.dto.fcm.CloudMessage
 import com.captures2024.soongan.domain.usecase.member.GetCurrentMemberFlowUseCase
 import com.captures2024.soongan.domain.usecase.member.GetIsCurrentGuestModeUseCase
+import com.captures2024.soongan.domain.usecase.notification.ClearCloudMessageEventUseCase
+import com.captures2024.soongan.domain.usecase.notification.ClearNotificationEventUseCase
 import com.captures2024.soongan.domain.usecase.notification.GetCloudMessageEventFlowUseCase
 import com.captures2024.soongan.domain.usecase.notification.GetNotificationEventFlowUseCase
 import com.captures2024.soongan.domain.usecase.system.dialog.SetIsShowGuestModeDialogFlowUseCase
@@ -26,6 +28,8 @@ constructor(
     private val getNotificationEventFlowUseCase: GetNotificationEventFlowUseCase,
     private val getCloudMessageEventFlowUseCase: GetCloudMessageEventFlowUseCase,
     private val getCurrentMemberFlowUseCase: GetCurrentMemberFlowUseCase,
+    private val clearNotificationEventUseCase: ClearNotificationEventUseCase,
+    private val clearCloudMessageEventUseCase: ClearCloudMessageEventUseCase,
 
     analyticsHelper: AnalyticsHelper,
     showLoadingUseCase: ShowLoadingUseCase,
@@ -87,19 +91,11 @@ constructor(
     }
 
     private fun handleClearNotification() {
-        reduce {
-            copy(
-                notification = null,
-            )
-        }
+        clearNotificationEventUseCase()
     }
 
     private fun handleClearCloudMessage() {
-        reduce {
-            copy(
-                cloudMessage = null,
-            )
-        }
+        clearCloudMessageEventUseCase()
     }
 
     private suspend fun collectCurrentMember() {


### PR DESCRIPTION
# [SG-178] notification host 재구현

## 수정 사항
- 기존 사라졌던 notification navigate를 위한 host 로직을 다시 추가했습니다
- 해당 host에서 fcm과 프로필 notification 네비게이션을 동시에 담당해서 작업하면 될 것 같습니다

## 비고
- 테스트를 하실 때 굳이 추가적 신고를 하면서 테스트하시는 거 보다 아래처럼 `FirebaseCloudMessageService.kt` 값을 바꿔 테스트 하는 것을 권장합니다
- 해당 코드로 작업하면 스웨거의 test fcm api를 이용해도 테스트 가능합니다
```Kotlin
// current
 private fun createPendingIntent(
        title: String,
        body: String,
        messageData: Map<String, String>,
    ): PendingIntent {
        val intent = Intent(this, SoonGanActivity::class.java).apply {
            this.action = AppConst.Notification.PUSH_ACTION_NAME

            putExtra("title", title)
            putExtra("body", body)
            messageData.forEach { putExtra(it.key, it.value) }
        }
}

// todo
 private fun createPendingIntent(
        title: String,
        body: String,
        messageData: Map<String, String>,
    ): PendingIntent {
        val intent = Intent(this, SoonGanActivity::class.java).apply {
            this.action = AppConst.Notification.PUSH_ACTION_NAME

            putExtra("title", title)
            putExtra("body", body)
//            messageData.forEach { putExtra(it.key, it.value) }
            putExtra("notificationType", "ACTIVITY")
            putExtra("targetId", "78")
            putExtra("targetType", "WEEKLY_POST")
            putExtra("timestamp", "2025-09-08T00:00:00")
        }
```

[SG-178]: https://captures2024.atlassian.net/browse/SG-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ